### PR TITLE
Add development container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+{
+    "name": "ha-termoweb",
+    "image": "mcr.microsoft.com/devcontainers/python:3.13",
+    "postCreateCommand": "scripts/setup",
+    "forwardPorts": [
+        8123
+    ],
+    "portsAttributes": {
+        "8123": {
+            "label": "Home Assistant",
+            "onAutoForward": "notify"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff",
+                "github.vscode-pull-request-github",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ryanluker.vscode-coverage-gutters"
+            ],
+            "settings": {
+                "files.eol": "\n",
+                "editor.tabSize": 4,
+                "editor.formatOnPaste": true,
+                "editor.formatOnSave": true,
+                "editor.formatOnType": false,
+                "files.trimTrailingWhitespace": true,
+                "python.analysis.typeCheckingMode": "basic",
+                "python.analysis.autoImportCompletions": true,
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                }
+            }
+        }
+    },
+    "remoteUser": "vscode",
+    "features": {
+        "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+            "packages": "ffmpeg,libturbojpeg0,libpcap-dev"
+        }
+    }
+}

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Install the project in editable mode using uv
+uv pip install --system -e .
+
+if [ -f ".pre-commit-config.yaml" ]; then
+    # Run pre-commit through uv to ensure the correct environment
+    uv run pre-commit install
+fi


### PR DESCRIPTION
## Summary
- add VS Code devcontainer config for Python 3.13 with Home Assistant port and helpful extensions
- include setup script using uv to install project in editable mode and handle pre-commit

## Testing
- `bash -n scripts/setup`
- `uv pip install --system -e . --dry-run` *(fails: Failed to fetch `voluptuous`)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689885b360508329b2030c6fee0e92b4