### PR TITLE
Await and clear heartbeat task on stop

### DIFF
--- a/custom_components/termoweb/ws_client_legacy.py
+++ b/custom_components/termoweb/ws_client_legacy.py
@@ -93,6 +93,10 @@ class TermoWebWSLegacyClient:
         self._closing = True
         if self._hb_task:
             self._hb_task.cancel()
+            try:
+                await self._hb_task
+            except asyncio.CancelledError:
+                pass
             self._hb_task = None
         if self._ws:
             try:


### PR DESCRIPTION
## Summary
- await and suppress CancelledError from heartbeat task on stop

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b2737c3d4832984cf6d3e3eba8312