### PR TITLE
Track newly added refresh buttons

### DIFF
--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -33,9 +33,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
             uid = f"{DOMAIN}:{dev_id}:refresh"
             if uid in cur_ids:
                 continue
-            to_add.append(TermoWebRefreshButton(coordinator, dev_id))
+            entity = TermoWebRefreshButton(coordinator, dev_id)
+            to_add.append(entity)
+            cur_ids.add(uid)
         if to_add:
             async_add_entities(to_add)
+            new.extend(to_add)
 
     coordinator.async_add_listener(_on_update)
 


### PR DESCRIPTION
## Summary
- prevent duplicate TermoWeb refresh buttons by tracking added entities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b273cca608329a218491981c137d1