### PR TITLE
Handle unload exceptions in websocket tasks and clients

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -142,11 +142,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await task
         except asyncio.CancelledError:
             pass
-    for client in list(rec.get("ws_clients", {}).values()):
+        except Exception:
+            _LOGGER.exception("WS task for %s failed to cancel cleanly", dev_id)
+
+    for dev_id, client in list(rec.get("ws_clients", {}).items()):
         try:
             await client.stop()
         except Exception:
-            pass
+            _LOGGER.exception("WS client for %s failed to stop", dev_id)
 
     if "unsub_ws_status" in rec and callable(rec["unsub_ws_status"]):
         rec["unsub_ws_status"]()


### PR DESCRIPTION
## Summary
- Log failures when cancelling websocket tasks during unload
- Log errors when stopping websocket clients

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2d7117dc83299313634d2a4ca815