### PR TITLE
Remove unused _as_float helper

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -17,20 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 HTR_SETTINGS_PER_CYCLE = 1
 
 
-def _as_float(val: Any) -> Optional[float]:
-    try:
-        if val is None:
-            return None
-        if isinstance(val, (int, float)):
-            return float(val)
-        s = str(val).strip()
-        if not s:
-            return None
-        return float(s)
-    except Exception:
-        return None
-
-
 class TermoWebCoordinator(DataUpdateCoordinator[Dict[str, Dict[str, Any]]]):  # dev_id -> per-device data
     """Polls TermoWeb and exposes a per-device dict used by platforms."""
 


### PR DESCRIPTION
## Summary
- delete unused `_as_float` helper from TermoWeb coordinator

## Testing
- `ruff check custom_components/termoweb/coordinator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b310073f4832999294e3efc778520