### PR TITLE
Ensure heater updates handle numeric addresses

### DIFF
--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -115,7 +115,7 @@ class TermoWebHeaterTemp(CoordinatorEntity, SensorEntity):
         if payload.get("dev_id") != self._dev_id:
             return
         addr = payload.get("addr")
-        if addr is not None and addr != self._addr:
+        if addr is not None and str(addr) != self._addr:
             return
         # Thread-safe state update
         self.schedule_update_ha_state()


### PR DESCRIPTION
## Summary
- Cast WebSocket heater address to `str` before comparison so updates arrive when provided as either `int` or `str`

## Testing
- `ruff check custom_components/termoweb/sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b30ea267c832998bcc9baf3065669