### PR TITLE
Add API helpers for PMO power and samples

### DIFF
--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -9,8 +9,12 @@ DOMAIN: Final = "termoweb"
 API_BASE: Final = "https://control.termoweb.net"
 TOKEN_PATH: Final = "/client/token"
 DEVS_PATH: Final = "/api/v2/devs/"
-CONNECTED_PATH_FMT: Final = "/api/v2/devs/{dev_id}/connected"  # some fw return 404; we tolerate
+CONNECTED_PATH_FMT: Final = (
+    "/api/v2/devs/{dev_id}/connected"  # some fw return 404; we tolerate
+)
 NODES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/mgr/nodes"
+PMO_POWER_PATH_FMT: Final = "/api/v2/devs/{dev_id}/pmo/{addr}/power"
+PMO_SAMPLES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/pmo/{addr}/samples"
 # NOTE: Old APKs referenced /thm/*; confirmed irrelevant here, so not exposed.
 
 # Public client creds (from APK v2.5.1)
@@ -18,8 +22,8 @@ BASIC_AUTH_B64: Final = "NTIxNzJkYzg0ZjYzZDZjNzU5MDAwMDA1OmJ4djRaM3hVU2U="
 
 # Polling
 DEFAULT_POLL_INTERVAL: Final = 120  # seconds
-MIN_POLL_INTERVAL: Final = 30       # seconds
-MAX_POLL_INTERVAL: Final = 3600     # seconds
+MIN_POLL_INTERVAL: Final = 30  # seconds
+MAX_POLL_INTERVAL: Final = 3600  # seconds
 STRETCHED_POLL_INTERVAL: Final = 2700  # seconds (45 minutes) when WS healthy ≥5m
 
 # UA / locale (matches app loosely; helps avoid quirky WAF rules)
@@ -35,6 +39,7 @@ INTEGRATION_VERSION: Final = "1.0.0"
 WS_NAMESPACE: Final = "/api/v2/socket_io"
 
 # --- Dispatcher signal helpers (WS → entities) ---
+
 
 def signal_ws_data(entry_id: str) -> str:
     """Signal name for WS ‘data’ frames dispatched to platforms."""


### PR DESCRIPTION
## Summary
- add constants for PMO power and samples endpoints
- implement `get_pmo_power` and `get_pmo_samples`
- add unit tests for PMO API helpers

## Testing
- `ruff check custom_components/termoweb/api.py custom_components/termoweb/const.py tests/test_api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b440757688329ad969eb85da4c469