### PR TITLE
Handle empty PMO energy samples

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -266,16 +266,20 @@ class TermoWebPmoEnergyCoordinator(
                     continue
                 except Exception:
                     continue
-                if not samples:
-                    continue
-                latest = max(samples, key=lambda s: s.get("t") or 0)
-                val = _as_float(latest.get("counter"))
-                if val is None:
-                    continue
                 dev_map = (
                     data.setdefault(dev_id, {})
                     .setdefault("pmo", {})
                     .setdefault("energy", {})
                 )
+                if not samples:
+                    _LOGGER.debug(
+                        "PMO energy samples empty for %s/%s", dev_id, addr
+                    )
+                    dev_map[addr] = None
+                    continue
+                latest = max(samples, key=lambda s: s.get("t") or 0)
+                val = _as_float(latest.get("counter"))
+                if val is None:
+                    continue
                 dev_map[addr] = val
         return data

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -74,6 +74,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                         .get("energy", {})
                     )
                     has_power = addr in power_map
+                    # Presence of the key (even if value is None) indicates a PMO node
                     has_energy = addr in energy_map
                     if has_power or has_energy:
                         _LOGGER.debug(


### PR DESCRIPTION
## Summary
- Mark PMO nodes with `None` energy when no samples are returned
- Treat energy-map key presence as sufficient to create energy sensors
- Test PMO energy sensors produce `unknown` state when samples are empty

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bab3d5b7883298b874ac2b104ddde