### PR TITLE
Include value in PMO power WS updates

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -209,18 +209,15 @@ class TermoWebPmoPowerCoordinator(
             return
         dev_id = payload.get("dev_id")
         addr = payload.get("addr")
-        base_val = (
-            (self._base.data or {})
-            .get(dev_id, {})
-            .get("pmo", {})
-            .get("power", {})
-            .get(addr)
-        )
+        val = _as_float(payload.get("value"))
+        if val is None:
+            return
         data: Dict[str, Dict[str, Any]] = dict(self.data or {})
         dev_map = data.setdefault(dev_id, {}).setdefault("pmo", {}).setdefault("power", {})
-        dev_map[addr] = base_val
+        dev_map[addr] = val
         if dev_id is not None and addr is not None:
             self.addr_set.setdefault(dev_id, set()).add(addr)
+            _LOGGER.debug("WS set PMO power %s/%s to %s", dev_id, addr, val)
         self.async_set_updated_data(data)
 
 

--- a/tests/test_pmo_power_sensor.py
+++ b/tests/test_pmo_power_sensor.py
@@ -241,7 +241,9 @@ def test_ws_event_updates_sensor() -> None:
 
         base.data["dev1"]["pmo"]["power"]["1"] = 7.0
         async_dispatcher_send(
-            hass, signal_ws_data("entry"), {"dev_id": "dev1", "addr": "1", "kind": "pmo_power"}
+            hass,
+            signal_ws_data("entry"),
+            {"dev_id": "dev1", "addr": "1", "kind": "pmo_power", "value": 7.0},
         )
         assert coord.data["dev1"]["pmo"]["power"]["1"] == 7.0
 
@@ -250,7 +252,9 @@ def test_ws_event_updates_sensor() -> None:
         await ent.async_added_to_hass()
         ent.schedule_update_ha_state = MagicMock()
         async_dispatcher_send(
-            hass, signal_ws_data("entry"), {"dev_id": "dev1", "addr": "1", "kind": "pmo_power"}
+            hass,
+            signal_ws_data("entry"),
+            {"dev_id": "dev1", "addr": "1", "kind": "pmo_power", "value": 7.0},
         )
         assert ent.schedule_update_ha_state.call_count == 1
 


### PR DESCRIPTION
## Summary
- include power value in `/pmo/*/power` websocket events
- store websocket power payloads directly in coordinator and log updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7ccaa7d083299769919549a80c95