### PR TITLE
Remove PMO power/energy sensors and coordinators

### DIFF
--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -4,8 +4,8 @@ import logging
 from typing import Any, Optional
 
 from homeassistant.components.sensor import (
-    SensorEntity,
     SensorDeviceClass,
+    SensorEntity,
     SensorStateClass,
 )
 from homeassistant.const import UnitOfTemperature
@@ -15,7 +15,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_data
-from .coordinator import TermoWebPmoEnergyCoordinator, TermoWebPmoPowerCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,13 +23,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up temperature sensors for each heater node."""
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
-    client = data["client"]
-    pmo_coord = TermoWebPmoPowerCoordinator(hass, client, coordinator, entry.entry_id)
-    data["pmo_power_coordinator"] = pmo_coord
-    await pmo_coord.async_config_entry_first_refresh()
-    pmo_energy_coord = TermoWebPmoEnergyCoordinator(hass, client, coordinator)
-    data["pmo_energy_coordinator"] = pmo_energy_coord
-    await pmo_energy_coord.async_config_entry_first_refresh()
 
     added: set[str] = set()
 
@@ -40,136 +32,30 @@ async def async_setup_entry(hass, entry, async_add_entities):
         for dev_id, dev in data_now.items():
             nodes = dev.get("nodes") or {}
             node_list = nodes.get("nodes") if isinstance(nodes, dict) else None
-            power_addrs = pmo_coord.addr_set.get(dev_id, set())
-            energy_addrs = pmo_energy_coord.addr_set.get(dev_id, set())
-            processed: set[str] = set()
             if isinstance(node_list, list):
                 for node in node_list:
                     if not isinstance(node, dict):
                         continue
                     ntype = (node.get("type") or "").lower()
+                    if ntype != "htr":
+                        continue
                     addr = str(node.get("addr"))
                     base_name = (node.get("name") or f"Node {addr}").strip() or f"Node {addr}"
-                    processed.add(addr)
-                    if ntype == "htr":
-                        unique_id = f"{DOMAIN}:{dev_id}:htr:{addr}:temp"
-                        if unique_id not in added:
-                            ent_name = f"{base_name} Temperature"
-                            new_entities.append(
-                                TermoWebHeaterTemp(
-                                    coordinator, entry.entry_id, dev_id, addr, ent_name, unique_id
-                                )
-                            )
-                            added.add(unique_id)
-
-                        has_power = addr in power_addrs
-                        has_energy = addr in energy_addrs
-                        if has_power or has_energy:
-                            _LOGGER.debug(
-                                "PMO data found for heater %s/%s: power=%s energy=%s",
-                                dev_id,
-                                addr,
-                                has_power,
-                                has_energy,
-                            )
-                            if has_power:
-                                unique_id_p = f"{DOMAIN}:{dev_id}:pmo:{addr}:power"
-                                if unique_id_p not in added:
-                                    ent_name_p = f"{base_name} Power"
-                                    new_entities.append(
-                                        TermoWebPmoPower(
-                                            pmo_coord,
-                                            entry.entry_id,
-                                            dev_id,
-                                            addr,
-                                            ent_name_p,
-                                            unique_id_p,
-                                        )
-                                    )
-                                    added.add(unique_id_p)
-                            if has_energy:
-                                unique_id_energy = f"{dev_id}:{addr}:energy"
-                                if unique_id_energy not in added:
-                                    ent_name_energy = f"{base_name} Energy Total"
-                                    new_entities.append(
-                                        TermoWebPmoEnergyTotal(
-                                            pmo_energy_coord,
-                                            entry.entry_id,
-                                            dev_id,
-                                            addr,
-                                            ent_name_energy,
-                                            unique_id_energy,
-                                        )
-                                    )
-                                    added.add(unique_id_energy)
-                        else:
-                            _LOGGER.debug(
-                                "No PMO data for heater %s/%s", dev_id, addr
-                            )
-                    elif ntype == "pmo":
-                        unique_id = f"{DOMAIN}:{dev_id}:pmo:{addr}:power"
-                        if unique_id not in added:
-                            ent_name = f"{base_name} Power"
-                            new_entities.append(
-                                TermoWebPmoPower(
-                                    pmo_coord, entry.entry_id, dev_id, addr, ent_name, unique_id
-                                )
-                            )
-                            added.add(unique_id)
-                        unique_id_energy = f"{dev_id}:{addr}:energy"
-                        if unique_id_energy not in added:
-                            ent_name_energy = f"{base_name} Energy Total"
-                            new_entities.append(
-                                TermoWebPmoEnergyTotal(
-                                    pmo_energy_coord,
-                                    entry.entry_id,
-                                    dev_id,
-                                    addr,
-                                    ent_name_energy,
-                                    unique_id_energy,
-                                )
-                            )
-                            added.add(unique_id_energy)
-
-            extra_addrs = (power_addrs | energy_addrs) - processed
-            for addr in extra_addrs:
-                base_name = f"Node {addr}"
-                if addr in power_addrs:
-                    unique_id_p = f"{DOMAIN}:{dev_id}:pmo:{addr}:power"
-                    if unique_id_p not in added:
-                        ent_name_p = f"{base_name} Power"
-                        new_entities.append(
-                            TermoWebPmoPower(
-                                pmo_coord,
-                                entry.entry_id,
-                                dev_id,
-                                addr,
-                                ent_name_p,
-                                unique_id_p,
-                            )
+                    unique_id = f"{DOMAIN}:{dev_id}:htr:{addr}:temp"
+                    if unique_id in added:
+                        continue
+                    ent_name = f"{base_name} Temperature"
+                    new_entities.append(
+                        TermoWebHeaterTemp(
+                            coordinator, entry.entry_id, dev_id, addr, ent_name, unique_id
                         )
-                        added.add(unique_id_p)
-                if addr in energy_addrs:
-                    unique_id_energy = f"{dev_id}:{addr}:energy"
-                    if unique_id_energy not in added:
-                        ent_name_energy = f"{base_name} Energy Total"
-                        new_entities.append(
-                            TermoWebPmoEnergyTotal(
-                                pmo_energy_coord,
-                                entry.entry_id,
-                                dev_id,
-                                addr,
-                                ent_name_energy,
-                                unique_id_energy,
-                            )
-                        )
-                        added.add(unique_id_energy)
+                    )
+                    added.add(unique_id)
 
         if new_entities:
             _LOGGER.debug("Adding %d TermoWeb sensors", len(new_entities))
             async_add_entities(new_entities)
 
-    # Add now and on subsequent coordinator updates
     await build_and_add()
 
     def _on_coordinator_update() -> None:
@@ -254,101 +140,3 @@ class TermoWebHeaterTemp(CoordinatorEntity, SensorEntity):
         }
 
 
-class TermoWebPmoPower(CoordinatorEntity, SensorEntity):
-    """Power sensor for PMO nodes."""
-
-    _attr_device_class = SensorDeviceClass.POWER
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "W"
-
-    def __init__(
-        self,
-        coordinator: TermoWebPmoPowerCoordinator,
-        entry_id: str,
-        dev_id: str,
-        addr: str,
-        name: str,
-        unique_id: str,
-    ) -> None:
-        super().__init__(coordinator)
-        self._entry_id = entry_id
-        self._dev_id = dev_id
-        self._addr = addr
-        self._attr_name = name
-        self._attr_unique_id = unique_id
-        self._unsub_ws = None
-
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
-        self._unsub_ws = async_dispatcher_connect(
-            self.hass, signal_ws_data(self._entry_id), self._on_ws_data
-        )
-        self.async_on_remove(lambda: self._unsub_ws() if self._unsub_ws else None)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
-
-    @callback
-    def _on_ws_data(self, payload: dict) -> None:
-        if payload.get("kind") != "pmo_power":
-            return
-        if payload.get("dev_id") != self._dev_id:
-            return
-        addr = payload.get("addr")
-        if addr is not None and addr != self._addr:
-            return
-        self.schedule_update_ha_state()
-
-    @property
-    def native_value(self) -> Optional[float]:
-        dev = (self.coordinator.data or {}).get(self._dev_id, {})
-        return (
-            dev.get("pmo", {})
-            .get("power", {})
-            .get(self._addr)
-        )
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        return {
-            "dev_id": self._dev_id,
-            "addr": self._addr,
-        }
-
-
-class TermoWebPmoEnergyTotal(CoordinatorEntity, SensorEntity):
-    """Total energy sensor for PMO nodes."""
-
-    _attr_state_class = "total_increasing"
-    _attr_native_unit_of_measurement = "kWh"
-
-    def __init__(
-        self,
-        coordinator: TermoWebPmoEnergyCoordinator,
-        entry_id: str,
-        dev_id: str,
-        addr: str,
-        name: str,
-        unique_id: str,
-    ) -> None:
-        super().__init__(coordinator)
-        self._entry_id = entry_id
-        self._dev_id = dev_id
-        self._addr = addr
-        self._attr_name = name
-        self._attr_unique_id = unique_id
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
-
-    @property
-    def native_value(self) -> Optional[float]:
-        dev = (self.coordinator.data or {}).get(self._dev_id, {})
-        val = dev.get("pmo", {}).get("energy", {}).get(self._addr)
-        return val / 1000.0 if val is not None else None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        return {"dev_id": self._dev_id, "addr": self._addr}


### PR DESCRIPTION
## Summary
- drop PMO power and energy coordinators
- simplify sensor setup to only expose heater temperature sensors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cdcfeaf1883298d266278c5749bea