### PR TITLE
Remove PMO power handling from legacy WS client

### DIFF
--- a/custom_components/termoweb/ws_client_legacy.py
+++ b/custom_components/termoweb/ws_client_legacy.py
@@ -297,7 +297,6 @@ class TermoWebWSLegacyClient:
         # Apply updates to coordinator.data in-place to keep shape compatible with current entities.
         updated_nodes = False
         updated_addrs: List[str] = []
-        updated_pmo_power: Dict[str, float] = {}
 
         for item in batch:
             if not isinstance(item, dict):
@@ -357,21 +356,6 @@ class TermoWebWSLegacyClient:
                 if isinstance(body, dict):
                     adv_map[addr] = body
 
-            elif "/pmo/" in path and path.endswith("/power"):
-                addr = path.split("/pmo/")[1].split("/")[0]
-                power_map: Dict[str, Any] = dev_map.setdefault("pmo", {}).setdefault("power", {})
-                val: float | None = None
-                if isinstance(body, dict):
-                    body = body.get("power")
-                try:
-                    if body is not None:
-                        val = float(body)
-                except Exception:
-                    val = None
-                if val is not None:
-                    power_map[addr] = val
-                    updated_pmo_power[addr] = val
-
             else:
                 # Other top-level paths, store compactly under raw
                 raw = dev_map.setdefault("raw", {})
@@ -384,12 +368,10 @@ class TermoWebWSLegacyClient:
         if updated_nodes:
             async_dispatcher_send(self.hass, signal_ws_data(self.entry_id), {**payload_base, "addr": None, "kind": "nodes"})
         for addr in set(updated_addrs):
-            async_dispatcher_send(self.hass, signal_ws_data(self.entry_id), {**payload_base, "addr": addr, "kind": "htr_settings"})
-        for addr, val in updated_pmo_power.items():
             async_dispatcher_send(
                 self.hass,
                 signal_ws_data(self.entry_id),
-                {**payload_base, "addr": addr, "kind": "pmo_power", "value": val},
+                {**payload_base, "addr": addr, "kind": "htr_settings"},
             )
 
     # ----------------- Helpers -----------------


### PR DESCRIPTION
## Summary
- drop legacy PMO power update parsing
- keep heater and node updates intact

## Testing
- `ruff check custom_components/termoweb/ws_client_legacy.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cde4d91fc8329b805a37bf22d334f