### PR TITLE
Add heater samples API

### DIFF
--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -13,6 +13,7 @@ CONNECTED_PATH_FMT: Final = (
     "/api/v2/devs/{dev_id}/connected"  # some fw return 404; we tolerate
 )
 NODES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/mgr/nodes"
+HTR_SAMPLES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/htr/{addr}/samples"
 
 # Public client creds (from APK v2.5.1)
 BASIC_AUTH_B64: Final = "NTIxNzJkYzg0ZjYzZDZjNzU5MDAwMDA1OmJ4djRaM3hVU2U="


### PR DESCRIPTION
## Summary
- add heater samples path constant
- implement client method to fetch heater energy samples

## Testing
- `pytest` *(command not found)*
- `ruff custom_components/termoweb/const.py custom_components/termoweb/api.py` *(ruff not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689ce04f3bb08329bc04357bdc773b6d