### PR TITLE
feat: add heater energy coordinator

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
+import time
 from typing import Any, Dict, List, Optional
 
 from aiohttp import ClientError
@@ -127,4 +128,102 @@ class TermoWebCoordinator(DataUpdateCoordinator[Dict[str, Dict[str, Any]]]):  # 
             self.update_interval = timedelta(seconds=self._backoff)
             raise UpdateFailed(f"Rate limited; backing off to {self._backoff}s") from err
         except (ClientError, TermoWebAuthError) as err:
+            raise UpdateFailed(f"API error: {err}") from err
+
+
+class TermoWebHeaterEnergyCoordinator(
+    DataUpdateCoordinator[Dict[str, Dict[str, Any]]]
+):  # dev_id -> per-device data
+    """Polls heater energy counters and exposes energy and power per heater."""
+
+    def __init__(self, hass: HomeAssistant, client: TermoWebClient) -> None:
+        super().__init__(
+            hass,
+            logger=_LOGGER,
+            name="termoweb-htr-energy",
+            update_interval=timedelta(minutes=15),
+        )
+        self.client = client
+        self._last: dict[tuple[str, str], tuple[float, float]] = {}
+
+    async def _async_update_data(self) -> Dict[str, Dict[str, Any]]:
+        try:
+            devices: List[Dict[str, Any]] = await self.client.list_devices()
+            if not isinstance(devices, list):
+                devices = []
+
+            result: Dict[str, Dict[str, Any]] = {}
+            for dev in devices:
+                if not isinstance(dev, dict):
+                    continue
+
+                dev_id = str(
+                    dev.get("dev_id") or dev.get("id") or dev.get("serial_id") or ""
+                ).strip()
+                if not dev_id:
+                    continue
+
+                try:
+                    nodes = await self.client.get_nodes(dev_id)
+                except Exception:
+                    nodes = None
+
+                addrs: list[str] = []
+                node_list = nodes.get("nodes") if isinstance(nodes, dict) else None
+                if isinstance(node_list, list):
+                    for n in node_list:
+                        if isinstance(n, dict) and (n.get("type") or "").lower() == "htr":
+                            addrs.append(str(n.get("addr")))
+
+                energy_map: Dict[str, float] = {}
+                power_map: Dict[str, float] = {}
+
+                for addr in addrs:
+                    now = time.time()
+                    start = now - 3600  # fetch recent samples
+                    try:
+                        samples = await self.client.get_htr_samples(dev_id, addr, start, now)
+                    except (
+                        ClientError,
+                        TermoWebRateLimitError,
+                        TermoWebAuthError,
+                    ):
+                        samples = []
+
+                    if not samples:
+                        continue
+
+                    last = samples[-1]
+                    counter = _as_float(last.get("counter"))
+                    t = _as_float(last.get("t"))
+                    if counter is None or t is None:
+                        continue
+
+                    energy_map[addr] = counter
+
+                    prev = self._last.get((dev_id, addr))
+                    if prev:
+                        prev_t, prev_counter = prev
+                        if counter < prev_counter or t <= prev_t:
+                            self._last[(dev_id, addr)] = (t, counter)
+                            continue
+                        dt_hours = (t - prev_t) / 3600
+                        if dt_hours > 0:
+                            power = (counter - prev_counter) / dt_hours * 1000
+                            power_map[addr] = power
+                        self._last[(dev_id, addr)] = (t, counter)
+                    else:
+                        self._last[(dev_id, addr)] = (t, counter)
+
+                result[dev_id] = {
+                    "dev_id": dev_id,
+                    "htr": {
+                        "energy": energy_map,
+                        "power": power_map,
+                    },
+                }
+
+            return result
+
+        except (ClientError, TermoWebRateLimitError, TermoWebAuthError) as err:
             raise UpdateFailed(f"API error: {err}") from err

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Minimal aiohttp stub
+aiohttp_stub = types.ModuleType("aiohttp")
+
+
+class ClientError(Exception):  # pragma: no cover - placeholder
+    pass
+
+
+aiohttp_stub.ClientError = ClientError
+sys.modules["aiohttp"] = aiohttp_stub
+
+# Stub minimal Home Assistant modules
+ha_core = types.ModuleType("homeassistant.core")
+
+
+class HomeAssistant:  # pragma: no cover - placeholder
+    pass
+
+
+ha_core.HomeAssistant = HomeAssistant
+sys.modules["homeassistant"] = types.ModuleType("homeassistant")
+sys.modules["homeassistant.core"] = ha_core
+
+ha_helpers = types.ModuleType("homeassistant.helpers")
+uc = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+
+class UpdateFailed(Exception):  # pragma: no cover - placeholder
+    pass
+
+
+class DataUpdateCoordinator:  # pragma: no cover - minimal stub
+    def __init__(self, hass, *, logger=None, name=None, update_interval=None) -> None:
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data: Dict[str, Dict[str, Any]] | None = None
+
+    async def async_refresh(self) -> None:
+        self.data = await self._async_update_data()
+
+    async def async_config_entry_first_refresh(self) -> None:
+        await self.async_refresh()
+
+    def async_add_listener(self, *_args) -> None:
+        return None
+
+    @classmethod
+    def __class_getitem__(cls, _item) -> type:
+        return cls
+
+
+uc.UpdateFailed = UpdateFailed
+uc.DataUpdateCoordinator = DataUpdateCoordinator
+ha_helpers.update_coordinator = uc
+sys.modules["homeassistant.helpers"] = ha_helpers
+sys.modules["homeassistant.helpers.update_coordinator"] = uc
+
+# Stub API module
+package = "custom_components.termoweb"
+api_stub = types.ModuleType(f"{package}.api")
+import time as _time
+
+
+class TermoWebClient:  # pragma: no cover - placeholder
+    pass
+
+
+class TermoWebAuthError(Exception):  # pragma: no cover - placeholder
+    pass
+
+
+class TermoWebRateLimitError(Exception):  # pragma: no cover - placeholder
+    pass
+
+
+api_stub.TermoWebClient = TermoWebClient
+api_stub.TermoWebAuthError = TermoWebAuthError
+api_stub.TermoWebRateLimitError = TermoWebRateLimitError
+api_stub.time = _time
+sys.modules[f"{package}.api"] = api_stub
+
+# Load coordinator module
+COORD_PATH = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "termoweb" / "coordinator.py"
+)
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+termoweb_pkg = types.ModuleType(package)
+termoweb_pkg.__path__ = [str(COORD_PATH.parent)]
+sys.modules[package] = termoweb_pkg
+
+spec = importlib.util.spec_from_file_location(f"{package}.coordinator", COORD_PATH)
+coord_module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[f"{package}.coordinator"] = coord_module
+spec.loader.exec_module(coord_module)
+
+TermoWebHeaterEnergyCoordinator = coord_module.TermoWebHeaterEnergyCoordinator
+
+
+def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        client = types.SimpleNamespace()
+        client.list_devices = AsyncMock(return_value=[{"dev_id": "1"}])
+        client.get_nodes = AsyncMock(return_value={"nodes": [{"type": "htr", "addr": "A"}]})
+        client.get_htr_samples = AsyncMock(
+            side_effect=[
+                [{"t": 1000, "counter": "1.0"}],
+                [{"t": 1900, "counter": "1.5"}],
+            ]
+        )
+
+        hass = HomeAssistant()
+        coord = TermoWebHeaterEnergyCoordinator(hass, client)  # type: ignore[arg-type]
+
+        fake_time = 1000.0
+
+        def _fake_time() -> float:
+            return fake_time
+
+        monkeypatch.setattr(coord_module.time, "time", _fake_time)
+
+        await coord.async_refresh()
+        assert coord.data["1"]["htr"]["energy"]["A"] == 1.0
+        assert "A" not in coord.data["1"]["htr"]["power"]
+
+        fake_time = 1900.0
+        await coord.async_refresh()
+        assert coord.data["1"]["htr"]["energy"]["A"] == 1.5
+        power = coord.data["1"]["htr"]["power"]["A"]
+        assert power == pytest.approx(2000.0, rel=1e-3)
+
+    asyncio.run(_run())
+
+
+def test_counter_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        client = types.SimpleNamespace()
+        client.list_devices = AsyncMock(return_value=[{"dev_id": "1"}])
+        client.get_nodes = AsyncMock(return_value={"nodes": [{"type": "htr", "addr": "A"}]})
+        client.get_htr_samples = AsyncMock(
+            side_effect=[
+                [{"t": 1000, "counter": "5.0"}],
+                [{"t": 1900, "counter": "1.0"}],
+            ]
+        )
+
+        hass = HomeAssistant()
+        coord = TermoWebHeaterEnergyCoordinator(hass, client)  # type: ignore[arg-type]
+
+        fake_time = 1000.0
+
+        def _fake_time() -> float:
+            return fake_time
+
+        monkeypatch.setattr(coord_module.time, "time", _fake_time)
+
+        await coord.async_refresh()
+        fake_time = 1900.0
+        await coord.async_refresh()
+
+        assert coord.data["1"]["htr"]["energy"]["A"] == 1.0
+        assert "A" not in coord.data["1"]["htr"]["power"]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add coordinator to track heater energy and power usage
- cover heater energy coordinator logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce1e14f8c832981f63c05d7c28585