### PR TITLE
Cache TermoWeb hub and node identifiers

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -17,28 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up one connectivity binary sensor per TermoWeb hub (dev_id)."""
-    coord: TermoWebCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    added_ids: set[str] = hass.data[DOMAIN][entry.entry_id].setdefault(
-        "added_binary_ids", set()
-    )
-
-    @callback
-    def _add_entities() -> None:
-        # Add exactly one sensor per dev_id (the hub)
-        for dev_id, _data in (coord.data or {}).items():
-            uid = f"{dev_id}_online"
-            if uid in added_ids:
-                continue
-            try:
-                ent = TermoWebDeviceOnlineBinarySensor(coord, entry.entry_id, dev_id)
-                async_add_entities([ent])
-                added_ids.add(uid)
-            except Exception as exc:
-                _LOGGER.error("Failed to add hub binary sensor dev_id=%s: %s", dev_id, exc)
-
-    coord.async_add_listener(_add_entities)
-    if coord.data:
-        _add_entities()
+    data = hass.data[DOMAIN][entry.entry_id]
+    coord: TermoWebCoordinator = data["coordinator"]
+    dev_id = data["dev_id"]
+    ent = TermoWebDeviceOnlineBinarySensor(coord, entry.entry_id, dev_id)
+    async_add_entities([ent])
 
 
 class TermoWebDeviceOnlineBinarySensor(

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import DeviceInfo
@@ -16,31 +15,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Expose only a safe 'Force refresh' hub-level button per device."""
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
-    client = data.get("client")
-
-    # Build one button per device we know about
-    new: list[ButtonEntity] = []
-    for dev_id, dev in (coordinator.data or {}).items():
-        new.append(TermoWebRefreshButton(coordinator, dev_id))
-    if new:
-        async_add_entities(new)
-
-    # If devices appear later, add a button then
-    def _on_update():
-        cur_ids = {e.unique_id for e in new}
-        to_add: list[ButtonEntity] = []
-        for dev_id, dev in (coordinator.data or {}).items():
-            uid = f"{DOMAIN}:{dev_id}:refresh"
-            if uid in cur_ids:
-                continue
-            entity = TermoWebRefreshButton(coordinator, dev_id)
-            to_add.append(entity)
-            cur_ids.add(uid)
-        if to_add:
-            async_add_entities(to_add)
-            new.extend(to_add)
-
-    coordinator.async_add_listener(_on_update)
+    dev_id = data["dev_id"]
+    async_add_entities([TermoWebRefreshButton(coordinator, dev_id)])
 
 
 class TermoWebRefreshButton(CoordinatorEntity, ButtonEntity):

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -114,8 +114,6 @@ TermoWebHeaterEnergyCoordinator = coord_module.TermoWebHeaterEnergyCoordinator
 def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
         client = types.SimpleNamespace()
-        client.list_devices = AsyncMock(return_value=[{"dev_id": "1"}])
-        client.get_nodes = AsyncMock(return_value={"nodes": [{"type": "htr", "addr": "A"}]})
         client.get_htr_samples = AsyncMock(
             side_effect=[
                 [{"t": 1000, "counter": "1.0"}],
@@ -124,7 +122,7 @@ def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
         hass = HomeAssistant()
-        coord = TermoWebHeaterEnergyCoordinator(hass, client)  # type: ignore[arg-type]
+        coord = TermoWebHeaterEnergyCoordinator(hass, client, "1", ["A"])  # type: ignore[arg-type]
 
         fake_time = 1000.0
 
@@ -149,8 +147,6 @@ def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_counter_reset(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
         client = types.SimpleNamespace()
-        client.list_devices = AsyncMock(return_value=[{"dev_id": "1"}])
-        client.get_nodes = AsyncMock(return_value={"nodes": [{"type": "htr", "addr": "A"}]})
         client.get_htr_samples = AsyncMock(
             side_effect=[
                 [{"t": 1000, "counter": "5.0"}],
@@ -159,7 +155,7 @@ def test_counter_reset(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
         hass = HomeAssistant()
-        coord = TermoWebHeaterEnergyCoordinator(hass, client)  # type: ignore[arg-type]
+        coord = TermoWebHeaterEnergyCoordinator(hass, client, "1", ["A"])  # type: ignore[arg-type]
 
         fake_time = 1000.0
 

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -197,8 +197,6 @@ signal_ws_data = __import__(f"{package}.const", fromlist=["signal_ws_data"]).sig
 def test_coordinator_and_sensors() -> None:
     async def _run() -> None:
         client = types.SimpleNamespace()
-        client.list_devices = AsyncMock(return_value=[{"dev_id": "1"}])
-        client.get_nodes = AsyncMock(return_value={"nodes": [{"type": "htr", "addr": "A"}]})
         client.get_htr_samples = AsyncMock(
             side_effect=[
                 [{"t": 1000, "counter": "1.0"}],
@@ -207,7 +205,7 @@ def test_coordinator_and_sensors() -> None:
         )
 
         hass = HomeAssistant()
-        coord = TermoWebHeaterEnergyCoordinator(hass, client)  # type: ignore[arg-type]
+        coord = TermoWebHeaterEnergyCoordinator(hass, client, "1", ["A"])  # type: ignore[arg-type]
 
         await coord.async_refresh()
         await coord.async_refresh()


### PR DESCRIPTION
## Summary
- Cache hub `dev_id` and heater addresses once during setup and share via `hass.data`
- Refactor coordinators to reuse cached IDs instead of listing devices/nodes on every update
- Simplify platform setups to create entities from cached node list without dynamic listeners

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf197f9948329b6ac0b70f6ba249a