### PR TITLE
docs: explain energy sensors and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,15 @@ ha-termoweb/ha-termoweb
 ---
 
 ## Tips
-- **Voice control:** Expose heater entities via Home Assistant’s Google or Alexa integrations.  
+- **Voice control:** Expose heater entities via Home Assistant’s Google or Alexa integrations.
 - **Automations idea:** Lower temperature when nobody’s home; switch to **Off** if a window sensor is open for 10+ minutes.
+
+## Energy monitoring & history
+- Each heater provides an **Energy** sensor in kWh and the integration adds a **Total Energy** sensor aggregating all heaters.
+- Add these sensors in **Settings → Dashboards → Energy** to include them in Home Assistant’s Energy Dashboard.
+- Energy counters are fetched hourly from TermoWeb.
+- Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration.
+- No extra configuration is required beyond selecting the sensors in the Energy Dashboard.
 
 ---
 

--- a/docs/termoweb_api.md
+++ b/docs/termoweb_api.md
@@ -122,6 +122,14 @@ Common bodies:
 
 Observed cadence for `htr`: ~3600 s.
 
+### Home Assistant energy integration
+
+- Each heater’s `counter` value maps to a Home Assistant **Energy** sensor, and an aggregate sensor sums all heater counters for whole-home tracking.
+- Add these sensors in **Settings → Dashboards → Energy** so they appear in the Energy Dashboard.
+- The integration polls this endpoint hourly. When the cloud emits optional `htr/samples` WebSocket events, sensors update as those pushes arrive.
+- Call the `termoweb.import_energy_history` service to backfill past samples into Home Assistant’s statistics database.
+
+
 
 ## Real‑time (legacy Socket.IO 0.9)
 


### PR DESCRIPTION
## Summary
- document energy sensors and Energy Dashboard integration
- note `termoweb.import_energy_history` service and optional WebSocket updates (API docs only)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cff5730808329887ae0bf16e75f5c