### PR TITLE
Add detailed logging for WS connection errors

### DIFF
--- a/custom_components/termoweb/ws_client_legacy.py
+++ b/custom_components/termoweb/ws_client_legacy.py
@@ -143,7 +143,15 @@ class TermoWebWSLegacyClient:
                 break
             except Exception as e:
                 # Avoid noisy logs; just one INFO per failure with brief cause.
-                _LOGGER.info("WS %s: connection error (%s); will retry", self.dev_id, type(e).__name__)
+                _LOGGER.info(
+                    "WS %s: connection error (%s: %s); will retry",
+                    self.dev_id,
+                    type(e).__name__,
+                    e,
+                )
+                _LOGGER.debug(
+                    "WS %s: connection error details", self.dev_id, exc_info=True
+                )
             finally:
                 # Clean up this attempt
                 if self._hb_task:


### PR DESCRIPTION
## Summary
- log exception messages and stack traces when websocket connections fail

## Testing
- `ruff check custom_components/termoweb/ws_client_legacy.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0ac45fa883298844489435151fc3