### PR TITLE
Add energy history import service

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -29,7 +29,11 @@ except Exception:  # pragma: no cover - fallback for older HA
         hass: HomeAssistant, metadata: dict[str, Any], stats: list[dict[str, Any]]
     ) -> None:
         """Insert statistics using legacy recorder helper."""
-        async_add_external_statistics(hass, metadata, stats)
+        stat_id: str = metadata["statistic_id"]
+        domain, obj_id = stat_id.split(".", 1)
+        ext_meta = dict(metadata)
+        ext_meta.update({"statistic_id": f"{domain}:{obj_id}", "source": domain})
+        async_add_external_statistics(hass, ext_meta, stats)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant

--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -7,7 +7,8 @@ import time
 from typing import Any, Dict, Iterable
 
 from homeassistant.components.recorder.statistics import (
-    async_add_external_statistics,
+    async_import_statistics,
+    async_update_statistics_metadata,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
@@ -170,10 +171,12 @@ async def _async_import_energy_history(
         }
         _LOGGER.debug("%s: adding %d stats entries", addr, len(stats))
         try:
-            async_add_external_statistics(hass, metadata, stats)
+            async_update_statistics_metadata(hass, metadata)
+            stat_list = [{"statistic_id": entity_id, **s} for s in stats]
+            async_import_statistics(hass, stat_list)
         except Exception as err:  # pragma: no cover - log & continue
             _LOGGER.exception(
-                "%s: async_add_external_statistics failed: %s",
+                "%s: async_import_statistics failed: %s",
                 addr,
                 err,
             )

--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -151,7 +151,7 @@ async def _async_import_energy_history(
         }
         _LOGGER.debug("%s: adding %d stats entries", addr, len(stats))
         try:
-            await async_add_external_statistics(hass, metadata, stats)
+            async_add_external_statistics(hass, metadata, stats)
         except Exception as err:  # pragma: no cover - log & continue
             _LOGGER.exception(
                 "%s: async_add_external_statistics failed: %s",

--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -17,8 +17,7 @@ try:
     ) -> None:
         """Insert statistics using new recorder helpers."""
         async_update_statistics_metadata(hass, metadata)
-        stat_list = [{"statistic_id": metadata["statistic_id"], **s} for s in stats]
-        async_import_statistics(hass, stat_list)
+        async_import_statistics(hass, metadata, stats)
 
 except Exception:  # pragma: no cover - fallback for older HA
     from homeassistant.components.recorder.statistics import (

--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -35,7 +35,7 @@ OPTION_ENERGY_HISTORY_IMPORTED = "energy_history_imported"
 OPTION_ENERGY_HISTORY_PROGRESS = "energy_history_progress"
 OPTION_MAX_HISTORY_RETRIEVED = "max_history_retrieved"
 
-DEFAULT_MAX_HISTORY_DAYS = 365
+DEFAULT_MAX_HISTORY_DAYS = 7
 
 # Guard htr/samples API usage
 _SAMPLES_QUERY_LOCK = asyncio.Lock()
@@ -144,7 +144,7 @@ async def _async_import_energy_history(
 
         metadata = {
             "source": DOMAIN,
-            "statistic_id": f"{DOMAIN}:{dev_id}:htr:{addr}:energy",
+            "statistic_id": f"{DOMAIN}:{dev_id}_htr_{addr}_energy",
             "unit_of_measurement": "kWh",
             "name": f"{dev_id} {addr} energy",
             "has_sum": True,
@@ -332,11 +332,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not entry.options.get(OPTION_ENERGY_HISTORY_IMPORTED):
         _LOGGER.debug("%s: scheduling initial energy import", entry.entry_id)
 
-        def _schedule_import(_event: Any | None = None) -> None:
-            hass.async_create_task(_async_import_energy_history(hass, entry))
+        async def _schedule_import(_event: Any | None = None) -> None:
+            await _async_import_energy_history(hass, entry)
 
         if hass.is_running:
-            _schedule_import()
+            hass.async_create_task(_schedule_import())
         else:
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _schedule_import)
 

--- a/custom_components/termoweb/services.yaml
+++ b/custom_components/termoweb/services.yaml
@@ -70,6 +70,7 @@ import_energy_history:
       description: >-
         Number of days of history to retrieve. Overrides the configured
         default for this import only.
+      default: 7
       selector:
         number:
           min: 1

--- a/custom_components/termoweb/services.yaml
+++ b/custom_components/termoweb/services.yaml
@@ -48,3 +48,30 @@ set_preset_temperatures:
       name: Day preset
       description: Temperature for the day preset (°C or °F).
       example: 20.0
+
+import_energy_history:
+  name: Import energy history
+  description: >-
+    Import historical hourly energy counters for TermoWeb heaters up to one
+    year ago into Home Assistant statistics.
+  target:
+    entity:
+      integration: termoweb
+  fields:
+    reset_progress:
+      name: Reset progress
+      description: >-
+        Clear stored progress and re-import history from scratch.
+      default: false
+      selector:
+        boolean: {}
+    max_history_retrieval:
+      name: Max history days
+      description: >-
+        Number of days of history to retrieve. Overrides the configured
+        default for this import only.
+      selector:
+        number:
+          min: 1
+          max: 3650
+          unit_of_measurement: days

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -175,7 +175,7 @@ def test_import_energy_history(monkeypatch: pytest.MonkeyPatch) -> None:
 
         add_stats.assert_awaited_once()
         args = add_stats.await_args[0]
-        assert args[1]["statistic_id"] == f"{const.DOMAIN}:dev:htr:A:energy"
+        assert args[1]["statistic_id"] == f"{const.DOMAIN}:dev_htr_A_energy"
         stats_list = args[2]
         assert [s["sum"] for s in stats_list] == [pytest.approx(0.001), pytest.approx(0.002)]
         assert entry.options[mod.OPTION_ENERGY_HISTORY_IMPORTED] is True
@@ -294,7 +294,9 @@ def test_setup_defers_import_until_started(monkeypatch: pytest.MonkeyPatch) -> N
         assert not called
 
         for cb in listeners:
-            cb(None)
+            res = cb(None)
+            if asyncio.iscoroutine(res):
+                await res
         await asyncio.gather(*tasks)
 
         assert called

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -6,7 +6,7 @@ import itertools
 import sys
 import types
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -58,7 +58,7 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch):
     # Recorder statistics stub
     recorder = types.ModuleType("homeassistant.components.recorder")
     stats = types.ModuleType("homeassistant.components.recorder.statistics")
-    add_stats = AsyncMock()
+    add_stats = Mock()
     stats.async_add_external_statistics = add_stats
     sys.modules.setdefault("homeassistant.components", types.ModuleType("homeassistant.components"))
     sys.modules["homeassistant.components.recorder"] = recorder
@@ -173,8 +173,8 @@ def test_import_energy_history(monkeypatch: pytest.MonkeyPatch) -> None:
         assert first_call == ("dev", "A", 259_200, 345_600)
         assert second_call == ("dev", "A", 172_800, 259_200)
 
-        add_stats.assert_awaited_once()
-        args = add_stats.await_args[0]
+        add_stats.assert_called_once()
+        args = add_stats.call_args[0]
         assert args[1]["statistic_id"] == f"{const.DOMAIN}:dev_htr_A_energy"
         stats_list = args[2]
         assert [s["sum"] for s in stats_list] == [pytest.approx(0.001), pytest.approx(0.002)]
@@ -227,7 +227,7 @@ def test_import_energy_history_reset_and_subset(monkeypatch: pytest.MonkeyPatch)
         await mod._async_import_energy_history(hass, entry, ["A"], reset_progress=True)
 
         client.get_htr_samples.assert_awaited_once_with("dev", "A", 86_400, 172_800)
-        add_stats.assert_awaited_once()
+        add_stats.assert_called_once()
         progress = entry.options[mod.OPTION_ENERGY_HISTORY_PROGRESS]
         assert progress == {"A": 86_400, "B": 0}
         assert entry.options[mod.OPTION_ENERGY_HISTORY_IMPORTED] is True

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import itertools
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+async def _load_module(monkeypatch: pytest.MonkeyPatch):
+    package = "custom_components.termoweb"
+
+    # Stub Home Assistant modules
+    ha_core = types.ModuleType("homeassistant.core")
+    class HomeAssistant:  # pragma: no cover - minimal stub
+        pass
+    ha_core.HomeAssistant = HomeAssistant
+    sys.modules["homeassistant"] = types.ModuleType("homeassistant")
+    sys.modules["homeassistant.core"] = ha_core
+
+    ha_cfg = types.ModuleType("homeassistant.config_entries")
+    class ConfigEntry:  # pragma: no cover - minimal stub
+        def __init__(self, entry_id, data=None, options=None):
+            self.entry_id = entry_id
+            self.data = data or {}
+            self.options = options or {}
+    ha_cfg.ConfigEntry = ConfigEntry
+    sys.modules["homeassistant.config_entries"] = ha_cfg
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    aiohttp_client.async_get_clientsession = lambda hass: None
+    dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
+    dispatcher.async_dispatcher_connect = lambda hass, sig, cb: (lambda: None)
+    entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    entity_registry.async_get = lambda hass: None
+    helpers.aiohttp_client = aiohttp_client
+    helpers.entity_registry = entity_registry
+    sys.modules["homeassistant.helpers"] = helpers
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client
+    sys.modules["homeassistant.helpers.dispatcher"] = dispatcher
+    sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
+
+    loader = types.ModuleType("homeassistant.loader")
+    async def async_get_integration(hass, domain):
+        return types.SimpleNamespace(version="1.0")
+    loader.async_get_integration = async_get_integration
+    sys.modules["homeassistant.loader"] = loader
+
+    # Recorder statistics stub
+    recorder = types.ModuleType("homeassistant.components.recorder")
+    stats = types.ModuleType("homeassistant.components.recorder.statistics")
+    add_stats = AsyncMock()
+    stats.async_add_external_statistics = add_stats
+    sys.modules.setdefault("homeassistant.components", types.ModuleType("homeassistant.components"))
+    sys.modules["homeassistant.components.recorder"] = recorder
+    sys.modules["homeassistant.components.recorder.statistics"] = stats
+
+    # Stub package modules
+    sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    termoweb_pkg = types.ModuleType(package)
+    termoweb_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components" / "termoweb")]
+    sys.modules[package] = termoweb_pkg
+
+    api_stub = types.ModuleType(f"{package}.api")
+    class TermoWebClient:  # pragma: no cover - placeholder
+        pass
+    api_stub.TermoWebClient = TermoWebClient
+    sys.modules[f"{package}.api"] = api_stub
+
+    coord_stub = types.ModuleType(f"{package}.coordinator")
+    class TermoWebCoordinator:  # pragma: no cover - placeholder
+        pass
+    coord_stub.TermoWebCoordinator = TermoWebCoordinator
+    sys.modules[f"{package}.coordinator"] = coord_stub
+
+    ws_stub = types.ModuleType(f"{package}.ws_client_legacy")
+    class TermoWebWSLegacyClient:  # pragma: no cover - placeholder
+        pass
+    ws_stub.TermoWebWSLegacyClient = TermoWebWSLegacyClient
+    sys.modules[f"{package}.ws_client_legacy"] = ws_stub
+
+    # Load const and __init__ modules
+    const_path = Path(__file__).resolve().parents[1] / "custom_components" / "termoweb" / "const.py"
+    spec_const = importlib.util.spec_from_file_location(f"{package}.const", const_path)
+    const_module = importlib.util.module_from_spec(spec_const)
+    sys.modules[f"{package}.const"] = const_module
+    spec_const.loader.exec_module(const_module)
+
+    init_path = Path(__file__).resolve().parents[1] / "custom_components" / "termoweb" / "__init__.py"
+    spec = importlib.util.spec_from_file_location(f"{package}.__init__", init_path)
+    init_module = importlib.util.module_from_spec(spec)
+    sys.modules[f"{package}.__init__"] = init_module
+    spec.loader.exec_module(init_module)
+
+    return init_module, const_module, add_stats, ConfigEntry, HomeAssistant
+
+
+def test_import_energy_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        mod, const, add_stats, ConfigEntry, HomeAssistant = await _load_module(monkeypatch)
+
+        hass = HomeAssistant()
+        hass.data = {const.DOMAIN: {}}
+        hass.config_entries = types.SimpleNamespace(
+            async_update_entry=lambda entry, *, options: entry.options.update(options)
+        )
+
+        entry = ConfigEntry("1", options={"max_history_retrieved": 2})
+        client = types.SimpleNamespace()
+        client.get_htr_samples = AsyncMock(
+            side_effect=[
+                [{"t": 259_200, "counter": "1.0"}],
+                [{"t": 172_800, "counter": "2.0"}],
+            ]
+        )
+        hass.data[const.DOMAIN][entry.entry_id] = {
+            "client": client,
+            "dev_id": "dev",
+            "htr_addrs": ["A"],
+            "config_entry": entry,
+        }
+
+        fake_now = 4 * 86_400
+        monotonic_counter = itertools.count(start=1, step=2)
+        monkeypatch.setattr(
+            mod,
+            "time",
+            types.SimpleNamespace(
+                time=lambda: fake_now, monotonic=lambda: next(monotonic_counter)
+            ),
+        )
+
+        await mod._async_import_energy_history(hass, entry)
+
+        assert client.get_htr_samples.await_count == 2
+        first_call = client.get_htr_samples.await_args_list[0][0]
+        second_call = client.get_htr_samples.await_args_list[1][0]
+        assert first_call == ("dev", "A", 259_200, 345_600)
+        assert second_call == ("dev", "A", 172_800, 259_200)
+
+        add_stats.assert_awaited_once()
+        args = add_stats.await_args[0]
+        assert args[1]["statistic_id"] == f"{const.DOMAIN}:dev:htr:A:energy"
+        stats_list = args[2]
+        assert [s["sum"] for s in stats_list] == [pytest.approx(0.001), pytest.approx(0.002)]
+        assert entry.options[mod.OPTION_ENERGY_HISTORY_IMPORTED] is True
+        assert entry.options[mod.OPTION_ENERGY_HISTORY_PROGRESS] == {"A": 172_800}
+        assert entry.options["max_history_retrieved"] == 2
+
+    asyncio.run(_run())
+
+
+def test_import_energy_history_reset_and_subset(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        mod, const, add_stats, ConfigEntry, HomeAssistant = await _load_module(monkeypatch)
+
+        hass = HomeAssistant()
+        hass.data = {const.DOMAIN: {}}
+        hass.config_entries = types.SimpleNamespace(
+            async_update_entry=lambda entry, *, options: entry.options.update(options)
+        )
+
+        entry = ConfigEntry(
+            "1",
+            options={
+                mod.OPTION_ENERGY_HISTORY_IMPORTED: True,
+                mod.OPTION_ENERGY_HISTORY_PROGRESS: {"A": 0, "B": 0},
+                "max_history_retrieved": 1,
+            },
+        )
+        client = types.SimpleNamespace()
+        client.get_htr_samples = AsyncMock(
+            return_value=[{"t": 86_400, "counter": "1.0"}]
+        )
+        hass.data[const.DOMAIN][entry.entry_id] = {
+            "client": client,
+            "dev_id": "dev",
+            "htr_addrs": ["A", "B"],
+            "config_entry": entry,
+        }
+
+        fake_now = 2 * 86_400
+        monotonic_counter = itertools.count(start=1, step=2)
+        monkeypatch.setattr(
+            mod,
+            "time",
+            types.SimpleNamespace(
+                time=lambda: fake_now, monotonic=lambda: next(monotonic_counter)
+            ),
+        )
+
+        await mod._async_import_energy_history(hass, entry, ["A"], reset_progress=True)
+
+        client.get_htr_samples.assert_awaited_once_with("dev", "A", 86_400, 172_800)
+        add_stats.assert_awaited_once()
+        progress = entry.options[mod.OPTION_ENERGY_HISTORY_PROGRESS]
+        assert progress == {"A": 86_400, "B": 0}
+        assert entry.options[mod.OPTION_ENERGY_HISTORY_IMPORTED] is True
+
+    asyncio.run(_run())

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -235,8 +235,8 @@ def test_import_energy_history(monkeypatch: pytest.MonkeyPatch) -> None:
         update_meta.assert_called_once()
         import_stats.assert_called_once()
         args = import_stats.call_args[0]
-        stats_list = args[1]
-        assert all(s["statistic_id"] == "sensor.dev_A_energy" for s in stats_list)
+        assert args[1]["statistic_id"] == "sensor.dev_A_energy"
+        stats_list = args[2]
         assert [s["sum"] for s in stats_list] == [pytest.approx(0.001), pytest.approx(0.002)]
         assert entry.options[mod.OPTION_ENERGY_HISTORY_IMPORTED] is True
         assert entry.options[mod.OPTION_ENERGY_HISTORY_PROGRESS] == {"A": 172_800}


### PR DESCRIPTION
## Summary
- reverse hourly history queries to walk backward from today and track per-heater progress in config options
- add max_history_retrieved option and completion check to resume interrupted imports and avoid repeats
- reset completion flags on service invocation and test progress-aware import flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cff26066c8329a6e5e88198873111