### PR TITLE
Log heater settings fetch errors

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from aiohttp import ClientError
 from homeassistant.core import HomeAssistant
@@ -88,7 +88,10 @@ class TermoWebCoordinator(
                         js = await self.client.get_htr_settings(dev_id, addr)
                         if isinstance(js, dict):
                             settings_map[addr] = js
-                    except (ClientError, TermoWebRateLimitError, TermoWebAuthError):
+                    except (ClientError, TermoWebRateLimitError, TermoWebAuthError) as err:
+                        _LOGGER.debug(
+                            "Error fetching settings for heater %s: %s", addr, err, exc_info=err
+                        )
                         # keep previous settings on error
                         pass
                 self._rr_index[dev_id] = (start + count) % len(addrs)


### PR DESCRIPTION
## Summary
- debug log heater setting fetch errors without overwriting existing settings

## Testing
- `ruff check custom_components/termoweb/coordinator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3737f164832989a56c4b3d6f90f5