### PR TITLE
Add optional test dependencies and coverage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,18 @@ ha-termoweb/ha-termoweb
 ## Privacy & Security
 
 - Credentials stay in Home Assistant.  
-- Access tokens are **redacted** from logs.  
+- Access tokens are **redacted** from logs.
 - This project is **not affiliated** with S&P, ATC, Ecotermi/Linea Plus, EHC, or TermoWeb.
+
+---
+
+## Development
+
+Run tests with coverage:
+
+```bash
+uv run pytest --cov=custom_components/termoweb --cov-report=term-missing
+```
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,13 @@ dependencies = [
     "voluptuous>=0.13",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- add `test` optional-dependencies with pytest tooling
- document running tests with coverage via `uv`

## Testing
- `pytest`
- `uv run pytest --cov=custom_components/termoweb --cov-report=term-missing` *(fails: Could not fetch pytest-asyncio from PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_689e36e3563083298fdb065c8ec8a9fe