### PR TITLE
Remove unused import from climate component

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers import entity_platform
-from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
 from .const import DOMAIN, signal_ws_data


### PR DESCRIPTION
## Summary
- remove unused config_validation import

## Testing
- `ruff check custom_components/termoweb/climate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e371593908329802cfea4ce8f7b38