### PR TITLE
Handle TermoWeb client startup errors

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -12,14 +12,16 @@ from typing import Any, Dict, Iterable, List, Optional
 # async_import_statistics.  See _store_statistics for details.
 async_import_statistics = None  # type: ignore
 async_update_statistics_metadata = None  # type: ignore
+from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.loader import async_get_integration
 
-from .api import TermoWebClient
+from .api import TermoWebAuthError, TermoWebClient, TermoWebRateLimitError
 from .const import (
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
@@ -327,12 +329,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     version = integration.version or "unknown"
 
     client = TermoWebClient(session, username, password)
-    devices = await client.list_devices()
+    try:
+        devices = await client.list_devices()
+    except TermoWebAuthError as err:
+        _LOGGER.info("list_devices auth error: %s", err)
+        raise ConfigEntryAuthFailed from err
+    except (ClientError, TermoWebRateLimitError, asyncio.TimeoutError) as err:
+        _LOGGER.info("list_devices connection error: %s", err)
+        raise ConfigEntryNotReady from err
+
+    if not devices:
+        _LOGGER.info("list_devices returned no devices")
+        raise ConfigEntryNotReady
+
     dev = devices[0] if isinstance(devices, list) and devices else {}
     dev_id = str(
         dev.get("dev_id") or dev.get("id") or dev.get("serial_id") or ""
     ).strip()
-    nodes = await client.get_nodes(dev_id)
+    try:
+        nodes = await client.get_nodes(dev_id)
+    except TermoWebAuthError as err:
+        _LOGGER.info("get_nodes auth error: %s", err)
+        raise ConfigEntryAuthFailed from err
+    except (ClientError, TermoWebRateLimitError, asyncio.TimeoutError) as err:
+        _LOGGER.info("get_nodes connection error: %s", err)
+        raise ConfigEntryNotReady from err
     addrs: list[str] = []
     node_list = nodes.get("nodes") if isinstance(nodes, dict) else None
     if isinstance(node_list, list):

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -36,6 +36,17 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False)
     ha_const.EVENT_HOMEASSISTANT_STARTED = "homeassistant_started"
     sys.modules["homeassistant.const"] = ha_const
 
+    ha_exc = types.ModuleType("homeassistant.exceptions")
+    class ConfigEntryAuthFailed(Exception):
+        pass
+
+    class ConfigEntryNotReady(Exception):
+        pass
+
+    ha_exc.ConfigEntryAuthFailed = ConfigEntryAuthFailed
+    ha_exc.ConfigEntryNotReady = ConfigEntryNotReady
+    sys.modules["homeassistant.exceptions"] = ha_exc
+
     helpers = types.ModuleType("homeassistant.helpers")
     aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
     aiohttp_client.async_get_clientsession = lambda hass: None
@@ -129,6 +140,14 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False)
             return {"nodes": [{"type": "htr", "addr": "A"}]}
 
     api_stub.TermoWebClient = TermoWebClient
+    class TermoWebAuthError(Exception):  # pragma: no cover - placeholder
+        pass
+
+    class TermoWebRateLimitError(Exception):  # pragma: no cover - placeholder
+        pass
+
+    api_stub.TermoWebAuthError = TermoWebAuthError
+    api_stub.TermoWebRateLimitError = TermoWebRateLimitError
     sys.modules[f"{package}.api"] = api_stub
 
     coord_stub = types.ModuleType(f"{package}.coordinator")


### PR DESCRIPTION
## Summary
- Wrap list_devices and get_nodes with error handling
- Raise ConfigEntryAuthFailed or ConfigEntryNotReady based on failure cause
- Update tests for new Home Assistant exception stubs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e37343dd88329ab3cafd911608f3c