### PR TITLE
Remove unused timezone import

### DIFF
--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -5,11 +5,11 @@ import importlib.util
 import itertools
 import sys
 import types
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from datetime import datetime, timezone
 
 
 async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False):


### PR DESCRIPTION
## Summary
- remove unused timezone import from energy history test

## Testing
- `ruff check tests/test_import_energy_history.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3730ab98832991e3079378f64074