### PR TITLE
Move time import to top of energy coordinator test

### DIFF
--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import sys
+import time as _time
 import types
 from pathlib import Path
 from typing import Any, Dict
@@ -75,7 +76,6 @@ sys.modules["homeassistant.helpers.update_coordinator"] = uc
 # Stub API module
 package = "custom_components.termoweb"
 api_stub = types.ModuleType(f"{package}.api")
-import time as _time
 
 
 class TermoWebClient:  # pragma: no cover - placeholder


### PR DESCRIPTION
## Summary
- Move `import time as _time` to the top of `tests/test_energy_coordinator.py`

## Testing
- `ruff check tests/test_energy_coordinator.py`
- `ruff check --select E402 tests/test_energy_coordinator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e37288a7083298547375109a76355