### PR TITLE
refactor: remove unused typing List

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 import time
-from typing import Any, Dict, List, Optional
+from datetime import timedelta
+from typing import Any, Dict, Optional
 
 from aiohttp import ClientError
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Summary
- remove leftover List import from coordinator

## Testing
- `ruff check custom_components/termoweb/coordinator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e371952008329a8f64142093ecd70