### PR TITLE
Add debug logging for missing heater energy samples

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from aiohttp import ClientError
 from homeassistant.core import HomeAssistant
@@ -165,12 +165,20 @@ class TermoWebHeaterEnergyCoordinator(
                     samples = []
 
                 if not samples:
+                    _LOGGER.debug(
+                        "No energy samples for device %s heater %s", dev_id, addr
+                    )
                     continue
 
                 last = samples[-1]
                 counter = _as_float(last.get("counter"))
                 t = _as_float(last.get("t"))
                 if counter is None or t is None:
+                    _LOGGER.debug(
+                        "Latest sample missing 't' or 'counter' for device %s heater %s",
+                        dev_id,
+                        addr,
+                    )
                     continue
 
                 energy_map[addr] = counter


### PR DESCRIPTION
## Summary
- Add debug log when heater energy samples are missing or invalid
- Remove unused typing import

## Testing
- `ruff check custom_components/termoweb/coordinator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e373d13648329a2c089132a901430