### PR TITLE
Add shared float conversion helper

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -17,10 +17,10 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers import entity_platform
-from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
 from .const import DOMAIN, signal_ws_data
+from .util import float_or_none
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,17 +153,6 @@ class TermoWebHeater(CoordinatorEntity, ClimateEntity):
         settings = (htr.get("settings") or {}).get(self._addr)
         return settings if isinstance(settings, dict) else None
 
-    @staticmethod
-    def _f(v: Any) -> Optional[float]:
-        try:
-            if v is None:
-                return None
-            if isinstance(v, (int, float)):
-                return float(v)
-            s = str(v).strip()
-            return float(s) if s else None
-        except Exception:
-            return None
 
     def _units(self) -> str:
         s = self._settings() or {}
@@ -233,12 +222,12 @@ class TermoWebHeater(CoordinatorEntity, ClimateEntity):
     @property
     def current_temperature(self) -> Optional[float]:
         s = self._settings() or {}
-        return self._f(s.get("mtemp"))
+        return float_or_none(s.get("mtemp"))
 
     @property
     def target_temperature(self) -> Optional[float]:
         s = self._settings() or {}
-        return self._f(s.get("stemp"))
+        return float_or_none(s.get("stemp"))
 
     @property
     def min_temp(self) -> float:
@@ -276,7 +265,7 @@ class TermoWebHeater(CoordinatorEntity, ClimateEntity):
             ptemp = s.get("ptemp")
             try:
                 if isinstance(ptemp, (list, tuple)) and 0 <= slot < len(ptemp):
-                    attrs["program_setpoint"] = self._f(ptemp[slot])
+                    attrs["program_setpoint"] = float_or_none(ptemp[slot])
             except Exception:
                 pass
 

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_data
 from .coordinator import TermoWebHeaterEnergyCoordinator
+from .util import float_or_none
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,17 +131,6 @@ class TermoWebHeaterTemp(CoordinatorEntity, SensorEntity):
         settings = (htr.get("settings") or {}).get(self._addr)
         return settings if isinstance(settings, dict) else None
 
-    @staticmethod
-    def _f(val: Any) -> Optional[float]:
-        try:
-            if val is None:
-                return None
-            if isinstance(val, (int, float)):
-                return float(val)
-            s = str(val).strip()
-            return float(s) if s else None
-        except Exception:
-            return None
 
     @callback
     def _on_ws_data(self, payload: dict) -> None:
@@ -160,7 +150,7 @@ class TermoWebHeaterTemp(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> Optional[float]:
         s = self._settings() or {}
-        return self._f(s.get("mtemp"))
+        return float_or_none(s.get("mtemp"))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/termoweb/util.py
+++ b/custom_components/termoweb/util.py
@@ -1,0 +1,22 @@
+"""Utility helpers for TermoWeb integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def float_or_none(value: Any) -> float | None:
+    """Return value as ``float`` if possible, else ``None``.
+
+    Converts integers, floats, and numeric strings to ``float`` while safely
+    handling ``None`` and non-numeric inputs.
+    """
+    try:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        string_val = str(value).strip()
+        return float(string_val) if string_val else None
+    except Exception:
+        return None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from custom_components.termoweb.util import float_or_none
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, None),
+        ("abc", None),
+        ("123", 123.0),
+        (5, 5.0),
+        ("   ", None),
+    ],
+)
+def test_float_or_none(value, expected) -> None:
+    assert float_or_none(value) == expected


### PR DESCRIPTION
## Summary
- create shared `float_or_none` utility
- use shared helper in climate and sensor entities
- cover util with tests for `None` and non-numeric strings

## Testing
- `ruff check custom_components/termoweb/util.py custom_components/termoweb/climate.py custom_components/termoweb/sensor.py tests/test_util.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e3743a38083299994fd80ec7cac45