### PR TITLE
Add recorder after dependency to manifest

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "termoweb",
   "name": "TermoWeb",
+  "after_dependencies": ["recorder"],
   "codeowners": [
     "@ha-termoweb"
   ],
   "config_flow": true,
-  "after_dependencies": ["recorder"],
   "documentation": "https://github.com/ha-termoweb/ha-termoweb#readme",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",


### PR DESCRIPTION
## Summary
- specify recorder as an after dependency to satisfy hassfest

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a30aeb80788329ba439e60a1114fdc