### PR TITLE
Ensure float_or_none handles non-finite values

### DIFF
--- a/custom_components/termoweb/util.py
+++ b/custom_components/termoweb/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 
@@ -15,8 +16,12 @@ def float_or_none(value: Any) -> float | None:
         if value is None:
             return None
         if isinstance(value, (int, float)):
-            return float(value)
-        string_val = str(value).strip()
-        return float(string_val) if string_val else None
+            num = float(value)
+        else:
+            string_val = str(value).strip()
+            if not string_val:
+                return None
+            num = float(string_val)
+        return num if math.isfinite(num) else None
     except Exception:
         return None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,10 @@ from custom_components.termoweb.util import float_or_none
         ("123", 123.0),
         (5, 5.0),
         ("   ", None),
+        ("nan", None),
+        ("inf", None),
+        (float("nan"), None),
+        (float("inf"), None),
     ],
 )
 def test_float_or_none(value, expected) -> None:


### PR DESCRIPTION
## Summary
- Guard float_or_none against NaN and infinite numbers
- Test float_or_none for non-finite string and float inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31551add883298643cf57089502c3