### PR TITLE
Ensure unique heater address extraction

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -10,11 +10,12 @@ def extract_heater_addrs(nodes: dict[str, Any] | None) -> list[str]:
     `/mgr/nodes` endpoint and extracts the `addr` of all entries
     whose `type` is `htr` (case-insensitive).
     """
-    addrs: list[str] = []
+    addrs: dict[str, None] = {}
     if isinstance(nodes, dict):
         node_list = nodes.get("nodes")
         if isinstance(node_list, list):
             for n in node_list:
                 if isinstance(n, dict) and (n.get("type") or "").lower() == "htr":
-                    addrs.append(str(n.get("addr")))
-    return addrs
+                    addr = str(n.get("addr"))
+                    addrs.setdefault(addr)
+    return list(addrs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,10 +7,7 @@ from pathlib import Path
 
 
 UTILS_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "custom_components"
-    / "termoweb"
-    / "utils.py"
+    Path(__file__).resolve().parents[1] / "custom_components" / "termoweb" / "utils.py"
 )
 
 
@@ -43,3 +40,12 @@ def test_extract_heater_addrs() -> None:
     }
 
     assert extract(nodes) == ["A", "1"]
+
+
+def test_extract_heater_addrs_deduplicates() -> None:
+    utils = _load_utils()
+    extract = utils.extract_heater_addrs
+
+    nodes = {"nodes": [{"type": "htr", "addr": "A"}, {"type": "HTR", "addr": "A"}]}
+
+    assert extract(nodes) == ["A"]


### PR DESCRIPTION
## Summary
- ensure `extract_heater_addrs` only returns unique heater addresses
- add test covering duplicate heater entries

## Testing
- `ruff check custom_components/termoweb/utils.py tests/test_utils.py`
- `black custom_components/termoweb/utils.py tests/test_utils.py`
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a31556d1dc8329b67b1bc7d93eeb69