### PR TITLE
Add tests for non-finite float strings

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,11 +13,14 @@ from custom_components.termoweb.util import float_or_none
         ("123", 123.0),
         (5, 5.0),
         ("   ", None),
-        ("nan", None),
-        ("inf", None),
         (float("nan"), None),
         (float("inf"), None),
     ],
 )
 def test_float_or_none(value, expected) -> None:
     assert float_or_none(value) == expected
+
+
+@pytest.mark.parametrize("value", ["nan", "inf"])
+def test_float_or_none_non_finite_strings(value) -> None:
+    assert float_or_none(value) is None


### PR DESCRIPTION
## Summary
- test that `float_or_none` returns `None` for `'nan'` and `'inf'` string inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a31c63c2d8832991878ecfe42dff82