### PR TITLE
Propagate websocket closure errors

### DIFF
--- a/custom_components/termoweb/ws_client_legacy.py
+++ b/custom_components/termoweb/ws_client_legacy.py
@@ -309,12 +309,18 @@ class TermoWebWSLegacyClient:
 
         while True:
             msg = await ws.receive()
-            if msg.type == aiohttp.WSMsgType.CLOSED:
-                raise RuntimeError("ws closed")
-            if msg.type == aiohttp.WSMsgType.CLOSE:
-                raise RuntimeError("ws closing")
+            if msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSE):
+                exc = ws.exception()
+                if exc is not None:
+                    raise exc
+                raise RuntimeError(
+                    f"websocket closed: code={ws.close_code} reason={msg.extra}"
+                )
             if msg.type == aiohttp.WSMsgType.ERROR:
-                raise RuntimeError("ws error")
+                exc = ws.exception()
+                if exc is not None:
+                    raise exc
+                raise RuntimeError("websocket error")
             if msg.type not in (aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY):
                 continue
 

--- a/tests/test_ws_client_legacy.py
+++ b/tests/test_ws_client_legacy.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+WS_CLIENT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "termoweb"
+    / "ws_client_legacy.py"
+)
+
+
+def _load_ws_client():
+    package = "custom_components.termoweb"
+    sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+    termoweb_pkg = types.ModuleType(package)
+    termoweb_pkg.__path__ = [str(WS_CLIENT_PATH.parent)]
+    sys.modules[package] = termoweb_pkg
+
+    ha = types.ModuleType("homeassistant")
+    ha_core = types.ModuleType("homeassistant.core")
+    ha_core.HomeAssistant = object  # type: ignore[attr-defined]
+    ha_helpers = types.ModuleType("homeassistant.helpers")
+    ha_dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
+
+    def _send(*args, **kwargs):
+        return None
+
+    ha_dispatcher.async_dispatcher_send = _send
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.core"] = ha_core
+    sys.modules["homeassistant.helpers"] = ha_helpers
+    sys.modules["homeassistant.helpers.dispatcher"] = ha_dispatcher
+
+    aiohttp_stub = types.ModuleType("aiohttp")
+    class WSMsgType:
+        TEXT = 1
+        BINARY = 2
+        CLOSED = 3
+        CLOSE = 4
+        ERROR = 5
+
+    aiohttp_stub.WSMsgType = WSMsgType
+    aiohttp_stub.ClientSession = object  # pragma: no cover - placeholder
+    aiohttp_stub.ClientTimeout = object  # pragma: no cover - placeholder
+    aiohttp_stub.WSCloseCode = types.SimpleNamespace(GOING_AWAY=1001)
+    sys.modules["aiohttp"] = aiohttp_stub
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package}.ws_client_legacy", WS_CLIENT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[f"{package}.ws_client_legacy"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_read_loop_bubbles_exception_on_close():
+    async def _run() -> None:
+        module = _load_ws_client()
+        Client = module.TermoWebWSLegacyClient
+        hass = types.SimpleNamespace(loop=asyncio.get_event_loop())
+        api = types.SimpleNamespace(_session=None)
+        coordinator = types.SimpleNamespace()
+        client = Client(hass, entry_id="e", dev_id="d", api_client=api, coordinator=coordinator)
+
+        aiohttp = sys.modules["aiohttp"]
+
+        class DummyWS:
+            def __init__(self):
+                self.close_code = 1006
+
+            async def receive(self):
+                return types.SimpleNamespace(type=aiohttp.WSMsgType.CLOSED, data=None, extra="bye")
+
+            def exception(self):
+                return RuntimeError("boom")
+
+        client._ws = DummyWS()
+        with pytest.raises(RuntimeError, match="boom"):
+            await client._read_loop()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Surface underlying websocket errors instead of suppressing them
- Update regression test to verify exceptions are bubbled up

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c6eaefd48329bb507ad414a3c9f3