### PR TITLE
Refactor TermoWeb climate modes

### DIFF
--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -118,8 +118,9 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False)
             return
 
     class HVACMode:  # pragma: no cover - minimal stub
-        HEAT = "heat"
+        MANUAL = "manual"
         OFF = "off"
+        AUTO = "auto"
 
     class HVACAction:  # pragma: no cover - minimal stub
         HEATING = "heating"

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -118,7 +118,7 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False)
             return
 
     class HVACMode:  # pragma: no cover - minimal stub
-        MANUAL = "manual"
+        HEAT = "heat"
         OFF = "off"
         AUTO = "auto"
 


### PR DESCRIPTION
## Summary
- drop preset mode support and expose off/manual/auto HVAC modes
- post off/auto/manual settings and map backend mode to HA HVAC modes
- show calendar-clock icon for AUTO and adjust test stubs
- replace "manual" string with `HVACMode.MANUAL` constant for consistency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5bc5e77988329ac586ec29d5f9cd3