### PR TITLE
Translate heat hvac mode to manual for API

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -316,7 +316,10 @@ class TermoWebClient:
 
         # Mode
         if mode is not None:
-            payload["mode"] = mode
+            mode_str = str(mode).lower()
+            if mode_str == "heat":
+                mode_str = "manual"
+            payload["mode"] = mode_str
 
         # Manual setpoint – format as string with one decimal
         if stemp is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -211,3 +211,28 @@ def test_request_retries_on_401() -> None:
         assert second_headers["Authorization"] == "Bearer new"
 
     asyncio.run(_run())
+
+
+def test_set_htr_settings_translates_heat(monkeypatch) -> None:
+    async def _run() -> None:
+        session = MagicMock()
+        client = TermoWebClient(session, "user", "pass")
+
+        async def fake_headers() -> dict[str, str]:
+            return {}
+
+        monkeypatch.setattr(client, "_authed_headers", fake_headers)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_request(method: str, path: str, **kwargs) -> Any:
+            captured["json"] = kwargs.get("json")
+            return {}
+
+        monkeypatch.setattr(client, "_request", fake_request)
+
+        await client.set_htr_settings("dev", 1, mode="heat", stemp=21.0)
+
+        assert captured["json"]["mode"] == "manual"
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- translate HA "heat" HVAC mode to TermoWeb API "manual"
- test API client converts "heat" to "manual"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5cd12105c832986648da9f8068cd8