### PR TITLE
Expose heaters as individual devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ For someone who runs Home Assistant and already uses the **TermoWeb** mobile app
 
 These product lines are documented to work with the **TermoWeb** portal/app:
 
-- **S&P — Soler & Palau**: “**Termoweb**” kits and **EMI-TECH Termoweb** radiators.  
-- **Ecotermi / Linea Plus**: **Serie Termoweb** radiators.  
+- **S&P — Soler & Palau**: “**TermoWeb**” kits and **EMI-TECH TermoWeb** radiators.
+- **Ecotermi / Linea Plus**: **Serie TermoWeb** radiators.
 - **EHC — Electric Heating Company**: **eco SAVE** Smart Gateway kits that register on the TermoWeb portal.
 - **ATC (UK/Ireland)**: **Sun Ray Wifi** radiators with Wifi gateway.
 
 
 > If a brand isn’t listed but the user signs in at **control.termoweb.net** (or **control2.termoweb.net**) with an app called **TermoWeb**, this integration should work.
 
-_Not supported:_ brands using different apps/backends (for example “Ducaheat/Ducasa”’s own “Termoweb” app, which is a separate system).
+_Not supported:_ brands using different apps/backends (for example “Ducaheat/Ducasa”’s own “TermoWeb” app, which is a separate system).
 
 ---
 
@@ -129,5 +129,5 @@ uv run pytest --cov=custom_components/termoweb --cov-report=term-missing
 
 ## Search keywords
 
-*Home Assistant TermoWeb, TermoWeb heaters Home Assistant, ATC radiators, S&P TermoWeb Home Assistant, Soler & Palau Termoweb, Ecotermi Termoweb, Linea Plus Termoweb, Electric Heating Company eco SAVE Home Assistant, eco SAVE Smart Gateway Home Assistant*
+*Home Assistant TermoWeb, TermoWeb heaters Home Assistant, ATC radiators, S&P TermoWeb Home Assistant, Soler & Palau TermoWeb, Ecotermi TermoWeb, Linea Plus TermoWeb, Electric Heating Company eco SAVE Home Assistant, eco SAVE Smart Gateway Home Assistant*
 

--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -41,13 +41,7 @@ class TermoWebDeviceOnlineBinarySensor(
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._dev_id = str(dev_id)
-        data = coordinator.data.get(self._dev_id, {}) or {}
-        base_name = data.get("name") or self._dev_id
-        try:
-            base_name = str(base_name).strip()
-        except Exception:
-            base_name = str(self._dev_id)
-        self._attr_name = f"{base_name} Online"
+        self._attr_name = "TermoWeb Gateway Online"
         self._attr_unique_id = f"{self._dev_id}_online"
         self._unsub_ws = None
 
@@ -74,15 +68,10 @@ class TermoWebDeviceOnlineBinarySensor(
             "version"
         )
         model = (data.get("raw") or {}).get("model") or "Gateway/Controller"
-        name = data.get("name") or self._dev_id
-        try:
-            name = str(name).strip()
-        except Exception:
-            name = str(self._dev_id)
         return DeviceInfo(
             identifiers={(DOMAIN, self._dev_id)},
-            name=name,
-            manufacturer="ATC / Termoweb",
+            name="TermoWeb Gateway",
+            manufacturer="TermoWeb",
             model=str(model),
             sw_version=str(version) if version is not None else None,
             configuration_url="https://control.termoweb.net",

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -32,7 +32,13 @@ class TermoWebRefreshButton(CoordinatorEntity, ButtonEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._dev_id)},
+            name="TermoWeb Gateway",
+            manufacturer="TermoWeb",
+            model="Gateway/Controller",
+            configuration_url="https://control.termoweb.net",
+        )
 
     async def async_press(self) -> None:
         await self.coordinator.async_request_refresh()

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -147,7 +147,13 @@ class TermoWebHeater(CoordinatorEntity, ClimateEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._dev_id, self._addr)},
+            name=self._attr_name,
+            manufacturer="TermoWeb",
+            model="Heater",
+            via_device=(DOMAIN, self._dev_id),
+        )
 
     # -------------------- Helpers --------------------
     def _client(self):

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -92,7 +92,7 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         data = {"username": username, "password": password, "poll_interval": poll_interval}
-        title = f"Termoweb ({username})"
+        title = f"TermoWeb ({username})"
         return self.async_create_entry(title=title, data=data)
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -54,7 +54,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
         uid_temp = f"{DOMAIN}:{dev_id}:htr:{addr}:temp"
         new_entities.append(
             TermoWebHeaterTemp(
-                coordinator, entry.entry_id, dev_id, addr, f"{base_name} Temperature", uid_temp
+                coordinator,
+                entry.entry_id,
+                dev_id,
+                addr,
+                f"{base_name} Temperature",
+                uid_temp,
+                base_name,
             )
         )
         uid_energy = f"{DOMAIN}:{dev_id}:htr:{addr}:energy"
@@ -66,6 +72,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 addr,
                 f"{base_name} Energy",
                 uid_energy,
+                base_name,
             )
         )
         uid_power = f"{DOMAIN}:{dev_id}:htr:{addr}:power"
@@ -77,6 +84,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 addr,
                 f"{base_name} Power",
                 uid_power,
+                base_name,
             )
         )
 
@@ -104,13 +112,23 @@ class TermoWebHeaterTemp(CoordinatorEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    def __init__(self, coordinator, entry_id: str, dev_id: str, addr: str, name: str, unique_id: str) -> None:
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        name: str,
+        unique_id: str,
+        device_name: str,
+    ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._dev_id = dev_id
         self._addr = addr
         self._attr_name = name
         self._attr_unique_id = unique_id
+        self._device_name = device_name
         self._unsub_ws = None
 
     async def async_added_to_hass(self) -> None:
@@ -122,8 +140,13 @@ class TermoWebHeaterTemp(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        # Attach to the existing hub device (like climate + button)
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._dev_id, self._addr)},
+            name=self._device_name,
+            manufacturer="TermoWeb",
+            model="Heater",
+            via_device=(DOMAIN, self._dev_id),
+        )
 
     def _settings(self) -> dict[str, Any] | None:
         d = (self.coordinator.data or {}).get(self._dev_id, {})
@@ -177,6 +200,7 @@ class TermoWebHeaterEnergyTotal(CoordinatorEntity, SensorEntity):
         addr: str,
         name: str,
         unique_id: str,
+        device_name: str,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
@@ -184,6 +208,7 @@ class TermoWebHeaterEnergyTotal(CoordinatorEntity, SensorEntity):
         self._addr = addr
         self._attr_name = name
         self._attr_unique_id = unique_id
+        self._device_name = device_name
         self._unsub_ws = None
 
     async def async_added_to_hass(self) -> None:
@@ -195,7 +220,13 @@ class TermoWebHeaterEnergyTotal(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._dev_id, self._addr)},
+            name=self._device_name,
+            manufacturer="TermoWeb",
+            model="Heater",
+            via_device=(DOMAIN, self._dev_id),
+        )
 
     @callback
     def _on_ws_data(self, payload: dict) -> None:
@@ -243,6 +274,7 @@ class TermoWebHeaterPower(CoordinatorEntity, SensorEntity):
         addr: str,
         name: str,
         unique_id: str,
+        device_name: str,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry_id
@@ -250,6 +282,7 @@ class TermoWebHeaterPower(CoordinatorEntity, SensorEntity):
         self._addr = addr
         self._attr_name = name
         self._attr_unique_id = unique_id
+        self._device_name = device_name
         self._unsub_ws = None
 
     async def async_added_to_hass(self) -> None:
@@ -261,7 +294,13 @@ class TermoWebHeaterPower(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._dev_id)})
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._dev_id, self._addr)},
+            name=self._device_name,
+            manufacturer="TermoWeb",
+            model="Heater",
+            via_device=(DOMAIN, self._dev_id),
+        )
 
     @callback
     def _on_ws_data(self, payload: dict) -> None:

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -227,8 +227,12 @@ def test_coordinator_and_sensors() -> None:
         power = coord.data["1"]["htr"]["power"]["A"]
         assert power == pytest.approx(2000.0, rel=1e-3)
 
-        energy_sensor = TermoWebHeaterEnergyTotal(coord, "entry", "1", "A", "Energy", "e1")
-        power_sensor = TermoWebHeaterPower(coord, "entry", "1", "A", "Power", "p1")
+        energy_sensor = TermoWebHeaterEnergyTotal(
+            coord, "entry", "1", "A", "Energy", "e1", "Heater"
+        )
+        power_sensor = TermoWebHeaterPower(
+            coord, "entry", "1", "A", "Power", "p1", "Heater"
+        )
         energy_sensor.hass = power_sensor.hass = hass
         await energy_sensor.async_added_to_hass()
         await power_sensor.async_added_to_hass()


### PR DESCRIPTION
## Summary
- Rename gateway device to **TermoWeb Gateway** and expose consistent metadata
- Register each heater as its own device with climate, temperature, energy and power entities
- Update tests for new device layout
- Set manufacturer to **TermoWeb** and standardize capitalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc2cb1dc832999195e9536527374