### PR TITLE
Handle CancelledError in request flow

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -158,6 +158,8 @@ class TermoWebClient:
                         _redact_bearer(str(e)),
                     )
                 raise
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 _LOGGER.error(
                     "Request %s %s failed (sanitized): %s",


### PR DESCRIPTION
## Summary
- Re-raise `asyncio.CancelledError` in `TermoWebClient._request` to avoid logging task cancellations as generic errors.

## Testing
- `ruff check custom_components/termoweb/api.py --fix` *(fails: Missing docstring in public module, etc.)*
- `ruff format custom_components/termoweb/api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5da0e05648329b3659a1cdb6b4084