### PR TITLE
Handle ignored HTTP statuses

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -66,9 +66,12 @@ class TermoWebClient:
         *,
         ignore_statuses: Iterable[int] = (),
         **kwargs,
-    ) -> Any:
-        """Perform an HTTP request; return JSON when possible, else text.
-        Errors are logged WITHOUT secrets; callers receive raised exceptions.
+    ) -> Any | None:
+        """Perform an HTTP request.
+
+        Return JSON when possible, otherwise text. HTTP statuses listed in
+        ``ignore_statuses`` are logged and yield ``None`` instead of raising an
+        exception. Errors are logged WITHOUT secrets.
         """
         headers = kwargs.pop("headers", {})
         ignore_statuses = set(ignore_statuses)
@@ -128,6 +131,8 @@ class TermoWebClient:
                         raise TermoWebAuthError("Unauthorized")
                     if resp.status == 429:
                         raise TermoWebRateLimitError("Rate limited")
+                    if resp.status in ignore_statuses:
+                        return None
                     if resp.status >= 400:
                         raise aiohttp.ClientResponseError(
                             resp.request_info,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,6 +177,29 @@ def test_get_htr_samples_404() -> None:
 
     asyncio.run(_run())
 
+
+def test_request_ignore_status_returns_none() -> None:
+    async def _run() -> None:
+        session = MagicMock()
+        session.post.return_value = MockResponse(
+            200,
+            {"access_token": "tok", "expires_in": 3600},
+            headers={"Content-Type": "application/json"},
+        )
+        session.request.return_value = MockResponse(
+            404,
+            {},
+            headers={"Content-Type": "application/json"},
+        )
+
+        client = TermoWebClient(session, "user", "pass")
+        result = await client._request(
+            "GET", "/missing", headers={}, ignore_statuses=(404,)
+        )
+        assert result is None
+
+    asyncio.run(_run())
+
 def test_request_retries_on_401() -> None:
     async def _run() -> None:
         session = MagicMock()


### PR DESCRIPTION
## Summary
- avoid raising for statuses declared in `ignore_statuses` and return `None`
- clarify request helper docstring
- test ignoring a 404 status

## Testing
- `ruff check custom_components/termoweb/api.py tests/test_api.py` *(fails: Missing docstring in public module, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5da486ff083298b8ac8b0288c7f3e