### PR TITLE
Validate units before heater settings payload

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -311,8 +311,13 @@ class TermoWebClient:
         overwriting unrelated settings on the device.
         """
 
+        # Validate units
+        unit_str: str = units.upper()
+        if unit_str not in {"C", "F"}:
+            raise ValueError(f"Invalid units: {units}")
+
         # Always include units
-        payload: dict[str, Any] = {"units": units}
+        payload: dict[str, Any] = {"units": unit_str}
 
         # Mode
         if mode is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,6 +177,7 @@ def test_get_htr_samples_404() -> None:
 
     asyncio.run(_run())
 
+
 def test_request_retries_on_401() -> None:
     async def _run() -> None:
         session = MagicMock()
@@ -234,5 +235,21 @@ def test_set_htr_settings_translates_heat(monkeypatch) -> None:
         await client.set_htr_settings("dev", 1, mode="heat", stemp=21.0)
 
         assert captured["json"]["mode"] == "manual"
+
+    asyncio.run(_run())
+
+
+def test_set_htr_settings_invalid_units(monkeypatch) -> None:
+    async def _run() -> None:
+        session = MagicMock()
+        client = TermoWebClient(session, "user", "pass")
+
+        async def fake_headers() -> dict[str, str]:
+            raise AssertionError("_authed_headers should not be called")
+
+        monkeypatch.setattr(client, "_authed_headers", fake_headers)
+
+        with pytest.raises(ValueError):
+            await client.set_htr_settings("dev", 1, units="K")
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- ensure set_htr_settings only accepts 'C' or 'F'
- test ValueError raised on invalid units

## Testing
- `ruff format custom_components/termoweb/api.py tests/test_api.py`
- `ruff check custom_components/termoweb/api.py tests/test_api.py --fix` *(fails: existing style issues)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5da4a4cb08329a91011e5843e1994