### PR TITLE
Fix energy sensor naming

### DIFF
--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -70,7 +70,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 entry.entry_id,
                 dev_id,
                 addr,
-                f"{base_name} Energy",
+                "Energy",
                 uid_energy,
                 base_name,
             )
@@ -82,7 +82,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 entry.entry_id,
                 dev_id,
                 addr,
-                f"{base_name} Power",
+                "Power",
                 uid_power,
                 base_name,
             )
@@ -191,6 +191,7 @@ class TermoWebHeaterEnergyTotal(CoordinatorEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_native_unit_of_measurement = "kWh"
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -265,6 +266,7 @@ class TermoWebHeaterPower(CoordinatorEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.POWER
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "W"
+    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -141,6 +141,14 @@ class SensorEntity:  # pragma: no cover - minimal entity
     def native_unit_of_measurement(self) -> str | None:
         return getattr(self, "_attr_native_unit_of_measurement", None)
 
+    @property
+    def name(self) -> str | None:
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def has_entity_name(self) -> bool:
+        return getattr(self, "_attr_has_entity_name", False)
+
 
 class SensorDeviceClass:  # pragma: no cover - simple container
     ENERGY = "energy"
@@ -240,9 +248,13 @@ def test_coordinator_and_sensors() -> None:
         assert energy_sensor.device_class == SensorDeviceClass.ENERGY
         assert energy_sensor.state_class == SensorStateClass.TOTAL_INCREASING
         assert energy_sensor.native_unit_of_measurement == "kWh"
+        assert energy_sensor.name == "Energy"
+        assert energy_sensor.has_entity_name is True
 
         assert energy_sensor.native_value == pytest.approx(0.0015)
         assert power_sensor.native_value == pytest.approx(2000.0, rel=1e-3)
+        assert power_sensor.name == "Power"
+        assert power_sensor.has_entity_name is True
 
         first_value: float = energy_sensor.native_value  # type: ignore[assignment]
 


### PR DESCRIPTION
## Summary
- Ensure heater energy and power sensors use device-friendly names
- Test energy sensors expose entity-aware names

## Testing
- `ruff check custom_components/termoweb/sensor.py tests/test_heater_energy_sensor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d8ee48a08329b922cc40071bf489