### PR TITLE
Remove unused imports from TermoWeb init

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 # Import of recorder statistics helpers is deferred until runtime in
 # _store_statistics to avoid ImportError on Home Assistant versions


### PR DESCRIPTION
## Summary
- remove unused timezone and typing imports from the TermoWeb integration entry point

## Testing
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68d13800becc8329891d4d26232ba11d