### PR TITLE
Add TermoWeb setup failure tests with stub isolation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,289 @@
+# ruff: noqa: D100,D101,D102,D103,D104,D105,D106,D107,INP001,E402
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from typing import Any, Callable
+
+
+ConfigEntryAuthFailedStub = type(
+    "ConfigEntryAuthFailed",
+    (Exception,),
+    {"__module__": "homeassistant.exceptions"},
+)
+ConfigEntryNotReadyStub = type(
+    "ConfigEntryNotReady",
+    (Exception,),
+    {"__module__": "homeassistant.exceptions"},
+)
+
+
+def _install_stubs() -> None:
+    # --- aiohttp ---------------------------------------------------------------
+    aiohttp_stub = types.ModuleType("aiohttp")
+
+    class ClientSession:  # pragma: no cover - placeholder
+        pass
+
+    class ClientTimeout:  # pragma: no cover - placeholder
+        def __init__(self, total: int | None = None) -> None:
+            self.total = total
+
+    class ClientResponseError(Exception):  # pragma: no cover - placeholder
+        def __init__(
+            self,
+            request_info: Any,
+            history: Any,
+            *,
+            status: int | None = None,
+            message: str | None = None,
+            headers: Any | None = None,
+        ) -> None:
+            super().__init__(message)
+            self.request_info = request_info
+            self.history = history
+            self.status = status
+            self.headers = headers
+
+    class ClientError(Exception):  # pragma: no cover - placeholder
+        pass
+
+    aiohttp_stub.ClientSession = ClientSession
+    aiohttp_stub.ClientTimeout = ClientTimeout
+    aiohttp_stub.ClientResponseError = ClientResponseError
+    aiohttp_stub.ClientError = ClientError
+    sys.modules["aiohttp"] = aiohttp_stub
+
+    # --- voluptuous ------------------------------------------------------------
+    vol = types.ModuleType("voluptuous")
+
+    class Required:  # pragma: no cover - minimal stub
+        def __init__(self, schema: Any, *, default: Any | None = None) -> None:
+            self.schema = schema
+            self.default = default
+
+    class All:  # pragma: no cover - minimal stub
+        def __init__(self, *validators: Any) -> None:
+            self.validators = validators
+
+    class Range:  # pragma: no cover - minimal stub
+        def __init__(self, *, min: int | None = None, max: int | None = None) -> None:
+            self.min = min
+            self.max = max
+
+    class Schema:  # pragma: no cover - minimal stub
+        def __init__(self, schema: dict[Any, Any]) -> None:
+            self.schema = schema
+
+        def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, validator in self.schema.items():
+                if isinstance(key, Required):
+                    name = key.schema
+                    if name in data:
+                        value = data[name]
+                    elif key.default is not None:
+                        value = key.default
+                    else:
+                        raise KeyError(name)
+                else:
+                    name = key
+                    value = data[name]
+                result[name] = _apply_validator(value, validator)
+            return result
+
+    def _apply_validator(value: Any, validator: Any) -> Any:
+        if isinstance(validator, All):
+            for item in validator.validators:
+                value = _apply_validator(value, item)
+            return value
+        if isinstance(validator, Range):
+            if validator.min is not None and value < validator.min:
+                raise ValueError(f"{value} < {validator.min}")
+            if validator.max is not None and value > validator.max:
+                raise ValueError(f"{value} > {validator.max}")
+            return value
+        if validator is int:
+            return int(value)
+        if validator is str:
+            return str(value)
+        if callable(validator):
+            return validator(value)
+        return value
+
+    vol.Required = Required
+    vol.All = All
+    vol.Range = Range
+    vol.Schema = Schema
+    sys.modules["voluptuous"] = vol
+
+    # --- custom_components -----------------------------------------------------
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [
+        str(Path(__file__).resolve().parents[1] / "custom_components")
+    ]
+    sys.modules["custom_components"] = custom_components_pkg
+
+    # --- homeassistant ---------------------------------------------------------
+    homeassistant_pkg = types.ModuleType("homeassistant")
+    config_entries_mod = types.ModuleType("homeassistant.config_entries")
+    const_mod = types.ModuleType("homeassistant.const")
+    core_mod = types.ModuleType("homeassistant.core")
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
+    helpers_mod = types.ModuleType("homeassistant.helpers")
+    aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    entity_registry_mod = types.ModuleType("homeassistant.helpers.entity_registry")
+    dispatcher_mod = types.ModuleType("homeassistant.helpers.dispatcher")
+    loader_mod = types.ModuleType("homeassistant.loader")
+    update_coordinator_mod = types.ModuleType(
+        "homeassistant.helpers.update_coordinator"
+    )
+
+    sys.modules["homeassistant"] = homeassistant_pkg
+    sys.modules["homeassistant.config_entries"] = config_entries_mod
+    sys.modules["homeassistant.const"] = const_mod
+    sys.modules["homeassistant.core"] = core_mod
+    sys.modules["homeassistant.exceptions"] = exceptions_mod
+    sys.modules["homeassistant.helpers"] = helpers_mod
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_mod
+    sys.modules["homeassistant.helpers.entity_registry"] = entity_registry_mod
+    sys.modules["homeassistant.helpers.dispatcher"] = dispatcher_mod
+    sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator_mod
+    sys.modules["homeassistant.loader"] = loader_mod
+
+    homeassistant_pkg.config_entries = config_entries_mod
+    homeassistant_pkg.const = const_mod
+    homeassistant_pkg.core = core_mod
+    homeassistant_pkg.exceptions = exceptions_mod
+    homeassistant_pkg.helpers = helpers_mod
+    homeassistant_pkg.loader = loader_mod
+    def async_get_clientsession(hass: Any) -> ClientSession:
+        if hasattr(hass, "client_session_calls"):
+            hass.client_session_calls += 1
+        return ClientSession()
+
+    aiohttp_client_mod.async_get_clientsession = async_get_clientsession
+
+    helpers_mod.aiohttp_client = aiohttp_client_mod
+    helpers_mod.entity_registry = entity_registry_mod
+    helpers_mod.dispatcher = dispatcher_mod
+    helpers_mod.update_coordinator = update_coordinator_mod
+
+    const_mod.EVENT_HOMEASSISTANT_STARTED = "homeassistant_started"
+
+    class ConfigEntry:
+        def __init__(
+            self,
+            entry_id: str,
+            data: dict[str, Any] | None = None,
+            options: dict[str, Any] | None = None,
+        ) -> None:
+            self.entry_id = entry_id
+            self.data = dict(data or {})
+            self.options = dict(options or {})
+            self.unique_id: str | None = None
+            self.title: str = ""
+
+    class _SimpleConfigEntries:
+        def __init__(self) -> None:
+            self._entries: dict[str, ConfigEntry] = {}
+            self.updated_entries: list[
+                tuple[ConfigEntry, dict[str, Any] | None, dict[str, Any] | None]
+            ] = []
+
+        def add_entry(self, entry: ConfigEntry) -> None:
+            self._entries[entry.entry_id] = entry
+
+        def async_get_entry(self, entry_id: str) -> ConfigEntry | None:
+            return self._entries.get(entry_id)
+
+        def async_update_entry(
+            self,
+            entry: ConfigEntry,
+            *,
+            data: dict[str, Any] | None = None,
+            options: dict[str, Any] | None = None,
+        ) -> None:
+            if data is not None:
+                entry.data = data
+            if options is not None:
+                entry.options = options
+            self.updated_entries.append((entry, data, options))
+
+    class HomeAssistant:
+        def __init__(self) -> None:
+            self.config_entries = _SimpleConfigEntries()
+            self.dispatcher_connections: list[
+                tuple[str, Callable[[Any], None]]
+            ] = []
+
+    config_entries_mod.ConfigEntry = ConfigEntry
+    core_mod.HomeAssistant = HomeAssistant
+    exceptions_mod.ConfigEntryAuthFailed = ConfigEntryAuthFailedStub
+    exceptions_mod.ConfigEntryNotReady = ConfigEntryNotReadyStub
+
+    class DataUpdateCoordinator:
+        def __class_getitem__(cls, _item: Any) -> type:
+            return cls
+
+        def __init__(
+            self,
+            hass: Any,
+            *,
+            logger: Any | None = None,
+            name: str | None = None,
+            update_interval: Any | None = None,
+        ) -> None:
+            self.hass = hass
+            self.logger = logger
+            self.name = name
+            self.update_interval = update_interval
+            self.data: Any = None
+
+        async def async_config_entry_first_refresh(self) -> None:
+            return None
+
+        def async_add_listener(self, _listener: Any) -> None:
+            return None
+
+    class UpdateFailed(Exception):
+        pass
+
+    update_coordinator_mod.DataUpdateCoordinator = DataUpdateCoordinator
+    update_coordinator_mod.UpdateFailed = UpdateFailed
+
+    def async_dispatcher_connect(
+        hass: Any, signal: str, callback: Callable[[Any], None]
+    ) -> Callable[[], None]:
+        if hasattr(hass, "dispatcher_connections"):
+            hass.dispatcher_connections.append((signal, callback))
+        return lambda: None
+
+    def async_dispatcher_send(hass: Any, signal: str, *args: Any) -> None:
+        if hasattr(hass, "dispatcher_connections"):
+            for sig, callback in hass.dispatcher_connections:
+                if sig == signal:
+                    callback(*args if args else {})
+
+    dispatcher_mod.async_dispatcher_connect = async_dispatcher_connect
+    dispatcher_mod.async_dispatcher_send = async_dispatcher_send
+
+    class _StubIntegration:
+        def __init__(self, domain: str) -> None:
+            self.domain = domain
+            self.version = "test-version"
+
+    async def async_get_integration(hass: Any, domain: str) -> _StubIntegration:
+        if hasattr(hass, "integration_requests"):
+            hass.integration_requests.append(domain)
+        return _StubIntegration(domain)
+
+    loader_mod.async_get_integration = async_get_integration
+
+
+_install_stubs()
+
+
+def pytest_runtest_setup(item: Any) -> None:  # pragma: no cover - ensure isolation
+    _install_stubs()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 # Provide a minimal aiohttp stub for the module import
-aiohttp_stub = types.ModuleType("aiohttp")
+aiohttp_module = sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
 
 
 class ClientSession:  # pragma: no cover - simple placeholder
@@ -34,13 +34,12 @@ class ClientResponseError(Exception):  # pragma: no cover - simple placeholder
         self.history = history
 
 
-aiohttp_stub.ClientSession = ClientSession
-aiohttp_stub.ClientTimeout = ClientTimeout
-aiohttp_stub.ClientResponseError = ClientResponseError
-aiohttp_stub.ClientError = Exception
+aiohttp_module.ClientSession = ClientSession
+aiohttp_module.ClientTimeout = ClientTimeout
+aiohttp_module.ClientResponseError = ClientResponseError
+aiohttp_module.ClientError = Exception
 
-sys.modules.setdefault("aiohttp", aiohttp_stub)
-aiohttp = aiohttp_stub
+aiohttp = aiohttp_module
 
 API_PATH = (
     Path(__file__).resolve().parents[1] / "custom_components" / "termoweb" / "api.py"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -106,10 +106,10 @@ def _apply_validator(value: Any, validator: Any) -> Any:
     return value
 
 
-vol.Required = getattr(vol, "Required", Required)
-vol.All = getattr(vol, "All", All)
-vol.Range = getattr(vol, "Range", Range)
-vol.Schema = getattr(vol, "Schema", Schema)
+vol.Required = Required
+vol.All = All
+vol.Range = Range
+vol.Schema = Schema
 
 # --- Minimal Home Assistant stubs ----------------------------------------------
 
@@ -148,7 +148,7 @@ class FlowResult(dict):  # pragma: no cover - placeholder type alias
     pass
 
 
-data_entry_flow_mod.FlowResult = getattr(data_entry_flow_mod, "FlowResult", FlowResult)
+data_entry_flow_mod.FlowResult = FlowResult
 
 
 class ConfigEntry:  # pragma: no cover - simplified stand-in
@@ -259,22 +259,18 @@ class OptionsFlow:  # pragma: no cover - simplified OptionsFlow base
         return FlowResult({"type": "create_entry", "title": title, "data": data})
 
 
-config_entries_mod.ConfigEntry = getattr(config_entries_mod, "ConfigEntry", ConfigEntry)
-config_entries_mod.ConfigEntriesManager = getattr(
-    config_entries_mod, "ConfigEntriesManager", ConfigEntriesManager
-)
-config_entries_mod.ConfigFlow = getattr(config_entries_mod, "ConfigFlow", ConfigFlow)
-config_entries_mod.OptionsFlow = getattr(config_entries_mod, "OptionsFlow", OptionsFlow)
-core_mod.HomeAssistant = getattr(core_mod, "HomeAssistant", HomeAssistant)
+config_entries_mod.ConfigEntry = ConfigEntry
+config_entries_mod.ConfigEntriesManager = ConfigEntriesManager
+config_entries_mod.ConfigFlow = ConfigFlow
+config_entries_mod.OptionsFlow = OptionsFlow
+core_mod.HomeAssistant = HomeAssistant
 
 
 def async_get_clientsession(_hass: HomeAssistant) -> object:  # pragma: no cover - stub
     return object()
 
 
-aiohttp_client_mod.async_get_clientsession = getattr(
-    aiohttp_client_mod, "async_get_clientsession", async_get_clientsession
-)
+aiohttp_client_mod.async_get_clientsession = async_get_clientsession
 
 
 class _Integration:  # pragma: no cover - minimal integration info
@@ -286,9 +282,7 @@ async def async_get_integration(_hass: HomeAssistant, _domain: str) -> _Integrat
     return _Integration("0.0-test")
 
 
-loader_mod.async_get_integration = getattr(
-    loader_mod, "async_get_integration", async_get_integration
-)
+loader_mod.async_get_integration = async_get_integration
 
 # --- Import module under test ---------------------------------------------------
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -1,0 +1,287 @@
+# ruff: noqa: D100,D101,D102,D103,D104,D105,D106,D107,INP001,E402
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from datetime import timedelta
+from typing import Any, Callable, Coroutine
+
+import pytest
+
+from homeassistant import const as const_mod
+from homeassistant import helpers as helpers_mod
+from homeassistant import loader as loader_mod
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import aiohttp_client as aiohttp_client_mod
+from homeassistant.helpers import dispatcher as dispatcher_mod
+from homeassistant.helpers import entity_registry as entity_registry_mod
+
+helpers_mod.aiohttp_client = aiohttp_client_mod
+helpers_mod.entity_registry = entity_registry_mod
+helpers_mod.dispatcher = dispatcher_mod
+const_mod.EVENT_HOMEASSISTANT_STARTED = getattr(
+    const_mod, "EVENT_HOMEASSISTANT_STARTED", "homeassistant_started"
+)
+
+
+class _StubClientSession:  # pragma: no cover - placeholder session
+    pass
+
+
+_STUB_SESSION = _StubClientSession()
+
+
+def async_get_clientsession(hass: Any) -> _StubClientSession:  # pragma: no cover - stub
+    if hasattr(hass, "client_session_calls"):
+        hass.client_session_calls += 1
+    return _STUB_SESSION
+
+
+aiohttp_client_mod.async_get_clientsession = async_get_clientsession
+
+
+def async_get_entity_registry(hass: Any) -> Any:  # pragma: no cover - stub
+    return None
+
+
+def async_dispatcher_connect(
+    hass: Any, signal: str, callback: Callable[[dict[str, Any]], None]
+) -> Callable[[], None]:  # pragma: no cover - stub
+    if hasattr(hass, "dispatcher_connections"):
+        hass.dispatcher_connections.append((signal, callback))
+    return lambda: None
+
+
+entity_registry_mod.async_get = async_get_entity_registry
+dispatcher_mod.async_dispatcher_connect = async_dispatcher_connect
+
+
+class _StubIntegration:  # pragma: no cover - minimal stub
+    def __init__(self, domain: str) -> None:
+        self.domain = domain
+        self.version = "test-version"
+
+
+async def async_get_integration(
+    hass: Any, domain: str
+) -> _StubIntegration:  # pragma: no cover
+    if hasattr(hass, "integration_requests"):
+        hass.integration_requests.append(domain)
+    return _StubIntegration(domain)
+
+
+loader_mod.async_get_integration = async_get_integration
+
+
+class StubServices:
+    def __init__(self) -> None:
+        self._services: dict[tuple[str, str], Any] = {}
+
+    def has_service(self, domain: str, service: str) -> bool:
+        return (domain, service) in self._services
+
+    def async_register(self, domain: str, service: str, handler: Any) -> None:
+        self._services[(domain, service)] = handler
+
+
+class StubConfigEntriesManager:
+    def __init__(self) -> None:
+        self.forwarded: list[tuple[ConfigEntry, tuple[str, ...]]] = []
+
+    async def async_forward_entry_setups(
+        self, entry: ConfigEntry, platforms: list[str] | tuple[str, ...]
+    ) -> None:
+        self.forwarded.append((entry, tuple(platforms)))
+
+    def async_update_entry(
+        self, entry: ConfigEntry, *, options: dict[str, Any] | None = None
+    ) -> None:
+        if options is not None:
+            entry.options = dict(options)
+
+    def async_get_entry(self, entry_id: str) -> ConfigEntry | None:
+        return None
+
+
+class StubHass:
+    def __init__(self) -> None:
+        self.data: dict[str, Any] = {}
+        self.services = StubServices()
+        self.config_entries = StubConfigEntriesManager()
+        self.dispatcher_connections: list[tuple[str, Callable[[dict[str, Any]], None]]] = []
+        self.tasks: list[asyncio.Task[Any]] = []
+        self.integration_requests: list[str] = []
+        self.client_session_calls = 0
+        self.is_running = True
+
+    def async_create_task(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
+        task = asyncio.create_task(coro)
+        self.tasks.append(task)
+        return task
+
+
+class FakeTask:
+    def __init__(self) -> None:
+        self._done = False
+
+    def done(self) -> bool:
+        return self._done
+
+
+class FakeWSClient:
+    def __init__(
+        self,
+        hass: StubHass,
+        *,
+        entry_id: str,
+        dev_id: str,
+        api_client: Any,
+        coordinator: Any,
+    ) -> None:
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self.api_client = api_client
+        self.coordinator = coordinator
+        self.start_calls = 0
+
+    def start(self) -> FakeTask:
+        self.start_calls += 1
+        return FakeTask()
+
+
+class FakeCoordinator:
+    def __init__(
+        self,
+        hass: StubHass,
+        client: Any,
+        base_interval: int,
+        dev_id: str,
+        dev: dict[str, Any],
+        nodes: dict[str, Any],
+    ) -> None:
+        self.hass = hass
+        self.client = client
+        self.base_interval = base_interval
+        self.dev_id = dev_id
+        self.dev = dev
+        self.nodes = nodes
+        self.update_interval = timedelta(seconds=base_interval)
+        self.data: dict[str, Any] = {dev_id: dev}
+        self.listeners: list[Callable[[], None]] = []
+        self.refresh_calls = 0
+
+    async def async_config_entry_first_refresh(self) -> None:
+        self.refresh_calls += 1
+
+    def async_add_listener(self, listener: Callable[[], None]) -> None:
+        self.listeners.append(listener)
+
+
+class BaseFakeClient:
+    def __init__(self, session: Any, username: str, password: str) -> None:
+        self.session = session
+        self.username = username
+        self.password = password
+        self.get_nodes_calls: list[str] = []
+
+    async def get_nodes(self, dev_id: str) -> dict[str, Any]:
+        self.get_nodes_calls.append(dev_id)
+        return {}
+
+
+@pytest.fixture
+def termoweb_init(monkeypatch: pytest.MonkeyPatch) -> Any:
+    for name in list(sys.modules):
+        if name.startswith("custom_components.termoweb"):
+            sys.modules.pop(name)
+
+    module = importlib.import_module("custom_components.termoweb.__init__")
+    module = importlib.reload(module)
+    monkeypatch.setattr(module, "TermoWebCoordinator", FakeCoordinator)
+    monkeypatch.setattr(module, "TermoWebWSLegacyClient", FakeWSClient)
+    monkeypatch.setattr(module, "extract_heater_addrs", lambda _nodes: [])
+    return module
+
+
+@pytest.fixture
+def stub_hass() -> StubHass:
+    return StubHass()
+
+
+def test_async_setup_entry_auth_error(
+    termoweb_init: Any, stub_hass: StubHass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class AuthErrorClient(BaseFakeClient):
+        async def list_devices(self) -> list[dict[str, Any]]:
+            raise termoweb_init.TermoWebAuthError("bad credentials")
+
+    monkeypatch.setattr(termoweb_init, "TermoWebClient", AuthErrorClient)
+    entry = ConfigEntry("auth", data={"username": "user", "password": "pw"})
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        asyncio.run(termoweb_init.async_setup_entry(stub_hass, entry))
+
+
+@pytest.mark.parametrize("error_case", ["timeout", "rate_limit"], ids=["timeout", "rate_limit"])
+def test_async_setup_entry_connection_errors(
+    termoweb_init: Any,
+    stub_hass: StubHass,
+    monkeypatch: pytest.MonkeyPatch,
+    error_case: str,
+) -> None:
+    class ConnectionErrorClient(BaseFakeClient):
+        async def list_devices(self) -> list[dict[str, Any]]:
+            if error_case == "timeout":
+                raise TimeoutError("timeout")
+            raise termoweb_init.TermoWebRateLimitError("rate limited")
+
+    monkeypatch.setattr(termoweb_init, "TermoWebClient", ConnectionErrorClient)
+    entry = ConfigEntry("conn", data={"username": "user", "password": "pw"})
+
+    with pytest.raises(ConfigEntryNotReady):
+        asyncio.run(termoweb_init.async_setup_entry(stub_hass, entry))
+
+
+def test_async_setup_entry_no_devices(
+    termoweb_init: Any, stub_hass: StubHass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class EmptyClient(BaseFakeClient):
+        async def list_devices(self) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(termoweb_init, "TermoWebClient", EmptyClient)
+    entry = ConfigEntry("empty", data={"username": "user", "password": "pw"})
+
+    with pytest.raises(ConfigEntryNotReady):
+        asyncio.run(termoweb_init.async_setup_entry(stub_hass, entry))
+
+
+def test_async_setup_entry_happy_path(
+    termoweb_init: Any, stub_hass: StubHass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class HappyClient(BaseFakeClient):
+        async def list_devices(self) -> list[dict[str, Any]]:
+            return [{"dev_id": "dev-1"}]
+
+    monkeypatch.setattr(termoweb_init, "TermoWebClient", HappyClient)
+    entry = ConfigEntry("happy", data={"username": "user", "password": "pw"})
+
+    async def _run_setup() -> bool:
+        result = await termoweb_init.async_setup_entry(stub_hass, entry)
+        if stub_hass.tasks:
+            await asyncio.gather(*stub_hass.tasks, return_exceptions=True)
+        return result
+
+    result = asyncio.run(_run_setup())
+    assert result is True
+
+    assert termoweb_init.DOMAIN in stub_hass.data
+    assert stub_hass.config_entries.forwarded == [
+        (entry, tuple(termoweb_init.PLATFORMS))
+    ]
+    assert stub_hass.services.has_service(
+        termoweb_init.DOMAIN, "import_energy_history"
+    )


### PR DESCRIPTION
## Summary
- add shared aiohttp/Home Assistant stubs in tests/conftest.py so the integration can be imported in isolation
- add tests/test_init_setup.py covering async_setup_entry error handling and success behaviour using fake clients/coordinators
- update existing tests to cooperate with the shared stubs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d137ecc3d88329ba88fb8d507c507d