### PR TITLE
Skip Ruff linting in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,9 @@ ignore = [
   "PLE0605",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["ALL"]
+
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false


### PR DESCRIPTION
## Summary
- add a Ruff per-file ignore entry so the tests directory is skipped during linting

## Testing
- ruff check *(fails: existing application docstring and lint violations persist outside `tests/`; no new issues introduced)*
- ruff check tests


------
https://chatgpt.com/codex/tasks/task_e_68d14a65d64c832981876acb7a6e8ffb