### PR TITLE
Remove unused logging from button and binary sensor

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
@@ -14,8 +13,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_status
 from .coordinator import TermoWebCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):


### PR DESCRIPTION
## Summary
- remove unused logging setup from the TermoWeb button entity module
- remove unused logging setup from the TermoWeb binary sensor module

## Testing
- ruff check *(fails: pre-existing docstring and lint issues in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d1561b20f08329a689922d95031fe3