### PR TITLE
Add tests for legacy websocket client handshake and events

### DIFF
--- a/tests/test_ws_client_legacy.py
+++ b/tests/test_ws_client_legacy.py
@@ -5,6 +5,8 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from typing import Any, Iterable
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -16,12 +18,18 @@ WS_CLIENT_PATH = (
 )
 
 
-def _load_ws_client():
+def _load_ws_client(
+    *,
+    get_responses: Iterable[Any] | None = None,
+    ws_connect_results: Iterable[Any] | None = None,
+):
     package = "custom_components.termoweb"
     sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
     termoweb_pkg = types.ModuleType(package)
     termoweb_pkg.__path__ = [str(WS_CLIENT_PATH.parent)]
     sys.modules[package] = termoweb_pkg
+
+    sys.modules.pop(f"{package}.ws_client_legacy", None)
 
     ha = types.ModuleType("homeassistant")
     ha_core = types.ModuleType("homeassistant.core")
@@ -39,6 +47,7 @@ def _load_ws_client():
     sys.modules["homeassistant.helpers.dispatcher"] = ha_dispatcher
 
     aiohttp_stub = types.ModuleType("aiohttp")
+
     class WSMsgType:
         TEXT = 1
         BINARY = 2
@@ -47,9 +56,158 @@ def _load_ws_client():
         ERROR = 5
 
     aiohttp_stub.WSMsgType = WSMsgType
-    aiohttp_stub.ClientSession = object  # pragma: no cover - placeholder
-    aiohttp_stub.ClientTimeout = object  # pragma: no cover - placeholder
+
+    class FakeClientTimeout:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    aiohttp_stub.ClientTimeout = FakeClientTimeout
+
+    class ClientError(Exception):
+        pass
+
+    aiohttp_stub.ClientError = ClientError
     aiohttp_stub.WSCloseCode = types.SimpleNamespace(GOING_AWAY=1001)
+
+    default_get_script = list(get_responses or [])
+    default_ws_script = list(ws_connect_results or [])
+
+    class FakeHTTPResponse:
+        def __init__(
+            self,
+            status: int,
+            body: Any,
+            *,
+            headers: dict[str, Any] | None = None,
+        ) -> None:
+            self.status = status
+            self._body = body
+            self.headers = headers or {}
+
+        async def text(self) -> str:
+            body = self._body
+            if asyncio.iscoroutine(body):
+                body = await body
+            if callable(body):
+                body = body()
+            if isinstance(body, bytes):
+                return body.decode("utf-8", "ignore")
+            return str(body or "")
+
+    class FakeGetContext:
+        def __init__(self, response: FakeHTTPResponse) -> None:
+            self._response = response
+
+        async def __aenter__(self) -> FakeHTTPResponse:
+            return self._response
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def _coerce_response(entry: Any) -> FakeHTTPResponse:
+        if isinstance(entry, FakeHTTPResponse):
+            return entry
+        if isinstance(entry, tuple):
+            status = int(entry[0])
+            body = entry[1] if len(entry) > 1 else ""
+            headers = entry[2] if len(entry) > 2 else None
+            return FakeHTTPResponse(status, body, headers=headers)
+        if isinstance(entry, dict):
+            return FakeHTTPResponse(
+                int(entry.get("status", 200)),
+                entry.get("body", ""),
+                headers=entry.get("headers"),
+            )
+        return FakeHTTPResponse(200, entry)
+
+    class FakeWebSocket:
+        def __init__(self, messages: Iterable[Any] | None = None) -> None:
+            self._messages = list(messages or [])
+            self.sent: list[str] = []
+            self.close_code: int | None = None
+            self._exception: BaseException | None = None
+
+        def queue_message(self, message: Any) -> None:
+            self._messages.append(message)
+
+        async def receive(self) -> Any:
+            if not self._messages:
+                return types.SimpleNamespace(
+                    type=aiohttp_stub.WSMsgType.CLOSED, data=None, extra=None
+                )
+            msg = self._messages.pop(0)
+            if callable(msg):
+                msg = msg()
+            if asyncio.iscoroutine(msg):
+                msg = await msg
+            if isinstance(msg, dict):
+                return types.SimpleNamespace(
+                    type=msg.get("type", aiohttp_stub.WSMsgType.TEXT),
+                    data=msg.get("data"),
+                    extra=msg.get("extra"),
+                )
+            return msg
+
+        async def send_str(self, data: str) -> None:
+            self.sent.append(data)
+
+        async def close(self, code: int | None = None, message: bytes | None = None) -> None:
+            self.close_code = code
+
+        def exception(self) -> BaseException | None:
+            return self._exception
+
+        def set_exception(self, exc: BaseException | None) -> None:
+            self._exception = exc
+
+    class FakeClientSession:
+        def __init__(
+            self,
+            *,
+            get_responses: Iterable[Any] | None = None,
+            ws_connect_results: Iterable[Any] | None = None,
+        ) -> None:
+            self._get_script = list(get_responses or default_get_script)
+            self._ws_script = list(ws_connect_results or default_ws_script)
+            self.get_calls: list[dict[str, Any]] = []
+            self.ws_connect_calls: list[dict[str, Any]] = []
+
+        def queue_get(self, response: Any) -> None:
+            self._get_script.append(response)
+
+        def queue_ws(self, result: Any) -> None:
+            self._ws_script.append(result)
+
+        def get(self, url: str, *, timeout: Any | None = None) -> FakeGetContext:
+            if not self._get_script:
+                raise AssertionError("No scripted GET response available")
+            entry = self._get_script.pop(0)
+            if callable(entry):
+                entry = entry(url=url, timeout=timeout)
+            response = _coerce_response(entry)
+            self.get_calls.append({"url": url, "timeout": timeout})
+            return FakeGetContext(response)
+
+        async def ws_connect(self, url: str, **kwargs: Any) -> Any:
+            if not self._ws_script:
+                raise AssertionError("No scripted ws_connect result available")
+            entry = self._ws_script.pop(0)
+            if callable(entry):
+                entry = entry(url=url, **kwargs)
+            if asyncio.iscoroutine(entry):
+                entry = await entry
+            if isinstance(entry, dict) and "messages" in entry:
+                entry = FakeWebSocket(entry["messages"])
+            self.ws_connect_calls.append({"url": url, "kwargs": kwargs})
+            return entry
+
+    aiohttp_stub.ClientSession = FakeClientSession
+    aiohttp_stub.ClientWebSocketResponse = FakeWebSocket
+    aiohttp_stub.testing = types.SimpleNamespace(
+        FakeClientSession=FakeClientSession,
+        FakeWebSocket=FakeWebSocket,
+        FakeHTTPResponse=FakeHTTPResponse,
+    )
     sys.modules["aiohttp"] = aiohttp_stub
 
     spec = importlib.util.spec_from_file_location(
@@ -88,3 +246,213 @@ def test_read_loop_bubbles_exception_on_close():
             await client._read_loop()
 
     asyncio.run(_run())
+
+
+def test_handshake_refreshes_token_after_401():
+    async def _run() -> None:
+        module = _load_ws_client()
+        Client = module.TermoWebWSLegacyClient
+        aiohttp = sys.modules["aiohttp"]
+        session = aiohttp.ClientSession(
+            get_responses=[
+                {"status": 401, "body": "unauthorized"},
+                {"status": 200, "body": "abc123:25:60:websocket"},
+            ]
+        )
+        hass = types.SimpleNamespace(loop=asyncio.get_event_loop())
+        coordinator = types.SimpleNamespace()
+        api = types.SimpleNamespace(
+            _session=session,
+            _authed_headers=AsyncMock(
+                side_effect=
+                [
+                    {"Authorization": "Bearer old"},
+                    {"Authorization": "Bearer new"},
+                ]
+            ),
+            _ensure_token=AsyncMock(),
+        )
+        client = Client(
+            hass,
+            entry_id="entry",
+            dev_id="dev",
+            api_client=api,
+            coordinator=coordinator,
+            session=session,
+        )
+        client._force_refresh_token = AsyncMock(return_value=None)
+        client._backoff_idx = 3
+
+        sid, hb = await client._handshake()
+
+        assert sid == "abc123"
+        assert hb == 25
+        assert client._force_refresh_token.await_count == 1
+        assert api._authed_headers.await_count == 2
+        assert len(session.get_calls) == 2
+        assert client._backoff_idx == 0
+
+    asyncio.run(_run())
+
+
+def test_handle_event_updates_state_and_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_ws_client()
+    module.async_dispatcher_send = MagicMock()
+    loop = asyncio.new_event_loop()
+    hass = types.SimpleNamespace(
+        loop=loop,
+        data={module.DOMAIN: {"entry": {"ws_state": {}}}},
+    )
+    coordinator = types.SimpleNamespace(
+        data={
+            "dev": {
+                "dev_id": "dev",
+                "name": "Device dev",
+                "raw": {"existing": True},
+                "connected": True,
+                "nodes": None,
+                "htr": {"addrs": [], "settings": {}},
+            }
+        }
+    )
+    api = types.SimpleNamespace(_session=types.SimpleNamespace())
+    client = module.TermoWebWSLegacyClient(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api,
+        coordinator=coordinator,
+    )
+    monkeypatch.setattr(module.time, "time", lambda: 1000.0)
+
+    event = {
+        "name": "data",
+        "args": [
+            [
+                {
+                    "path": "/mgr/nodes",
+                    "body": {
+                        "nodes": [
+                            {"addr": "01", "type": "htr"},
+                            {"addr": "02", "type": "HTR"},
+                        ]
+                    },
+                },
+                {"path": "/htr/01/settings", "body": {"temp": 21}},
+                {"path": "/htr/01/advanced_setup", "body": {"adv": True}},
+                {
+                    "path": "/htr/02/samples",
+                    "body": [{"ts": 1, "val": 2}],
+                },
+                {"path": "/misc", "body": {"foo": "bar"}},
+            ]
+        ],
+    }
+
+    client._handle_event(event)
+
+    dev_data = coordinator.data["dev"]
+    assert dev_data["nodes"] == {
+        "nodes": [{"addr": "01", "type": "htr"}, {"addr": "02", "type": "HTR"}]
+    }
+    assert dev_data["htr"]["addrs"] == ["01", "02"]
+    assert dev_data["htr"]["settings"]["01"] == {"temp": 21}
+    assert dev_data["htr"]["advanced"]["01"] == {"adv": True}
+    assert dev_data["raw"]["misc"] == {"foo": "bar"}
+    assert client._stats.events_total == 1
+    module.async_dispatcher_send.assert_has_calls(
+        [
+            call(
+                hass,
+                module.signal_ws_data("entry"),
+                {"dev_id": "dev", "ts": 1000.0, "addr": None, "kind": "nodes"},
+            ),
+            call(
+                hass,
+                module.signal_ws_data("entry"),
+                {"dev_id": "dev", "ts": 1000.0, "addr": "01", "kind": "htr_settings"},
+            ),
+            call(
+                hass,
+                module.signal_ws_data("entry"),
+                {"dev_id": "dev", "ts": 1000.0, "addr": "02", "kind": "htr_samples"},
+            ),
+        ]
+    )
+    assert module.async_dispatcher_send.call_count == 3
+    loop.close()
+
+
+def test_subscribe_htr_samples_sends_expected_payloads():
+    async def _run() -> None:
+        module = _load_ws_client()
+        Client = module.TermoWebWSLegacyClient
+        hass = types.SimpleNamespace(loop=asyncio.get_event_loop())
+        coordinator = types.SimpleNamespace(_addrs=lambda: ["01", "02"])
+        api = types.SimpleNamespace(_session=None)
+        client = Client(
+            hass,
+            entry_id="entry",
+            dev_id="dev",
+            api_client=api,
+            coordinator=coordinator,
+        )
+
+        class DummyWS:
+            def __init__(self) -> None:
+                self.sent: list[str] = []
+
+            async def send_str(self, data: str) -> None:
+                self.sent.append(data)
+
+        ws = DummyWS()
+        client._ws = ws
+
+        await client._subscribe_htr_samples()
+
+        assert ws.sent == [
+            '5::/api/v2/socket_io:{"name":"subscribe","args":["/htr/01/samples"]}',
+            '5::/api/v2/socket_io:{"name":"subscribe","args":["/htr/02/samples"]}',
+        ]
+
+    asyncio.run(_run())
+
+
+def test_mark_event_promotes_to_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_ws_client()
+    module.async_dispatcher_send = MagicMock()
+    loop = asyncio.new_event_loop()
+    hass = types.SimpleNamespace(
+        loop=loop,
+        data={module.DOMAIN: {"entry": {"ws_state": {}}}},
+    )
+    coordinator = types.SimpleNamespace()
+    api = types.SimpleNamespace(_session=None)
+    client = module.TermoWebWSLegacyClient(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api,
+        coordinator=coordinator,
+    )
+    client._connected_since = 500.0
+    client._healthy_since = None
+    client._stats.frames_total = 7
+    client._stats.events_total = 3
+    monkeypatch.setattr(module.time, "time", lambda: 805.0)
+
+    client._mark_event(paths=None)
+
+    ws_state = hass.data[module.DOMAIN]["entry"]["ws_state"]["dev"]
+    assert ws_state["status"] == "healthy"
+    assert ws_state["healthy_since"] == 805.0
+    assert ws_state["last_event_at"] == 805.0
+    assert ws_state["frames_total"] == 7
+    assert ws_state["events_total"] == 3
+    assert client._healthy_since == 805.0
+    module.async_dispatcher_send.assert_called_with(
+        hass,
+        module.signal_ws_status("entry"),
+        {"dev_id": "dev", "status": "healthy"},
+    )
+    loop.close()


### PR DESCRIPTION
## Summary
- extend the ws client test loader with configurable aiohttp session and websocket stubs
- add tests covering handshake retries, event processing, subscription payloads, and health promotion logic

## Testing
- pytest tests/test_ws_client_legacy.py
- pytest --cov=custom_components.termoweb --cov-report=term *(fails: pytest-cov plugin unavailable in container due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d156200c208329bc08dd9890914c5e