### PR TITLE
Add error handling tests for TermoWeb API

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import importlib.util
 from pathlib import Path
 import sys
 import types
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -94,10 +94,62 @@ class MockResponse:
         return self._json
 
 
+class LatchedResponse:
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def get(self) -> Any:
+        return self._value
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self._request_queue: list[Any] = []
+        self._post_queue: list[Any] = []
+        self.request_calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def queue_request(self, *responses: Any) -> None:
+        self._request_queue.extend(responses)
+
+    def queue_post(self, *responses: Any) -> None:
+        self._post_queue.extend(responses)
+
+    def clear_calls(self) -> None:
+        self.request_calls.clear()
+        self.post_calls.clear()
+
+    def _resolve(self, queue: list[Any], label: str) -> Any:
+        if not queue:
+            raise AssertionError(f"Unexpected {label} call with no queued response")
+        item = queue[0]
+        if isinstance(item, LatchedResponse):
+            result = item.get()
+        else:
+            result = queue.pop(0)
+        if callable(result):
+            result = result()
+        return result
+
+    def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Any:
+        self.request_calls.append((method, url, copy.deepcopy(kwargs)))
+        result = self._resolve(self._request_queue, "request")
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def post(self, url: str, *args: Any, **kwargs: Any) -> Any:
+        self.post_calls.append((url, args, copy.deepcopy(kwargs)))
+        result = self._resolve(self._post_queue, "post")
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
 def test_token_refresh(monkeypatch) -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.post.side_effect = [
+        session = FakeSession()
+        session.queue_post(
             MockResponse(
                 200,
                 {"access_token": "t1", "expires_in": 1},
@@ -108,7 +160,7 @@ def test_token_refresh(monkeypatch) -> None:
                 {"access_token": "t2", "expires_in": 3600},
                 headers={"Content-Type": "application/json"},
             ),
-        ]
+        )
 
         client = TermoWebClient(session, "user", "pass")
 
@@ -126,30 +178,35 @@ def test_token_refresh(monkeypatch) -> None:
         fake_time = 2.0  # advance beyond expiry
         token2 = await client._ensure_token()
         assert token2 == "t2"
-        assert session.post.call_count == 2
+        assert len(session.post_calls) == 2
 
     asyncio.run(_run())
 
 
 def test_get_htr_samples_success() -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.post.return_value = MockResponse(
-            200,
-            {"access_token": "tok", "expires_in": 3600},
-            headers={"Content-Type": "application/json"},
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "tok", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
         )
-        session.request.return_value = MockResponse(
-            200,
-            {"samples": [{"t": 1000, "counter": "1.5"}]},
-            headers={"Content-Type": "application/json"},
+        session.queue_request(
+            MockResponse(
+                200,
+                {"samples": [{"t": 1000, "counter": "1.5"}]},
+                headers={"Content-Type": "application/json"},
+            )
         )
 
         client = TermoWebClient(session, "user", "pass")
         samples = await client.get_htr_samples("dev", "A", 0, 10)
 
         assert samples == [{"t": 1000, "counter": "1.5"}]
-        params = session.request.call_args[1]["params"]
+        assert len(session.request_calls) == 1
+        params = session.request_calls[0][2]["params"]
         assert params == {"start": 0, "end": 10}
 
     asyncio.run(_run())
@@ -157,16 +214,20 @@ def test_get_htr_samples_success() -> None:
 
 def test_get_htr_samples_404() -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.post.return_value = MockResponse(
-            200,
-            {"access_token": "tok", "expires_in": 3600},
-            headers={"Content-Type": "application/json"},
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "tok", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
         )
-        session.request.return_value = MockResponse(
-            404,
-            {},
-            headers={"Content-Type": "application/json"},
+        session.queue_request(
+            MockResponse(
+                404,
+                {},
+                headers={"Content-Type": "application/json"},
+            )
         )
 
         client = TermoWebClient(session, "user", "pass")
@@ -178,16 +239,20 @@ def test_get_htr_samples_404() -> None:
 
 def test_request_ignore_status_returns_none() -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.post.return_value = MockResponse(
-            200,
-            {"access_token": "tok", "expires_in": 3600},
-            headers={"Content-Type": "application/json"},
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "tok", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
         )
-        session.request.return_value = MockResponse(
-            404,
-            {},
-            headers={"Content-Type": "application/json"},
+        session.queue_request(
+            MockResponse(
+                404,
+                {},
+                headers={"Content-Type": "application/json"},
+            )
         )
 
         client = TermoWebClient(session, "user", "pass")
@@ -199,102 +264,257 @@ def test_request_ignore_status_returns_none() -> None:
     asyncio.run(_run())
 
 
-def test_request_two_401_responses() -> None:
+def test_request_refreshes_once_then_raises() -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.request.side_effect = [
+        session = FakeSession()
+        session.queue_post(
             MockResponse(
-                401,
-                {},
+                200,
+                {"access_token": "initial", "expires_in": 3600},
                 headers={"Content-Type": "application/json"},
             ),
             MockResponse(
-                401,
-                {},
+                200,
+                {"access_token": "refreshed", "expires_in": 3600},
                 headers={"Content-Type": "application/json"},
             ),
-        ]
-        session.post.return_value = MockResponse(
-            200,
-            {"access_token": "fresh", "expires_in": 3600},
-            headers={"Content-Type": "application/json"},
+        )
+        session.queue_request(
+            LatchedResponse(
+                MockResponse(
+                    401,
+                    {"error": "invalid_token"},
+                    headers={"Content-Type": "application/json"},
+                    text_data='{"error":"invalid_token"}',
+                )
+            )
         )
 
         client = TermoWebClient(session, "user", "pass")
+        headers = await client._authed_headers()
+        session.clear_calls()
 
         with pytest.raises(api.TermoWebAuthError):
-            await client._request("GET", "/path", headers={})
+            await client._request("GET", "/api/test", headers=headers)
 
-        assert session.post.call_count == 1
-        assert session.request.call_count == 2
+        assert len(session.request_calls) == 2
+        assert len(session.post_calls) == 1
+        first_auth = session.request_calls[0][2]["headers"]["Authorization"]
+        second_auth = session.request_calls[1][2]["headers"]["Authorization"]
+        assert first_auth == "Bearer initial"
+        assert second_auth == "Bearer refreshed"
 
     asyncio.run(_run())
 
 
-def test_request_rate_limit() -> None:
+def test_request_rate_limit_error() -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.request.return_value = MockResponse(
-            429,
-            {},
-            headers={"Content-Type": "application/json"},
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "token", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+        session.queue_request(
+            MockResponse(
+                429,
+                {"error": "rate"},
+                headers={"Content-Type": "application/json"},
+                text_data='{"error":"rate"}',
+            )
         )
 
         client = TermoWebClient(session, "user", "pass")
+        headers = await client._authed_headers()
+        session.clear_calls()
 
         with pytest.raises(api.TermoWebRateLimitError):
-            await client._request("GET", "/path", headers={})
+            await client._request("GET", "/api/rate", headers=headers)
 
-        assert session.request.call_count == 1
+        assert len(session.request_calls) == 1
+        assert len(session.post_calls) == 0
+
+    asyncio.run(_run())
+
+
+def test_request_5xx_surfaces_client_error() -> None:
+    async def _run() -> None:
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "token", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+        session.queue_request(
+            MockResponse(
+                503,
+                {"error": "down"},
+                headers={"Content-Type": "application/json"},
+                text_data="Service unavailable",
+            )
+        )
+
+        client = TermoWebClient(session, "user", "pass")
+        headers = await client._authed_headers()
+        session.clear_calls()
+
+        with pytest.raises(aiohttp.ClientResponseError) as err:
+            await client._request("GET", "/api/down", headers=headers)
+
+        assert err.value.status == 503
+        assert len(session.request_calls) == 1
+
+    asyncio.run(_run())
+
+
+def test_request_timeout_propagates() -> None:
+    async def _run() -> None:
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "token", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+        session.queue_request(asyncio.TimeoutError())
+
+        client = TermoWebClient(session, "user", "pass")
+        headers = await client._authed_headers()
+        session.clear_calls()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await client._request("GET", "/api/slow", headers=headers)
+
+        assert len(session.request_calls) == 1
 
     asyncio.run(_run())
 
 
 def test_set_htr_settings_invalid_units() -> None:
     async def _run() -> None:
-        client = TermoWebClient(MagicMock(), "user", "pass")
+        session = FakeSession()
+        client = TermoWebClient(session, "user", "pass")
 
         with pytest.raises(ValueError, match="Invalid units"):
-            await client.set_htr_settings("dev", "A", units="kelvin")
+            await client.set_htr_settings("dev", "1", units="kelvin")
+
+        assert not session.request_calls
+        assert not session.post_calls
 
     asyncio.run(_run())
 
 
-def test_set_htr_settings_bad_stemp() -> None:
+def test_set_htr_settings_invalid_program() -> None:
     async def _run() -> None:
-        client = TermoWebClient(MagicMock(), "user", "pass")
-
-        with pytest.raises(ValueError, match="Invalid stemp value"):
-            await client.set_htr_settings("dev", "A", stemp="not-a-number")
-
-    asyncio.run(_run())
-
-
-def test_set_htr_settings_short_prog() -> None:
-    async def _run() -> None:
-        client = TermoWebClient(MagicMock(), "user", "pass")
+        session = FakeSession()
+        client = TermoWebClient(session, "user", "pass")
 
         with pytest.raises(ValueError, match="prog must be a list of 168"):
-            await client.set_htr_settings("dev", "A", prog=[0, 1, 2])
+            await client.set_htr_settings("dev", "1", prog=[0, 1, 2])
+
+        with pytest.raises(ValueError, match="prog values must be 0, 1, or 2"):
+            await client.set_htr_settings("dev", "1", prog=[0] * 167 + [5])
+
+        with pytest.raises(ValueError, match="prog contains non-integer value"):
+            await client.set_htr_settings("dev", "1", prog=[0] * 167 + ["bad"])
+
+        assert not session.request_calls
+        assert not session.post_calls
 
     asyncio.run(_run())
 
 
-def test_set_htr_settings_bad_ptemp() -> None:
+def test_set_htr_settings_invalid_temperatures() -> None:
     async def _run() -> None:
-        client = TermoWebClient(MagicMock(), "user", "pass")
+        session = FakeSession()
+        client = TermoWebClient(session, "user", "pass")
+
+        with pytest.raises(ValueError, match="Invalid stemp value"):
+            await client.set_htr_settings("dev", "1", stemp="warm")
+
+        with pytest.raises(
+            ValueError, match="ptemp must be a list of three numeric values"
+        ):
+            await client.set_htr_settings("dev", "1", ptemp=[21.0, 19.0])
 
         with pytest.raises(ValueError, match="ptemp contains non-numeric value"):
-            await client.set_htr_settings(
-                "dev", "A", ptemp=["19.5", "oops", "21.0"]
-            )
+            await client.set_htr_settings("dev", "1", ptemp=[21.0, "bad", 23.0])
+
+        assert not session.request_calls
+        assert not session.post_calls
 
     asyncio.run(_run())
 
-def test_request_retries_on_401() -> None:
+
+def test_get_htr_samples_empty_payload() -> None:
     async def _run() -> None:
-        session = MagicMock()
-        session.post.side_effect = [
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "tok", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+        session.queue_request(
+            MockResponse(
+                200,
+                {"samples": []},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        client = TermoWebClient(session, "user", "pass")
+        samples = await client.get_htr_samples("dev", "A", 0, 10)
+
+        assert samples == []
+
+    asyncio.run(_run())
+
+
+def test_get_htr_samples_decreasing_counters() -> None:
+    async def _run() -> None:
+        session = FakeSession()
+        session.queue_post(
+            MockResponse(
+                200,
+                {"access_token": "tok", "expires_in": 3600},
+                headers={"Content-Type": "application/json"},
+            )
+        )
+        session.queue_request(
+            MockResponse(
+                200,
+                {
+                    "samples": [
+                        {"t": 1, "counter": "3.0"},
+                        {"t": 2, "counter": "2.5"},
+                    ]
+                },
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        client = TermoWebClient(session, "user", "pass")
+        samples = await client.get_htr_samples("dev", "A", 0, 10)
+
+        assert samples == [
+            {"t": 1, "counter": "3.0"},
+            {"t": 2, "counter": "2.5"},
+        ]
+
+    asyncio.run(_run())
+
+
+def test_request_recovers_after_token_refresh() -> None:
+    async def _run() -> None:
+        session = FakeSession()
+        session.queue_post(
             MockResponse(
                 200,
                 {"access_token": "old", "expires_in": 3600},
@@ -305,64 +525,55 @@ def test_request_retries_on_401() -> None:
                 {"access_token": "new", "expires_in": 3600},
                 headers={"Content-Type": "application/json"},
             ),
-        ]
-        session.request.side_effect = [
-            MockResponse(401, {}, headers={"Content-Type": "application/json"}),
+        )
+        session.queue_request(
             MockResponse(
-                200, [{"dev_id": "1"}], headers={"Content-Type": "application/json"}
+                401,
+                {"error": "expired"},
+                headers={"Content-Type": "application/json"},
+                text_data='{"error":"expired"}',
             ),
-        ]
+            MockResponse(
+                200,
+                [{"dev_id": "1"}],
+                headers={"Content-Type": "application/json"},
+            ),
+        )
 
         client = TermoWebClient(session, "user", "pass")
         devices = await client.list_devices()
 
         assert devices == [{"dev_id": "1"}]
-        assert session.request.call_count == 2
-        assert session.post.call_count == 2
-
-        # Verify that the Authorization header was updated after the retry
-        second_headers = session.request.call_args_list[1][1]["headers"]
-        assert second_headers["Authorization"] == "Bearer new"
+        assert len(session.request_calls) == 2
+        assert len(session.post_calls) == 2
+        refreshed_headers = session.request_calls[1][2]["headers"]
+        assert refreshed_headers["Authorization"] == "Bearer new"
 
     asyncio.run(_run())
 
 
 def test_set_htr_settings_translates_heat(monkeypatch) -> None:
     async def _run() -> None:
-        session = MagicMock()
+        session = FakeSession()
         client = TermoWebClient(session, "user", "pass")
 
         async def fake_headers() -> dict[str, str]:
             return {}
 
-        monkeypatch.setattr(client, "_authed_headers", fake_headers)
-
         captured: dict[str, Any] = {}
 
-        async def fake_request(method: str, path: str, **kwargs) -> Any:
+        async def fake_request(method: str, path: str, **kwargs: Any) -> Any:
             captured["json"] = kwargs.get("json")
             return {}
 
+        monkeypatch.setattr(client, "_authed_headers", fake_headers)
         monkeypatch.setattr(client, "_request", fake_request)
 
         await client.set_htr_settings("dev", 1, mode="heat", stemp=21.0)
 
         assert captured["json"]["mode"] == "manual"
+        assert captured["json"]["stemp"] == "21.0"
 
     asyncio.run(_run())
 
 
-def test_set_htr_settings_invalid_units(monkeypatch) -> None:
-    async def _run() -> None:
-        session = MagicMock()
-        client = TermoWebClient(session, "user", "pass")
-
-        async def fake_headers() -> dict[str, str]:
-            raise AssertionError("_authed_headers should not be called")
-
-        monkeypatch.setattr(client, "_authed_headers", fake_headers)
-
-        with pytest.raises(ValueError):
-            await client.set_htr_settings("dev", 1, units="K")
-
-    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a deterministic FakeSession helper for exercising TermoWebClient branches
- cover token refresh failures, rate limiting, server errors, and timeout propagation
- validate heater settings payload validation and heater sample edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17e4cc68c832983481707da1c6dd8