### PR TITLE
Fix datetime UTC compatibility

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 import time
 from typing import Any
@@ -33,6 +33,8 @@ from .const import (
 from .coordinator import TermoWebCoordinator
 from .utils import extract_heater_addrs
 from .ws_client_legacy import TermoWebWSLegacyClient
+
+UTC = timezone.utc
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- replace usage of `datetime.UTC` with `timezone.utc` so the integration works on Python 3.10

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d182bc9a20832988d65e6f6eaace68