### PR TITLE
Add targeted heater refresh fallback

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -596,7 +596,7 @@ class TermoWebHeater(CoordinatorEntity, ClimateEntity):
         async def _fallback() -> None:
             await asyncio.sleep(_WS_ECHO_FALLBACK_REFRESH)
             try:
-                await self.coordinator.async_request_refresh()
+                await self.coordinator.async_refresh_heater(self._addr)
             except asyncio.CancelledError:
                 raise
             except Exception as e:


### PR DESCRIPTION
## Summary
- add a coordinator helper to fetch and merge settings for a single heater and publish the update
- point the climate fallback refresh at the targeted helper for writes that miss websocket echoes
- extend the climate regression test to cover targeted fallback refresh behaviour with two heaters
- fetch all heater settings during coordinator refresh now that the round-robin fallback is gone

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2c3a7395883299b3b6a492dfe34c8