### PR TITLE
Add brand selection and Ducaheat credentials

### DIFF
--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import timedelta
 from typing import Final
 
@@ -18,6 +19,48 @@ HTR_SAMPLES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/htr/{addr}/samples"
 
 # Public client creds (from APK v2.5.1)
 BASIC_AUTH_B64: Final = "NTIxNzJkYzg0ZjYzZDZjNzU5MDAwMDA1OmJ4djRaM3hVU2U="
+
+# Brand handling
+CONF_BRAND: Final = "brand"
+BRAND_TERMOWEB: Final = "termoweb"
+BRAND_DUCAHEAT: Final = "ducaheat"
+DEFAULT_BRAND: Final = BRAND_TERMOWEB
+
+BRAND_LABELS: Final[Mapping[str, str]] = {
+    BRAND_TERMOWEB: "TermoWeb",
+    BRAND_DUCAHEAT: "Ducaheat",
+}
+
+BRAND_API_BASES: Final[Mapping[str, str]] = {
+    BRAND_TERMOWEB: API_BASE,
+    BRAND_DUCAHEAT: "https://api-tevolve.termoweb.net",
+}
+
+BRAND_BASIC_AUTH: Final[Mapping[str, str]] = {
+    BRAND_TERMOWEB: BASIC_AUTH_B64,
+    BRAND_DUCAHEAT: "NWM0OWRjZTk3NzUxMDM1MTUwNmM0MmRiOnRldm9sdmU=",
+}
+
+
+def get_brand_api_base(brand: str) -> str:
+    """Return API base URL for the selected brand."""
+
+    base = BRAND_API_BASES.get(brand)
+    if base:
+        return base.rstrip("/")
+    return API_BASE
+
+
+def get_brand_basic_auth(brand: str) -> str:
+    """Return Base64-encoded client credentials for the brand."""
+
+    return BRAND_BASIC_AUTH.get(brand, BASIC_AUTH_B64)
+
+
+def get_brand_label(brand: str) -> str:
+    """Return human-readable brand label."""
+
+    return BRAND_LABELS.get(brand, BRAND_LABELS[BRAND_TERMOWEB])
 
 # Polling
 DEFAULT_POLL_INTERVAL: Final = 120  # seconds

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -2,9 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to TermoWeb",
-        "description": "Enter your TermoWeb login credentials.",
+        "title": "Connect to Tevolve heaters",
+        "description": "Choose your heater brand and enter your account credentials.",
         "data": {
+          "brand": "Brand",
           "username": "Email",
           "password": "Password",
           "poll_interval": "Base poll interval (seconds)"

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -2,9 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Termoweb",
-        "description": "Version: {version}\n\nEnter your Termoweb account credentials",
+        "title": "Connect to Tevolve heaters",
+        "description": "Version: {version}\n\nChoose your heater brand and enter your account credentials",
         "data": {
+          "brand": "Brand",
           "username": "Email",
           "password": "Password",
           "poll_interval": "Polling interval (seconds)"

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -22,7 +22,8 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False)
     ha_core = types.ModuleType("homeassistant.core")
 
     class HomeAssistant:  # pragma: no cover - minimal stub
-        pass
+        def __init__(self) -> None:
+            self.data = {}
 
     def callback(func):  # pragma: no cover - minimal stub
         return func
@@ -240,10 +241,12 @@ async def _load_module(monkeypatch: pytest.MonkeyPatch, *, legacy: bool = False)
 
     api_stub = types.ModuleType(f"{package}.api")
     class TermoWebClient:  # pragma: no cover - placeholder
-        def __init__(self, session, username, password):
+        def __init__(self, session, username, password, **kwargs):
             self.session = session
             self.username = username
             self.password = password
+            self.api_base = kwargs.get("api_base")
+            self.basic_auth_b64 = kwargs.get("basic_auth_b64")
 
         async def list_devices(self):
             return [{"dev_id": "dev"}]

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -207,10 +207,18 @@ class FakeCoordinator:
 
 
 class BaseFakeClient:
-    def __init__(self, session: Any, username: str, password: str) -> None:
+    def __init__(
+        self,
+        session: Any,
+        username: str,
+        password: str,
+        **kwargs: Any,
+    ) -> None:
         self.session = session
         self.username = username
         self.password = password
+        self.api_base = kwargs.get("api_base")
+        self.basic_auth_b64 = kwargs.get("basic_auth_b64")
         self.get_nodes_calls: list[str] = []
 
     async def list_devices(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- add brand-specific constants and helpers so the integration can switch between TermoWeb and Ducaheat cloud endpoints
- extend the config flow and setup logic to store the chosen brand and pass the correct API base and client credentials to the API and websocket clients
- refresh UI strings and unit tests to cover the new brand selector and per-brand behaviour

## Testing
- pytest


