### PR TITLE
Update ws_state timestamps on legacy ws events

### DIFF
--- a/custom_components/termoweb/ws_client_legacy.py
+++ b/custom_components/termoweb/ws_client_legacy.py
@@ -555,6 +555,16 @@ class TermoWebWSLegacyClient:
                         break
                 self._stats.last_paths = uniq
 
+        domain_bucket: dict[str, Any] = self.hass.data.setdefault(DOMAIN, {})
+        entry_bucket: dict[str, Any] = domain_bucket.setdefault(self.entry_id, {})
+        state_bucket: dict[str, dict[str, Any]] = entry_bucket.setdefault(
+            "ws_state", {}
+        )
+        state: dict[str, Any] = state_bucket.setdefault(self.dev_id, {})
+        state["last_event_at"] = now
+        state["frames_total"] = self._stats.frames_total
+        state["events_total"] = self._stats.events_total
+
         # Health heuristic: connected and alive for ≥ 300s => healthy
         if (
             self._connected_since

--- a/tests/test_ws_client_legacy.py
+++ b/tests/test_ws_client_legacy.py
@@ -682,7 +682,10 @@ def test_read_loop_bubbles_exception_on_close():
     async def _run() -> None:
         module = _load_ws_client()
         Client = module.TermoWebWSLegacyClient
-        hass = types.SimpleNamespace(loop=asyncio.get_event_loop())
+        hass = types.SimpleNamespace(
+            loop=asyncio.get_event_loop(),
+            data={module.DOMAIN: {}},
+        )
         api = types.SimpleNamespace(_session=None)
         coordinator = types.SimpleNamespace()
         client = Client(hass, entry_id="e", dev_id="d", api_client=api, coordinator=coordinator)
@@ -710,7 +713,10 @@ def test_read_loop_handles_error_frames_and_health(monkeypatch: pytest.MonkeyPat
     async def _run() -> None:
         module = _load_ws_client()
         Client = module.TermoWebWSLegacyClient
-        hass = types.SimpleNamespace(loop=asyncio.get_event_loop())
+        hass = types.SimpleNamespace(
+            loop=asyncio.get_event_loop(),
+            data={module.DOMAIN: {}},
+        )
         api = types.SimpleNamespace(_session=None)
         coordinator = types.SimpleNamespace()
         client = Client(hass, entry_id="e", dev_id="d", api_client=api, coordinator=coordinator)
@@ -1011,6 +1017,11 @@ def test_handle_event_updates_state_and_dispatch(monkeypatch: pytest.MonkeyPatch
         ]
     )
     assert module.async_dispatcher_send.call_count == 3
+
+    ws_state = hass.data[module.DOMAIN]["entry"]["ws_state"]["dev"]
+    assert ws_state["last_event_at"] == 1000.0
+    assert ws_state["events_total"] == 1
+    assert ws_state["frames_total"] == 0
     loop.close()
 
 


### PR DESCRIPTION
## Summary
- update `_mark_event` to keep the shared `ws_state` record's timestamps and counters in sync for every websocket event
- ensure `_mark_event` seeds the `ws_state` bucket before writing and extend the legacy client tests to cover the regression

## Testing
- pytest tests/test_ws_client_legacy.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e0e9d5d8832981935e2de6bba035