### PR TITLE
Align energy polling with imported statistics

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -180,21 +180,23 @@ class TermoWebHeaterEnergyCoordinator(
                     )
                     continue
 
-                energy_map[addr] = counter
+                kwh = counter / 1000.0
+                energy_map[addr] = kwh
 
                 prev = self._last.get((dev_id, addr))
                 if prev:
-                    prev_t, prev_counter = prev
-                    if counter < prev_counter or t <= prev_t:
-                        self._last[(dev_id, addr)] = (t, counter)
+                    prev_t, prev_kwh = prev
+                    if kwh < prev_kwh or t <= prev_t:
+                        self._last[(dev_id, addr)] = (t, kwh)
                         continue
                     dt_hours = (t - prev_t) / 3600
                     if dt_hours > 0:
-                        power = (counter - prev_counter) / dt_hours * 1000
+                        delta_kwh = kwh - prev_kwh
+                        power = delta_kwh / dt_hours * 1000
                         power_map[addr] = power
-                    self._last[(dev_id, addr)] = (t, counter)
+                    self._last[(dev_id, addr)] = (t, kwh)
                 else:
-                    self._last[(dev_id, addr)] = (t, counter)
+                    self._last[(dev_id, addr)] = (t, kwh)
 
             result: dict[str, dict[str, Any]] = {
                 dev_id: {

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -250,7 +250,7 @@ class TermoWebHeaterEnergyTotal(CoordinatorEntity, SensorEntity):
         if val is None:
             return None
         try:
-            return float(val) / 1000
+            return float(val)
         except (TypeError, ValueError):
             return None
 
@@ -391,7 +391,7 @@ class TermoWebTotalEnergy(CoordinatorEntity, SensorEntity):
                 continue
         if not found:
             return None
-        return total / 1000
+        return total
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- convert the heater energy poller to work in kWh like the history importer and compute power from kWh deltas
- expose kWh readings from the heater and total energy sensors so live states line up with imported statistics
- extend the importer test harness to load the real coordinator/sensor modules and add regression coverage for the polling hand-off

## Testing
- pytest tests/test_import_energy_history.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c80bddc88329b966e5c34c5de0ab