### PR TITLE
Document multi-brand Tevolve API deployments

### DIFF
--- a/docs/termoweb_api.md
+++ b/docs/termoweb_api.md
@@ -1,7 +1,21 @@
 # TermoWeb Cloud API — REST & WebSocket (capture‑verified, 2025‑08‑13)
 
-**Base host**: `https://control.termoweb.net`  
-**Auth**: Bearer token obtained via **POST `/client/token`** (basic client credentials + password grant).  
+**Tevolve app family**: TermoWeb, Ducaheat, and (future) Tevolve white-label the same API shape but talk to separate backend deployments with isolated user databases.
+
+**Backends & OAuth clients**
+
+| App (brand) | Base host | Client ID | Client secret | Notes |
+| --- | --- | --- | --- | --- |
+| TermoWeb | `https://control.termoweb.net` | `52172dc84f63d6c759000005` | `bxv4Z3xUSe` | Legacy/primary deployment. |
+| Ducaheat | `https://api-tevolve.termoweb.net` | `5c49dce977510351506c42db` | `tevolve` | Uses identical endpoints with brand-specific assets. |
+| Tevolve | _TODO_ | _TODO_ | _TODO_ | Placeholder for the third Android app. |
+
+For both implemented apps, Basic client credentials are sent as `Authorization: Basic <base64(client_id:client_secret)>`:
+
+- TermoWeb: `NTIxNzJkYzg0ZjYzZDZjNzU5MDAwMDA1OmJ4djRaM3hVU2U=`
+- Ducaheat: `NWM0OWRjZTk3NzUxMDM1MTUwNmM0MmRiOnRldm9sdmU=`
+
+**Auth**: Bearer token obtained via **POST `/client/token`** (basic client credentials + password grant).
 **Content type**: JSON for all REST endpoints (request/response).
 
 > This document reflects endpoints and behaviours seen in live traffic from the official Android app on 2025‑08‑13. The vendor’s app traffic is treated as authoritative.

--- a/docs/termoweb_openapi.yaml
+++ b/docs/termoweb_openapi.yaml
@@ -2,10 +2,19 @@ openapi: 3.0.3
 info:
   title: "TermoWeb Cloud (capture\u2011verified)"
   version: '2025-08-13'
-  description: "REST endpoints observed from the official Android app on 2025\u2011\
-    08\u201113. Socket.IO is documented at a high level."
+  description: |
+    REST endpoints observed from the official Android app on 2025‑08‑13.
+    Tevolve ships three Android apps (TermoWeb, Ducaheat, Tevolve) that share this API surface but use separate OAuth clients and base URLs.
+    Implemented backends:
+      • TermoWeb → https://control.termoweb.net (client_id 52172dc84f63d6c759000005, secret bxv4Z3xUSe)
+      • Ducaheat → https://api-tevolve.termoweb.net (client_id 5c49dce977510351506c42db, secret tevolve)
+    TODO: Document the Tevolve-branded backend once captured.
 servers:
 - url: https://control.termoweb.net
+  description: TermoWeb production backend (client_id 52172dc84f63d6c759000005)
+- url: https://api-tevolve.termoweb.net
+  description: Ducaheat backend (client_id 5c49dce977510351506c42db)
+# TODO: Add Tevolve backend server entry once implementation is captured.
 components:
   securitySchemes:
     basicAuth:


### PR DESCRIPTION
## Summary
- document the TermoWeb and Ducaheat backend separation, OAuth client IDs, and future Tevolve placeholder in the REST API markdown
- expand the OpenAPI description and servers list to cover both implemented backends and leave a TODO for the third app

## Testing
- `ruff check .` *(fails: pre-existing lint violations such as missing docstrings and private member access warnings)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d42c37f10c8329b5776fc7bed11770