### PR TITLE
Remove unused poll schema helper

### DIFF
--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -37,17 +37,6 @@ async def _get_version(hass: HomeAssistant) -> str:
     return integ.version or "unknown"
 
 
-def _poll_schema(default_poll: int) -> vol.Schema:
-    return vol.Schema(
-        {
-            vol.Required(
-                "poll_interval",
-                default=max(MIN_POLL_INTERVAL, int(default_poll)),
-            ): vol.All(int, vol.Range(min=MIN_POLL_INTERVAL, max=MAX_POLL_INTERVAL)),
-        }
-    )
-
-
 def _login_schema(
     default_user: str = "",
     default_poll: int = DEFAULT_POLL_INTERVAL,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -367,22 +367,6 @@ def test_get_version_returns_unknown_when_missing(
     result = asyncio.run(config_flow._get_version(hass))
 
     assert result == "unknown"
-
-
-def test_poll_schema_enforces_minimum() -> None:
-    below_min = config_flow.MIN_POLL_INTERVAL - 5
-    schema = config_flow._poll_schema(below_min)
-    default = _schema_default(schema, "poll_interval")
-    assert default == config_flow.MIN_POLL_INTERVAL
-
-    with pytest.raises(ValueError):
-        schema({"poll_interval": config_flow.MIN_POLL_INTERVAL - 1})
-
-    assert schema({"poll_interval": config_flow.MIN_POLL_INTERVAL + 10})[
-        "poll_interval"
-    ] == config_flow.MIN_POLL_INTERVAL + 10
-
-
 def test_validate_login_uses_brand_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- remove the unused `_poll_schema` helper from the config flow module
- drop the dedicated `_poll_schema` unit test while leaving other poll interval assertions intact

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d42e7abc388329b8c046a9027be483