### PR TITLE
Refactor heater entities to share common base

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -1,0 +1,193 @@
+"""Shared helpers and base entities for TermoWeb heaters."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+from typing import Any
+
+from homeassistant.core import callback
+from homeassistant.helpers import dispatcher
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, signal_ws_data
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def build_heater_name_map(
+    nodes: Any, default_factory: Callable[[str], str]
+) -> dict[str, str]:
+    """Return a mapping of heater address -> friendly name.
+
+    The TermoWeb API returns node metadata via ``/mgr/nodes``.  Both the
+    climate and sensor platforms previously duplicated the logic that parsed
+    that structure.  The helper tolerates malformed payloads and ensures we
+    keep backwards compatible naming semantics by falling back to the
+    ``default_factory`` when necessary.
+    """
+
+    name_map: dict[str, str] = {}
+
+    node_list = None
+    if isinstance(nodes, dict):
+        node_list = nodes.get("nodes")
+
+    if isinstance(node_list, list):
+        for node in node_list:
+            if not isinstance(node, dict):
+                continue
+            if (node.get("type") or "").lower() != "htr":
+                continue
+
+            addr = node.get("addr")
+            if addr is None:
+                continue
+
+            addr_str = str(addr)
+            raw_name = node.get("name")
+            default_name = default_factory(addr_str)
+            if isinstance(raw_name, str):
+                candidate = raw_name.strip()
+                name_map[addr_str] = candidate or default_name
+            else:
+                name_map[addr_str] = default_name
+
+    return name_map
+
+
+class TermoWebHeaterBase(CoordinatorEntity):
+    """Base entity implementing common TermoWeb heater behaviour."""
+
+    _unsub_ws: dispatcher.DispatcherHandle | None
+
+    def __init__(
+        self,
+        coordinator: Any,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        name: str,
+        unique_id: str | None = None,
+        *,
+        device_name: str | None = None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._dev_id = dev_id
+        self._addr = str(addr)
+        self._attr_name = name
+        self._attr_unique_id = unique_id or f"{DOMAIN}:{dev_id}:htr:{self._addr}"
+        self._device_name = device_name or name
+        self._unsub_ws = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self.hass is None:
+            return
+
+        signal = signal_ws_data(self._entry_id)
+        self._unsub_ws = async_dispatcher_connect(
+            self.hass, signal, self._handle_ws_message
+        )
+        self.async_on_remove(self._remove_ws_listener)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._remove_ws_listener()
+        await super().async_will_remove_from_hass()
+
+    def _remove_ws_listener(self) -> None:
+        if self._unsub_ws is None:
+            return
+        try:
+            self._unsub_ws()
+        except Exception:  # pragma: no cover - defensive
+            _LOGGER.exception(
+                "Failed to remove WS listener for dev=%s addr=%s",
+                self._dev_id,
+                self._addr,
+            )
+        finally:
+            self._unsub_ws = None
+
+    @callback
+    def _handle_ws_message(self, payload: dict) -> None:
+        if not self._payload_matches_heater(payload):
+            return
+        self._handle_ws_event(payload)
+
+    def _payload_matches_heater(self, payload: dict) -> bool:
+        if payload.get("dev_id") != self._dev_id:
+            return False
+        addr = payload.get("addr")
+        if addr is None:
+            return True
+        return str(addr) == self._addr
+
+    @callback
+    def _handle_ws_event(self, _payload: dict) -> None:
+        """Schedule a state refresh after a websocket update."""
+
+        self.schedule_update_ha_state()
+
+    @property
+    def should_poll(self) -> bool:
+        return False
+
+    @property
+    def available(self) -> bool:
+        return self._device_available(self._device_record())
+
+    def _device_available(self, device_entry: dict[str, Any] | None) -> bool:
+        if not isinstance(device_entry, dict):
+            return False
+        return device_entry.get("nodes") is not None
+
+    def _device_record(self) -> dict[str, Any] | None:
+        data = getattr(self.coordinator, "data", {}) or {}
+        getter = getattr(data, "get", None)
+
+        if callable(getter):
+            record = getter(self._dev_id)
+        elif isinstance(data, dict):
+            record = data.get(self._dev_id)
+        else:
+            return None
+
+        return record if isinstance(record, dict) else None
+
+    def _heater_section(self) -> dict[str, Any]:
+        record = self._device_record()
+        if record is None:
+            return {}
+        heaters = record.get("htr")
+        return heaters if isinstance(heaters, dict) else {}
+
+    def heater_settings(self) -> dict[str, Any] | None:
+        settings_map = self._heater_section().get("settings")
+        if not isinstance(settings_map, dict):
+            return None
+        settings = settings_map.get(self._addr)
+        return settings if isinstance(settings, dict) else None
+
+    def _client(self) -> Any:
+        hass_data = self.hass.data.get(DOMAIN, {}).get(self._entry_id, {})
+        return hass_data.get("client")
+
+    def _units(self) -> str:
+        settings = self.heater_settings() or {}
+        units = (settings.get("units") or "C").upper()
+        return "C" if units not in {"C", "F"} else units
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._dev_id, self._addr)},
+            name=self._device_name,
+            manufacturer="TermoWeb",
+            model="Heater",
+            via_device=(DOMAIN, self._dev_id),
+        )
+

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -74,6 +74,7 @@ class TermoWebHeaterBase(CoordinatorEntity):
         *,
         device_name: str | None = None,
     ) -> None:
+        """Initialise a heater entity tied to a TermoWeb device."""
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._dev_id = dev_id
@@ -84,6 +85,7 @@ class TermoWebHeaterBase(CoordinatorEntity):
         self._unsub_ws = None
 
     async def async_added_to_hass(self) -> None:
+        """Subscribe to websocket updates once the entity is added to hass."""
         await super().async_added_to_hass()
         if self.hass is None:
             return
@@ -95,6 +97,7 @@ class TermoWebHeaterBase(CoordinatorEntity):
         self.async_on_remove(self._remove_ws_listener)
 
     async def async_will_remove_from_hass(self) -> None:
+        """Tidy up websocket listeners before the entity is removed."""
         self._remove_ws_listener()
         await super().async_will_remove_from_hass()
 
@@ -134,10 +137,12 @@ class TermoWebHeaterBase(CoordinatorEntity):
 
     @property
     def should_poll(self) -> bool:
+        """Home Assistant should not poll heater entities."""
         return False
 
     @property
     def available(self) -> bool:
+        """Return whether the backing device exposes heater data."""
         return self._device_available(self._device_record())
 
     def _device_available(self, device_entry: dict[str, Any] | None) -> bool:
@@ -152,7 +157,7 @@ class TermoWebHeaterBase(CoordinatorEntity):
         if callable(getter):
             record = getter(self._dev_id)
         elif isinstance(data, dict):
-            record = data.get(self._dev_id)
+            record = dict.get(data, self._dev_id)
         else:
             return None
 
@@ -166,6 +171,7 @@ class TermoWebHeaterBase(CoordinatorEntity):
         return heaters if isinstance(heaters, dict) else {}
 
     def heater_settings(self) -> dict[str, Any] | None:
+        """Return the cached settings for this heater, if available."""
         settings_map = self._heater_section().get("settings")
         if not isinstance(settings_map, dict):
             return None
@@ -183,6 +189,7 @@ class TermoWebHeaterBase(CoordinatorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Expose Home Assistant device metadata for the heater."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._dev_id, self._addr)},
             name=self._device_name,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -386,19 +386,19 @@ def test_heater_properties_and_ws_update() -> None:
 
         assert heater._unsub_ws is not None
         heater.schedule_update_ha_state = MagicMock()
-        heater._on_ws_data({"dev_id": dev_id, "addr": addr})
+        heater._handle_ws_message({"dev_id": dev_id, "addr": addr})
         heater.schedule_update_ha_state.assert_called_once()
 
         heater.schedule_update_ha_state.reset_mock()
-        heater._on_ws_data({"dev_id": "other", "addr": addr})
-        heater._on_ws_data({"dev_id": dev_id, "addr": "B2"})
+        heater._handle_ws_message({"dev_id": "other", "addr": addr})
+        heater._handle_ws_message({"dev_id": dev_id, "addr": "B2"})
         heater.schedule_update_ha_state.assert_not_called()
 
-        heater._on_ws_data({"dev_id": dev_id})
+        heater._handle_ws_message({"dev_id": dev_id})
         heater.schedule_update_ha_state.assert_called_once()
 
         heater.schedule_update_ha_state.reset_mock()
-        heater._on_ws_data({"dev_id": dev_id, "addr": addr})
+        heater._handle_ws_message({"dev_id": dev_id, "addr": addr})
         heater.schedule_update_ha_state.assert_called_once()
 
         async def _pending() -> None:
@@ -406,7 +406,9 @@ def test_heater_properties_and_ws_update() -> None:
 
         task = asyncio.create_task(_pending())
         heater._refresh_fallback = task
-        heater._on_ws_data({"dev_id": dev_id, "addr": addr, "kind": "htr_settings"})
+        heater._handle_ws_message(
+            {"dev_id": dev_id, "addr": addr, "kind": "htr_settings"}
+        )
         await asyncio.sleep(0)
         assert task.cancelled()
         assert heater._refresh_fallback is None

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
-import pytest
+from conftest import _install_stubs
+
+_install_stubs()
 
 from custom_components.termoweb import heater as heater_module
 from homeassistant.core import HomeAssistant
@@ -53,12 +55,19 @@ def test_device_available_requires_nodes_section() -> None:
     assert heater._device_available({"nodes": []})
 
 
-def test_device_record_fallback_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+class _FakeDict(dict):
+    """Dictionary that exposes a non-callable ``get`` attribute."""
+
+    get = "not-callable"
+
+
+def test_device_record_fallback_dict() -> None:
     hass = HomeAssistant()
-    coordinator = SimpleNamespace(hass=hass, data={"dev": {"nodes": "ok"}})
+    coordinator = SimpleNamespace(
+        hass=hass, data=_FakeDict({"dev": {"nodes": "ok"}})
+    )
     heater = _make_heater(coordinator)
 
-    monkeypatch.setitem(heater_module.__dict__, "callable", lambda _obj: False)
     assert heater._device_record() == {"nodes": "ok"}
 
 

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.termoweb import heater as heater_module
+from homeassistant.core import HomeAssistant
+
+TermoWebHeaterBase = heater_module.TermoWebHeaterBase
+build_heater_name_map = heater_module.build_heater_name_map
+
+
+def _make_heater(coordinator: SimpleNamespace) -> TermoWebHeaterBase:
+    return TermoWebHeaterBase(coordinator, "entry", "dev", "A", "Heater A")
+
+
+def test_build_heater_name_map_handles_invalid_entries() -> None:
+    nodes = {
+        "nodes": [
+            123,
+            {"type": "HTR", "addr": None, "name": "Ignored"},
+            {"type": "foo", "addr": "B", "name": "Skip"},
+            {"type": "htr", "addr": 5, "name": "  "},
+            {"type": "htr", "addr": "6", "name": None},
+        ]
+    }
+
+    result = build_heater_name_map(nodes, lambda addr: f"Heater {addr}")
+
+    assert result == {"5": "Heater 5", "6": "Heater 6"}
+
+
+def test_heater_base_async_added_without_hass() -> None:
+    async def _run() -> None:
+        coordinator = SimpleNamespace(hass=None)
+        heater = _make_heater(coordinator)
+
+        assert heater.hass is None
+        await heater.async_added_to_hass()
+        assert heater._unsub_ws is None
+
+    asyncio.run(_run())
+
+
+def test_device_available_requires_nodes_section() -> None:
+    coordinator = SimpleNamespace(hass=None)
+    heater = _make_heater(coordinator)
+
+    assert not heater._device_available(None)
+    assert not heater._device_available({})
+    assert heater._device_available({"nodes": []})
+
+
+def test_device_record_fallback_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = HomeAssistant()
+    coordinator = SimpleNamespace(hass=hass, data={"dev": {"nodes": "ok"}})
+    heater = _make_heater(coordinator)
+
+    monkeypatch.setitem(heater_module.__dict__, "callable", lambda _obj: False)
+    assert heater._device_record() == {"nodes": "ok"}
+
+
+def test_device_record_unknown_structure() -> None:
+    hass = HomeAssistant()
+    coordinator = SimpleNamespace(hass=hass, data=SimpleNamespace())
+    heater = _make_heater(coordinator)
+
+    assert heater._device_record() is None
+
+
+def test_heater_section_handles_missing_device() -> None:
+    hass = HomeAssistant()
+    coordinator = SimpleNamespace(hass=hass, data={})
+    heater = _make_heater(coordinator)
+
+    assert heater._heater_section() == {}
+
+
+def test_heater_settings_missing_mapping() -> None:
+    hass = HomeAssistant()
+    coordinator = SimpleNamespace(
+        hass=hass, data={"dev": {"htr": {"settings": []}}}
+    )
+    heater = _make_heater(coordinator)
+
+    assert heater.heater_settings() is None


### PR DESCRIPTION
## Summary
- add a shared `TermoWebHeaterBase` and name-map helper for heater entities
- refactor the climate and heater sensor platforms to inherit from the new base
- update heater climate and sensor tests to cover the shared websocket and availability logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d44d1c0c4883299133db322fc82a69