### PR TITLE
refactor: introduce brand-aware backend layer (no functional change)

### DIFF
--- a/custom_components/termoweb/backend/__init__.py
+++ b/custom_components/termoweb/backend/__init__.py
@@ -1,0 +1,7 @@
+"""Backend package exports."""
+from __future__ import annotations
+
+from .base import Backend, HttpClientProto, WsClientProto
+from .factory import create_backend
+
+__all__ = ["Backend", "HttpClientProto", "WsClientProto", "create_backend"]

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -1,0 +1,83 @@
+"""Backend abstractions for brand-specific behavior."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from asyncio import Task
+from typing import Any, Protocol
+
+
+class HttpClientProto(Protocol):
+    """Protocol for the HTTP client used by TermoWeb entities."""
+
+    async def list_devices(self) -> list[dict[str, Any]]:
+        """Return the list of devices associated with the account."""
+
+    async def get_nodes(self, dev_id: str) -> Any:
+        """Return the node description for the given device."""
+
+    async def get_htr_settings(self, dev_id: str, addr: str | int) -> Any:
+        """Return heater settings for the specified node."""
+
+    async def set_htr_settings(
+        self,
+        dev_id: str,
+        addr: str | int,
+        *,
+        mode: str | None = None,
+        stemp: float | None = None,
+        prog: list[int] | None = None,
+        ptemp: list[float] | None = None,
+        units: str = "C",
+    ) -> Any:
+        """Update heater settings for the specified node."""
+
+    async def get_htr_samples(
+        self,
+        dev_id: str,
+        addr: str | int,
+        start: float,
+        stop: float,
+    ) -> list[dict[str, str | int]]:
+        """Return historical heater samples for the specified node."""
+
+
+class WsClientProto(Protocol):
+    """Protocol for websocket clients used by the integration."""
+
+    def start(self) -> Task[Any]:
+        """Start the websocket client."""
+
+    async def stop(self) -> None:
+        """Stop the websocket client."""
+
+
+class Backend(ABC):
+    """Base class for brand-specific integration backends."""
+
+    def __init__(self, *, brand: str, client: HttpClientProto) -> None:
+        """Initialize backend metadata."""
+
+        self._brand = brand
+        self._client = client
+
+    @property
+    def brand(self) -> str:
+        """Return the configured brand."""
+
+        return self._brand
+
+    @property
+    def client(self) -> HttpClientProto:
+        """Return the HTTP client associated with this backend."""
+
+        return self._client
+
+    @abstractmethod
+    def create_ws_client(
+        self,
+        hass: Any,
+        entry_id: str,
+        dev_id: str,
+        coordinator: Any,
+    ) -> WsClientProto:
+        """Create a websocket client for the given device."""

--- a/custom_components/termoweb/backend/factory.py
+++ b/custom_components/termoweb/backend/factory.py
@@ -1,0 +1,11 @@
+"""Backend factory."""
+from __future__ import annotations
+
+from .base import Backend, HttpClientProto
+from .termoweb import TermoWebBackend
+
+
+def create_backend(*, brand: str, client: HttpClientProto) -> Backend:
+    """Create a backend for the given brand."""
+
+    return TermoWebBackend(brand=brand, client=client)

--- a/custom_components/termoweb/backend/termoweb.py
+++ b/custom_components/termoweb/backend/termoweb.py
@@ -1,0 +1,37 @@
+"""TermoWeb backend implementation."""
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+from .base import Backend, WsClientProto
+
+
+class TermoWebBackend(Backend):
+    """Backend for the TermoWeb brand."""
+
+    def _resolve_ws_client_cls(self) -> type[Any]:
+        module = import_module("custom_components.termoweb.__init__")
+        ws_cls = getattr(module, "TermoWebWSLegacyClient", None)
+        if ws_cls is None:
+            legacy_module = import_module("custom_components.termoweb.ws_client_legacy")
+            ws_cls = legacy_module.TermoWebWSLegacyClient
+        return ws_cls
+
+    def create_ws_client(
+        self,
+        hass: Any,
+        entry_id: str,
+        dev_id: str,
+        coordinator: Any,
+    ) -> WsClientProto:
+        """Instantiate the legacy websocket client used by TermoWeb."""
+
+        ws_cls = self._resolve_ws_client_cls()
+        return ws_cls(
+            hass,
+            entry_id=entry_id,
+            dev_id=dev_id,
+            api_client=self.client,
+            coordinator=coordinator,
+        )

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from .api import TermoWebAuthError, TermoWebClient, TermoWebRateLimitError
 from .const import (
-    BRAND_DUCAHEAT,
+    BRAND_DUCAHEAT as CONST_BRAND_DUCAHEAT,
     BRAND_LABELS,
     BRAND_TERMOWEB,
     CONF_BRAND,
@@ -27,6 +27,8 @@ from .const import (
     get_brand_basic_auth,
     get_brand_label,
 )
+
+BRAND_DUCAHEAT = CONST_BRAND_DUCAHEAT
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.termoweb.backend import create_backend
+from custom_components.termoweb.backend.termoweb import TermoWebBackend
+from custom_components.termoweb.ws_client_legacy import TermoWebWSLegacyClient
+
+
+class DummyHttpClient:
+    def __init__(self) -> None:
+        self._session = SimpleNamespace()  # needed by WS client
+
+    async def list_devices(self) -> list[dict[str, Any]]:
+        return []
+
+    async def get_nodes(self, dev_id: str) -> dict[str, Any]:
+        return {"dev_id": dev_id}
+
+    async def get_htr_settings(self, dev_id: str, addr: str | int) -> dict[str, Any]:
+        return {"dev_id": dev_id, "addr": addr}
+
+    async def set_htr_settings(
+        self,
+        dev_id: str,
+        addr: str | int,
+        *,
+        mode: str | None = None,
+        stemp: float | None = None,
+        prog: list[int] | None = None,
+        ptemp: list[float] | None = None,
+        units: str = "C",
+    ) -> dict[str, Any]:
+        return {
+            "dev_id": dev_id,
+            "addr": addr,
+            "mode": mode,
+            "stemp": stemp,
+            "prog": prog,
+            "ptemp": ptemp,
+            "units": units,
+        }
+
+    async def get_htr_samples(
+        self,
+        dev_id: str,
+        addr: str | int,
+        start: float,
+        stop: float,
+    ) -> list[dict[str, str | int]]:
+        return [{"t": int(start), "counter": "1"}, {"t": int(stop), "counter": "2"}]
+
+
+def test_create_backend_returns_termoweb_backend() -> None:
+    client = DummyHttpClient()
+    backend = create_backend(brand="termoweb", client=client)
+    assert isinstance(backend, TermoWebBackend)
+    assert backend.brand == "termoweb"
+    assert backend.client is client
+
+
+def test_termoweb_backend_creates_ws_client() -> None:
+    client = DummyHttpClient()
+    backend = TermoWebBackend(brand="termoweb", client=client)
+    coordinator = object()
+    loop = asyncio.new_event_loop()
+    try:
+        fake_hass = SimpleNamespace(loop=loop)
+        ws_client = backend.create_ws_client(
+            fake_hass,
+            entry_id="entry123",
+            dev_id="device456",
+            coordinator=coordinator,
+        )
+    finally:
+        loop.close()
+
+    assert isinstance(ws_client, TermoWebWSLegacyClient)
+    assert ws_client.dev_id == "device456"
+    assert ws_client.entry_id == "entry123"
+    assert ws_client._coordinator is coordinator
+
+
+def test_termoweb_backend_fallback_ws_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    import custom_components.termoweb as init_module
+
+    monkeypatch.setattr(init_module, "TermoWebWSLegacyClient", None)
+    client = DummyHttpClient()
+    backend = TermoWebBackend(brand="termoweb", client=client)
+    loop = asyncio.new_event_loop()
+    try:
+        fake_hass = SimpleNamespace(loop=loop)
+        ws_client = backend.create_ws_client(
+            fake_hass,
+            entry_id="entry456",
+            dev_id="dev789",
+            coordinator=object(),
+        )
+    finally:
+        loop.close()
+
+    assert isinstance(ws_client, TermoWebWSLegacyClient)


### PR DESCRIPTION
## Summary
- add a backend package that abstracts brand-specific websocket instantiation
- update setup logic to create and store the backend while preserving existing client access
- ensure config flow exports BRAND_DUCAHEAT and add unit tests covering the backend factory

## Testing
- `ruff check custom_components/termoweb/backend tests/test_backend_factory.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d52c514cfc8329a94c1345b9960d30