### PR TITLE
feat(ws): add Ducaheat WS v2 client (skeleton) behind backend interface

### DIFF
--- a/custom_components/termoweb/backend/factory.py
+++ b/custom_components/termoweb/backend/factory.py
@@ -1,11 +1,15 @@
 """Backend factory."""
+
 from __future__ import annotations
 
 from .base import Backend, HttpClientProto
 from .termoweb import TermoWebBackend
 
 
-def create_backend(*, brand: str, client: HttpClientProto) -> Backend:
+def create_backend(
+    *, brand: str, client: HttpClientProto, ws_impl: str | None = None
+) -> Backend:
     """Create a backend for the given brand."""
 
+    _ = ws_impl  # placeholder until Ducaheat WS is wired in
     return TermoWebBackend(brand=brand, client=client)

--- a/custom_components/termoweb/ws_client_v2.py
+++ b/custom_components/termoweb/ws_client_v2.py
@@ -1,0 +1,222 @@
+"""Ducaheat WebSocket client skeleton used for testing infrastructure."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+import json
+import logging
+import time
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .api import TermoWebClient
+from .const import API_BASE, DOMAIN, signal_ws_data, signal_ws_status
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DucaheatWSClient:
+    """Minimal Socket.IO v2 client skeleton for Ducaheat cloud."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry_id: str,
+        dev_id: str,
+        api_client: TermoWebClient,
+        coordinator: Any,
+    ) -> None:
+        """Initialize the client."""
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self._client = api_client
+        self._coordinator = coordinator
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+        self._closing = False
+
+        self._status: str = "stopped"
+        self._last_event_at: float | None = None
+        self._healthy_since: float | None = None
+        self._handshake: dict[str, Any] | None = None
+        self._nodes: dict[str, Any] = {}
+
+        domain_bucket = self.hass.data.setdefault(DOMAIN, {})
+        entry_bucket = domain_bucket.setdefault(self.entry_id, {})
+        entry_bucket.setdefault("ws_state", {})
+
+    def start(self) -> asyncio.Task:
+        """Start the background runner."""
+        if self._task and not self._task.done():
+            return self._task
+        _LOGGER.info("WS %s: starting Ducaheat client", self.dev_id)
+        self._closing = False
+        self._stop_event = asyncio.Event()
+        self._task = self.hass.loop.create_task(
+            self._runner(), name=f"{DOMAIN}-ws-v2-{self.dev_id}"
+        )
+        return self._task
+
+    async def stop(self) -> None:
+        """Stop the runner."""
+        if self._task is None:
+            self._update_status("stopped")
+            return
+        _LOGGER.info("WS %s: stopping Ducaheat client", self.dev_id)
+        self._closing = True
+        self._stop_event.set()
+        task = self._task
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+
+    async def ws_url(self) -> str:
+        """Return the websocket URL using the API client's token helper."""
+        headers = await self._client._authed_headers()  # noqa: SLF001
+        token: str | None = None
+        auth_header = (
+            headers.get("Authorization") if isinstance(headers, dict) else None
+        )
+        if isinstance(auth_header, str):
+            parts = auth_header.split(" ", 1)
+            token = parts[1] if len(parts) == 2 else parts[0]
+        if not token:
+            raise RuntimeError("missing access token for WS connection")
+        base = getattr(self._client, "api_base", None)
+        api_base = base.rstrip("/") if isinstance(base, str) and base else API_BASE
+        return f"{api_base}/api/v2/socket_io?token={token}"
+
+    async def _runner(self) -> None:
+        """Background task waiting for stop events."""
+        self._healthy_since = None
+        self._last_event_at = None
+        self._nodes = {}
+        self._update_status("connecting")
+        try:
+            await self._stop_event.wait()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._update_status("stopped")
+
+    def _on_frame(self, payload: str) -> None:
+        """Process an incoming Socket.IO frame."""
+        try:
+            message = json.loads(payload)
+        except json.JSONDecodeError:
+            _LOGGER.debug("WS %s: ignoring non-JSON frame", self.dev_id)
+            return
+        if not isinstance(message, dict):
+            _LOGGER.debug("WS %s: ignoring non-dict frame", self.dev_id)
+            return
+        event = message.get("event")
+        data = message.get("data")
+        if event == "dev_handshake":
+            self._handle_handshake(data)
+        elif event == "dev_data":
+            self._handle_dev_data(data)
+        elif event == "update":
+            self._handle_update(data)
+        else:
+            _LOGGER.debug("WS %s: unhandled event %s", self.dev_id, event)
+
+    def _handle_handshake(self, data: Any) -> None:
+        if isinstance(data, dict):
+            self._handshake = deepcopy(data)
+            self._update_status("connected")
+        else:
+            _LOGGER.debug("WS %s: invalid handshake payload", self.dev_id)
+
+    def _handle_dev_data(self, data: Any) -> None:
+        nodes = self._extract_nodes(data)
+        if nodes is None:
+            _LOGGER.debug("WS %s: dev_data without nodes", self.dev_id)
+            return
+        self._nodes = deepcopy(nodes)
+        self._dispatch_nodes(self._nodes)
+        self._mark_event()
+
+    def _handle_update(self, data: Any) -> None:
+        nodes = self._extract_nodes(data)
+        if nodes is None:
+            _LOGGER.debug("WS %s: update without nodes", self.dev_id)
+            return
+        if not self._nodes:
+            self._nodes = deepcopy(nodes)
+        else:
+            self._merge_nodes(self._nodes, nodes)
+        self._dispatch_nodes(self._nodes)
+        self._mark_event()
+
+    def _extract_nodes(self, data: Any) -> dict[str, Any] | None:
+        if not isinstance(data, dict):
+            return None
+        nodes = data.get("nodes")
+        if isinstance(nodes, dict):
+            return nodes
+        return None
+
+    def _dispatch_nodes(self, nodes: dict[str, Any]) -> None:
+        payload = {"dev_id": self.dev_id, "nodes": deepcopy(nodes)}
+
+        def _send() -> None:
+            async_dispatcher_send(
+                self.hass,
+                signal_ws_data(self.entry_id),
+                payload,
+            )
+
+        self.hass.loop.call_soon_threadsafe(_send)
+
+    def _mark_event(self) -> None:
+        now = time.time()
+        self._last_event_at = now
+        if self._healthy_since is None:
+            self._healthy_since = now
+        self._update_status("healthy")
+
+    @staticmethod
+    def _merge_nodes(target: dict[str, Any], source: dict[str, Any]) -> None:
+        for key, value in source.items():
+            if isinstance(value, dict):
+                existing = target.get(key)
+                if isinstance(existing, dict):
+                    DucaheatWSClient._merge_nodes(existing, value)
+                else:
+                    target[key] = deepcopy(value)
+            else:
+                target[key] = value
+
+    def _update_status(self, status: str) -> None:
+        if status == self._status and status != "healthy":
+            return
+        self._status = status
+        now = time.time()
+        domain_bucket: dict[str, Any] = self.hass.data.setdefault(DOMAIN, {})
+        entry_bucket: dict[str, Any] = domain_bucket.setdefault(self.entry_id, {})
+        ws_bucket: dict[str, dict[str, Any]] = entry_bucket.setdefault("ws_state", {})
+        dev_bucket: dict[str, Any] = ws_bucket.setdefault(self.dev_id, {})
+        dev_bucket["status"] = status
+        dev_bucket["last_event_at"] = self._last_event_at
+        dev_bucket["healthy_since"] = self._healthy_since
+        dev_bucket["healthy_minutes"] = (
+            int((now - self._healthy_since) / 60) if self._healthy_since else 0
+        )
+
+        status_payload = {"dev_id": self.dev_id, "status": status}
+
+        def _send() -> None:
+            async_dispatcher_send(
+                self.hass,
+                signal_ws_status(self.entry_id),
+                status_payload,
+            )
+
+        self.hass.loop.call_soon_threadsafe(_send)

--- a/tests/test_ws_client_v2.py
+++ b/tests/test_ws_client_v2.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+
+import pytest
+
+import custom_components.termoweb.ws_client_v2 as ws_v2
+
+
+def test_ducaheat_ws_client_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    dispatcher_calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_dispatcher(hass, signal: str, payload: dict[str, object]) -> None:
+        dispatcher_calls.append((signal, payload))
+
+    monkeypatch.setattr(ws_v2, "async_dispatcher_send", fake_dispatcher)
+
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        hass = types.SimpleNamespace(
+            loop=loop,
+            data={ws_v2.DOMAIN: {"entry": {"ws_state": {}}}},
+        )
+        coordinator = types.SimpleNamespace()
+
+        class FakeClient:
+            api_base = "https://api-tevolve.termoweb.net/"
+
+            async def _authed_headers(self) -> dict[str, str]:
+                return {"Authorization": "Bearer tok"}
+
+        client = ws_v2.DucaheatWSClient(
+            hass,
+            entry_id="entry",
+            dev_id="dev",
+            api_client=FakeClient(),
+            coordinator=coordinator,
+        )
+
+        url = await client.ws_url()
+        assert url == "https://api-tevolve.termoweb.net/api/v2/socket_io?token=tok"
+
+        task = client.start()
+        assert isinstance(task, asyncio.Task)
+        await asyncio.sleep(0)
+
+        handshake_payload = {"devs": [{"id": "dev"}], "permissions": {"dev": ["read"]}}
+        client._on_frame(
+            json.dumps({"event": "dev_handshake", "data": handshake_payload})
+        )
+        await asyncio.sleep(0)
+        handshake_payload["devs"][0]["id"] = "mutated"
+        assert client._handshake is not None
+        assert client._handshake["devs"][0]["id"] == "dev"
+
+        initial_update = {"nodes": {"htr": {"status": {"01": {"temp": 20}}}}}
+        client._on_frame(json.dumps({"event": "update", "data": initial_update}))
+        await asyncio.sleep(0)
+
+        dev_data_payload = {
+            "nodes": {
+                "htr": {"status": {"01": {"temp": 20}}},
+                "raw": {"meta": {"foo": "bar"}},
+            }
+        }
+        client._on_frame(json.dumps({"event": "dev_data", "data": dev_data_payload}))
+        await asyncio.sleep(0)
+
+        incremental_update = {
+            "nodes": {
+                "htr": {"status": {"02": {"temp": 21}}},
+                "raw": {"meta": {"foo": "bar", "extra": True}},
+                "metrics": 3,
+            }
+        }
+        client._on_frame(json.dumps({"event": "update", "data": incremental_update}))
+        await asyncio.sleep(0)
+
+        client._on_frame(json.dumps({"event": "update", "data": None}))
+        client._on_frame(json.dumps({"event": "unknown", "data": {}}))
+        client._on_frame(json.dumps("literal"))
+        client._on_frame("not-json")
+        await asyncio.sleep(0)
+
+        await client.stop()
+        await asyncio.sleep(0)
+
+        status_signal = ws_v2.signal_ws_status("entry")
+        data_signal = ws_v2.signal_ws_data("entry")
+
+        status_updates = [
+            payload["status"]
+            for signal, payload in dispatcher_calls
+            if signal == status_signal
+        ]
+        assert status_updates == [
+            "connecting",
+            "connected",
+            "healthy",
+            "healthy",
+            "healthy",
+            "stopped",
+        ]
+
+        data_payloads = [
+            payload for signal, payload in dispatcher_calls if signal == data_signal
+        ]
+        assert len(data_payloads) == 3
+        assert data_payloads[0]["nodes"] == initial_update["nodes"]
+        assert data_payloads[1]["nodes"] == dev_data_payload["nodes"]
+        assert data_payloads[2]["nodes"]["htr"]["status"] == {
+            "01": {"temp": 20},
+            "02": {"temp": 21},
+        }
+        assert data_payloads[2]["nodes"]["raw"] == {
+            "meta": {"foo": "bar", "extra": True},
+        }
+        assert data_payloads[2]["nodes"]["metrics"] == 3
+        for payload in data_payloads:
+            assert payload["dev_id"] == "dev"
+            assert payload["nodes"] is not client._nodes
+
+        assert client._nodes["htr"]["status"]["02"]["temp"] == 21
+        assert client._healthy_since is not None
+        assert client._status == "stopped"
+
+    asyncio.run(_run())
+
+
+def test_ws_url_requires_token() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        hass = types.SimpleNamespace(
+            loop=loop,
+            data={ws_v2.DOMAIN: {"entry": {"ws_state": {}}}},
+        )
+        coordinator = types.SimpleNamespace()
+
+        class NoTokenClient:
+            async def _authed_headers(self) -> dict[str, str]:
+                return {}
+
+        client = ws_v2.DucaheatWSClient(
+            hass,
+            entry_id="entry",
+            dev_id="dev",
+            api_client=NoTokenClient(),
+            coordinator=coordinator,
+        )
+
+        with pytest.raises(RuntimeError):
+            await client.ws_url()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a DucaheatWSClient skeleton that handles handshake, data/update frames, and dispatches Home Assistant signals with healthy status tracking
- cover the new client with dedicated tests that simulate Socket.IO frames and validate dispatcher payloads and error paths
- extend the backend factory signature with an optional ws_impl placeholder for future wiring

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d53660d71c8329ad10a797a6fff455