### PR TITLE
Add node hierarchy and tests

### DIFF
--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -1,0 +1,156 @@
+"""Node model abstractions for TermoWeb devices."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .const import BRAND_DUCAHEAT
+
+
+class Node:
+    """Base representation of a TermoWeb node."""
+
+    __slots__ = ("_node_name", "addr", "brand", "type")
+    NODE_TYPE = ""
+
+    def __init__(
+        self,
+        *,
+        name: str | None,
+        addr: str | int,
+        brand: str,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise a node with normalised metadata."""
+
+        resolved_type = (node_type or self.NODE_TYPE or "").strip().lower()
+        if not resolved_type:
+            msg = "node_type must be provided"
+            raise ValueError(msg)
+
+        addr_str = str(addr).strip()
+        if not addr_str:
+            msg = "addr must be provided"
+            raise ValueError(msg)
+
+        brand_str = str(brand or "").strip()
+        if not brand_str:
+            msg = "brand must be provided"
+            raise ValueError(msg)
+
+        self.addr = addr_str
+        self.type = resolved_type
+        self.brand = brand_str
+        self._node_name = ""
+        self.name = name if name is not None else ""
+
+    @property
+    def name(self) -> str:
+        """Return the friendly name for the node."""
+
+        attr_name = getattr(self, "_attr_name", None)
+        if isinstance(attr_name, str) and attr_name.strip():
+            return attr_name
+        return self._node_name
+
+    @name.setter
+    def name(self, value: str | None) -> None:
+        cleaned = str(value or "").strip()
+        self._node_name = cleaned
+        if hasattr(self, "_attr_name"):
+            self._attr_name = cleaned
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of core node metadata."""
+
+        return {
+            "name": self.name,
+            "addr": self.addr,
+            "type": self.type,
+            "brand": self.brand,
+        }
+
+
+class HeaterNode(Node):
+    """Heater node (type ``htr``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "htr"
+
+    def __init__(self, *, name: str | None, addr: str | int, brand: str) -> None:
+        """Initialise a heater node."""
+
+        super().__init__(name=name, addr=addr, brand=brand)
+
+    def supports_boost(self) -> bool:
+        """Return whether the node natively exposes boost/runback control."""
+
+        return False
+
+
+class AccumulatorNode(HeaterNode):
+    """Storage heater / accumulator node (type ``acm``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "acm"
+
+    def supports_boost(self) -> bool:
+        """Return whether the accumulator exposes boost/runback."""
+
+        return False
+
+
+class DucaheatAccum(AccumulatorNode):
+    """Accumulator node for the Ducaheat brand supporting boost."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        *,
+        name: str | None,
+        addr: str | int,
+        brand: str = BRAND_DUCAHEAT,
+    ) -> None:
+        """Initialise a Ducaheat accumulator node."""
+
+        super().__init__(name=name, addr=addr, brand=brand)
+
+    def supports_boost(self) -> bool:
+        """Return ``True`` to indicate boost is available."""
+
+        return True
+
+
+class PowerMonitorNode(Node):
+    """Power monitor node (type ``pmo``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "pmo"
+
+    def __init__(self, *, name: str | None, addr: str | int, brand: str) -> None:
+        """Initialise a power monitor node."""
+
+        super().__init__(name=name, addr=addr, brand=brand)
+
+    def power_level(self) -> float:
+        """Return the reported power level (stub)."""
+
+        raise NotImplementedError
+
+
+class ThermostatNode(Node):
+    """Thermostat node (type ``thm``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "thm"
+
+    def __init__(self, *, name: str | None, addr: str | int, brand: str) -> None:
+        """Initialise a thermostat node."""
+
+        super().__init__(name=name, addr=addr, brand=brand)
+
+    def capabilities(self) -> dict[str, Any]:
+        """Return thermostat capabilities (stub)."""
+
+        raise NotImplementedError

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -17,7 +17,8 @@ from conftest import _install_stubs
 _install_stubs()
 
 from custom_components.termoweb import climate as climate_module
-from custom_components.termoweb.const import DOMAIN, signal_ws_data
+from custom_components.termoweb.const import BRAND_TERMOWEB, DOMAIN, signal_ws_data
+from custom_components.termoweb.nodes import HeaterNode
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -51,6 +52,27 @@ class FakeCoordinator:
         return None
 
 
+def test_termoweb_heater_is_heater_node() -> None:
+    _reset_environment()
+    hass = HomeAssistant()
+    coordinator = FakeCoordinator(hass, {"dev": {"htr": {"settings": {}}, "nodes": {}}})
+
+    heater = TermoWebHeater(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        " Living Room ",
+        brand=BRAND_TERMOWEB,
+    )
+
+    assert isinstance(heater, HeaterNode)
+    assert heater.type == "htr"
+    assert heater.addr == "1"
+    assert heater.brand == BRAND_TERMOWEB
+    assert heater.name == "Living Room"
+
+
 def test_async_setup_entry_creates_entities() -> None:
     async def _run() -> None:
         _reset_environment()
@@ -79,6 +101,7 @@ def test_async_setup_entry_creates_entities() -> None:
                     "nodes": nodes,
                     "htr_addrs": addrs,
                     "version": "3.1.4",
+                    "brand": BRAND_TERMOWEB,
                 }
             }
         }

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,60 @@
+"""Unit tests for node models."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.termoweb.const import BRAND_DUCAHEAT, BRAND_TERMOWEB
+from custom_components.termoweb.nodes import (
+    AccumulatorNode,
+    DucaheatAccum,
+    HeaterNode,
+    PowerMonitorNode,
+    ThermostatNode,
+)
+
+
+def test_heater_node_normalises_inputs() -> None:
+    node = HeaterNode(name=" Living ", addr=2, brand=BRAND_TERMOWEB)
+
+    assert node.name == "Living"
+    assert node.addr == "2"
+    assert node.type == "htr"
+    assert node.brand == BRAND_TERMOWEB
+    assert node.supports_boost() is False
+
+
+def test_accumulator_node_defaults() -> None:
+    node = AccumulatorNode(name=None, addr="007", brand=BRAND_TERMOWEB)
+
+    assert node.name == ""
+    assert node.addr == "007"
+    assert node.type == "acm"
+    assert node.supports_boost() is False
+
+
+def test_ducaheat_accum_supports_boost() -> None:
+    node = DucaheatAccum(name="Tank", addr="4")
+
+    assert node.brand == BRAND_DUCAHEAT
+    assert node.type == "acm"
+    assert node.supports_boost() is True
+
+
+def test_power_monitor_stub() -> None:
+    node = PowerMonitorNode(name="Monitor", addr="P1", brand=BRAND_TERMOWEB)
+
+    with pytest.raises(NotImplementedError):
+        node.power_level()
+
+
+def test_thermostat_stub() -> None:
+    node = ThermostatNode(name="Thermostat", addr="T1", brand=BRAND_TERMOWEB)
+
+    with pytest.raises(NotImplementedError):
+        node.capabilities()
+
+
+def test_node_requires_brand() -> None:
+    with pytest.raises(ValueError):
+        HeaterNode(name="Living", addr=1, brand="")


### PR DESCRIPTION
## Summary
- introduce a reusable node hierarchy with heater/accumulator/power monitor/thermostat specialisations plus a Ducaheat accumulator stub
- update the climate entity to mix in the heater node, plumb through brand metadata, and cover the new behaviour with tests

## Testing
- ruff check custom_components/termoweb/nodes.py tests/test_nodes.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d552ef22dc8329b5db3338cfbf9b90