### PR TITLE
Add node inventory builder and refactor address utilities

### DIFF
--- a/custom_components/termoweb/ws_client_legacy.py
+++ b/custom_components/termoweb/ws_client_legacy.py
@@ -14,7 +14,8 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .api import RESTClient
 from .const import API_BASE, DOMAIN, WS_NAMESPACE, signal_ws_data, signal_ws_status
-from .utils import extract_heater_addrs
+from .nodes import build_node_inventory
+from .utils import HEATER_NODE_TYPES, addresses_by_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -424,9 +425,28 @@ class WebSocket09Client:
                 # body is nodes payload
                 if isinstance(body, dict):
                     dev_map["nodes"] = body
-                    addrs = extract_heater_addrs(body)
+                    brand = getattr(self._coordinator, "brand", "")
+                    inventory: list[Any] = []
+                    if isinstance(brand, str) and brand:
+                        try:
+                            inventory = build_node_inventory(body, brand)
+                        except ValueError as err:  # pragma: no cover - defensive
+                            _LOGGER.debug(
+                                "WS %s: failed to build node inventory: %s",
+                                self.dev_id,
+                                err,
+                                exc_info=err,
+                            )
+                    addrs = addresses_by_type(inventory, HEATER_NODE_TYPES)
                     dev_map.setdefault("htr", {}).setdefault("settings", {})
                     dev_map["htr"]["addrs"] = addrs
+                    if hasattr(self._coordinator, "update_nodes"):
+                        self._coordinator.update_nodes(body, inventory)
+                    record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
+                    if isinstance(record, dict):
+                        record["nodes"] = body
+                        record["node_inventory"] = inventory
+                        record["htr_addrs"] = addrs
                     updated_nodes = True
 
             elif "/htr/" in path and path.endswith("/settings"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,32 +2,25 @@ from __future__ import annotations
 
 import pytest
 
-import custom_components.termoweb.utils as utils
-from custom_components.termoweb.utils import float_or_none
+from custom_components.termoweb.const import BRAND_TERMOWEB
+from custom_components.termoweb.nodes import build_node_inventory
+from custom_components.termoweb.utils import HEATER_NODE_TYPES, addresses_by_type, float_or_none
 
 
-def test_extract_heater_addrs() -> None:
-    extract = utils.extract_heater_addrs
+def test_addresses_by_type_filters_and_deduplicates() -> None:
+    inventory = build_node_inventory(
+        {
+            "nodes": [
+                {"type": "htr", "addr": "A"},
+                {"type": "foo", "addr": "B"},
+                {"type": "acm", "addr": 1},
+                {"type": "HTR", "addr": "A"},
+            ]
+        },
+        BRAND_TERMOWEB,
+    )
 
-    assert extract({}) == []
-
-    nodes = {
-        "nodes": [
-            {"type": "htr", "addr": "A"},
-            {"type": "foo", "addr": "B"},
-            {"type": "HTR", "addr": 1},
-        ]
-    }
-
-    assert extract(nodes) == ["A", "1"]
-
-
-def test_extract_heater_addrs_deduplicates() -> None:
-    extract = utils.extract_heater_addrs
-
-    nodes = {"nodes": [{"type": "htr", "addr": "A"}, {"type": "HTR", "addr": "A"}]}
-
-    assert extract(nodes) == ["A"]
+    assert addresses_by_type(inventory, HEATER_NODE_TYPES) == ["A", "1"]
 
 
 


### PR DESCRIPTION
## Summary
- add a node factory/registry and inventory builder that normalises metadata and logs unsupported types
- reuse the inventory when deriving heater addresses and persist the normalised nodes in setup and websocket updates
- expand tests to cover mixed node payloads, deduplicated addresses, and updated setup fixtures

## Testing
- pytest tests/test_nodes.py tests/test_utils.py tests/test_init_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d694036a6c83298a6a872402654da6