### PR TITLE
Add node-aware HTTP helpers and update Ducaheat API handling

### DIFF
--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -5,6 +5,10 @@ from abc import ABC, abstractmethod
 from asyncio import Task
 from typing import Any, Protocol
 
+from ..nodes import Node
+
+NodeDescriptor = Node | tuple[str, str | int]
+
 
 class HttpClientProto(Protocol):
     """Protocol for the HTTP client used by TermoWeb entities."""
@@ -14,6 +18,31 @@ class HttpClientProto(Protocol):
 
     async def get_nodes(self, dev_id: str) -> Any:
         """Return the node description for the given device."""
+
+    async def get_node_settings(self, dev_id: str, node: NodeDescriptor) -> Any:
+        """Return settings for the specified node."""
+
+    async def set_node_settings(
+        self,
+        dev_id: str,
+        node: NodeDescriptor,
+        *,
+        mode: str | None = None,
+        stemp: float | None = None,
+        prog: list[int] | None = None,
+        ptemp: list[float] | None = None,
+        units: str = "C",
+    ) -> Any:
+        """Update node settings for the specified node."""
+
+    async def get_node_samples(
+        self,
+        dev_id: str,
+        node: NodeDescriptor,
+        start: float,
+        stop: float,
+    ) -> list[dict[str, str | int]]:
+        """Return historical samples for the specified node."""
 
     async def get_htr_settings(self, dev_id: str, addr: str | int) -> Any:
         """Return heater settings for the specified node."""

--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -15,7 +15,7 @@ CONNECTED_PATH_FMT: Final = (
     "/api/v2/devs/{dev_id}/connected"  # some fw return 404; we tolerate
 )
 NODES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/mgr/nodes"
-HTR_SAMPLES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/htr/{addr}/samples"
+NODE_SAMPLES_PATH_FMT: Final = "/api/v2/devs/{dev_id}/{node_type}/{addr}/samples"
 
 # Public client creds (from APK v2.5.1)
 BASIC_AUTH_B64: Final = "NTIxNzJkYzg0ZjYzZDZjNzU5MDAwMDA1OmJ4djRaM3hVU2U="

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -12,13 +12,16 @@ class DummyClient:
     async def get_nodes(self, dev_id: str) -> dict[str, object]:
         return {"dev_id": dev_id}
 
-    async def get_htr_settings(self, dev_id: str, addr: str | int) -> dict[str, object]:
-        return {"dev_id": dev_id, "addr": addr}
+    async def get_node_settings(
+        self, dev_id: str, node: tuple[str, str | int]
+    ) -> dict[str, object]:
+        node_type, addr = node
+        return {"dev_id": dev_id, "addr": addr, "type": node_type}
 
-    async def set_htr_settings(
+    async def set_node_settings(
         self,
         dev_id: str,
-        addr: str | int,
+        node: tuple[str, str | int],
         *,
         mode: str | None = None,
         stemp: float | None = None,
@@ -28,10 +31,10 @@ class DummyClient:
     ) -> dict[str, object]:
         return {}
 
-    async def get_htr_samples(
+    async def get_node_samples(
         self,
         dev_id: str,
-        addr: str | int,
+        node: tuple[str, str | int],
         start: float,
         stop: float,
     ) -> list[dict[str, object]]:
@@ -58,3 +61,14 @@ def test_ducaheat_backend_creates_ws_client() -> None:
     assert isinstance(ws_client, DucaheatWSClient)
     assert ws_client.dev_id == "dev"
     assert ws_client.entry_id == "entry"
+
+
+def test_dummy_client_get_node_settings_accepts_acm() -> None:
+    client = DummyClient()
+
+    async def _run() -> dict[str, object]:
+        return await client.get_node_settings("dev", ("acm", "3"))
+
+    data = asyncio.run(_run())
+    assert data["type"] == "acm"
+    assert data["addr"] == "3"


### PR DESCRIPTION
## Summary
- add node-aware REST helpers that accept Node descriptors and log non-heater calls
- update Ducaheat REST client to reuse segmented endpoints and merge accumulator capabilities
- rename the generic node samples path and extend API/back-end tests for acm coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6d339cc3883298f91e08d5a84c211