### PR TITLE
Handle typed websocket updates

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -36,6 +36,39 @@ def addresses_by_type(nodes: Iterable[Node], node_types: Iterable[str]) -> list[
     return result
 
 
+def addresses_by_node_type(
+    nodes: Iterable[Node],
+    *,
+    known_types: Iterable[str] | None = None,
+) -> tuple[dict[str, list[str]], set[str]]:
+    """Return mapping of node type to address list, tracking unknown types."""
+
+    known: set[str] | None = None
+    if known_types is not None:
+        known = {str(node_type).strip().lower() for node_type in known_types if node_type}
+
+    result: dict[str, list[str]] = {}
+    seen: dict[str, set[str]] = {}
+    unknown: set[str] = set()
+
+    for node in nodes:
+        node_type = str(getattr(node, "type", "")).strip().lower()
+        if not node_type:
+            continue
+        addr = str(getattr(node, "addr", "")).strip()
+        if not addr:
+            continue
+        type_seen = seen.setdefault(node_type, set())
+        if addr in type_seen:
+            continue
+        type_seen.add(addr)
+        result.setdefault(node_type, []).append(addr)
+        if known is not None and node_type not in known:
+            unknown.add(node_type)
+
+    return result, unknown
+
+
 def float_or_none(value: Any) -> float | None:
     """Return value as ``float`` if possible, else ``None``.
 

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -516,6 +516,16 @@ def test_energy_state_coordinator_update_addresses_filters_duplicates() -> None:
     assert coord._addrs == ["A", "B"]
 
 
+def test_energy_state_coordinator_update_addresses_accepts_map() -> None:
+    hass = HomeAssistant()
+    client = types.SimpleNamespace()
+    coord = EnergyStateCoordinator(hass, client, "dev", [])  # type: ignore[arg-type]
+
+    coord.update_addresses({"htr": ["A", "A"], "acm": ["B", ""], "foo": ["X"]})
+
+    assert coord._addrs == ["A", "B"]
+
+
 def test_coordinator_rate_limit_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
         async def _raise_rate_limit(*_args: Any, **_kwargs: Any) -> Any:


### PR DESCRIPTION
## Summary
- track websocket heater caches per node type and include node_type in dispatcher payloads for both legacy and v2 clients
- propagate typed address maps to state and energy coordinators while logging unknown node types
- extend websocket and coordinator unit tests with mixed htr/acm scenarios and mapping coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6e6228f108329951e1d3c27275af0