### PR TITLE
Add docstrings and function map generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ The end user of this integration is a non-technical person who has a home automa
 - New features must be documented.
 - Do not make changes to parts of the code that are unrelated to your current task.
 
+## Tooling Tips
+- Run `python scripts/generate_function_map.py` to produce `docs/function_map.txt`,
+  which lists every function with its docstring summary (tests are excluded). This
+  is a quick way to understand the available helpers within the integration.
+
 ## Pull Request Expectations
 - Keep every PR focused on a single feature or test with minimal code changes as needed.
 - Provide a brief summary of your changes and how they were tested.

--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -13,8 +13,8 @@ from .const import (
     API_BASE,
     BASIC_AUTH_B64,
     DEVS_PATH,
-    NODES_PATH_FMT,
     NODE_SAMPLES_PATH_FMT,
+    NODES_PATH_FMT,
     TOKEN_PATH,
     USER_AGENT,
 )
@@ -61,6 +61,7 @@ class RESTClient:
         api_base: str = API_BASE,
         basic_auth_b64: str = BASIC_AUTH_B64,
     ) -> None:
+        """Initialise the REST client with authentication context."""
         self._session = session
         self._username = username
         self._password = password
@@ -260,6 +261,7 @@ class RESTClient:
                 return token
 
     async def _authed_headers(self) -> dict[str, str]:
+        """Return HTTP headers including a valid bearer token."""
         token = await self._ensure_token()
         return {
             "Authorization": f"Bearer {token}",

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -1,8 +1,8 @@
 """Ducaheat backend implementation and HTTP adapter."""
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
+import logging
 from typing import Any
 
 from ..api import RESTClient
@@ -180,6 +180,7 @@ class DucaheatRESTClient(RESTClient):
     def _normalise_settings(
         self, payload: Any, *, node_type: str = "htr"
     ) -> dict[str, Any]:
+        """Flatten the vendor payload into HA-friendly heater settings."""
         if not isinstance(payload, dict):
             return {}
 
@@ -290,6 +291,7 @@ class DucaheatRESTClient(RESTClient):
         merged: dict[str, Any] = {}
 
         def _merge(target: dict[str, Any], source: dict[str, Any]) -> None:
+            """Recursively merge capability dictionaries."""
             for key, value in source.items():
                 if (
                     isinstance(value, dict)
@@ -312,6 +314,7 @@ class DucaheatRESTClient(RESTClient):
         return merged
 
     def _normalise_prog(self, data: Any) -> list[int] | None:
+        """Convert vendor programme payloads into a 168-slot list."""
         if isinstance(data, list):
             try:
                 return self._ensure_prog(data)
@@ -357,6 +360,7 @@ class DucaheatRESTClient(RESTClient):
         return values if len(values) == 168 else None
 
     def _normalise_prog_temps(self, data: Any) -> list[str] | None:
+        """Convert preset temperature payloads into stringified list."""
         if not isinstance(data, dict):
             return None
         antifrost = data.get("antifrost") or data.get("cold")
@@ -376,6 +380,7 @@ class DucaheatRESTClient(RESTClient):
         return formatted
 
     def _serialise_prog(self, prog: list[int]) -> dict[str, Any]:
+        """Serialise the 168-slot programme back to API structure."""
         normalised = self._ensure_prog(prog)
         days: dict[str, Any] = {}
         for idx, day in enumerate(_DAY_ORDER):
@@ -384,6 +389,7 @@ class DucaheatRESTClient(RESTClient):
         return {"days": days}
 
     def _serialise_prog_temps(self, ptemp: list[float]) -> dict[str, str]:
+        """Serialise preset temperatures into the API schema."""
         antifrost, eco, comfort = self._ensure_ptemp(ptemp)
         return {"antifrost": antifrost, "eco": eco, "comfort": comfort}
 

--- a/custom_components/termoweb/backend/termoweb.py
+++ b/custom_components/termoweb/backend/termoweb.py
@@ -11,6 +11,7 @@ class TermoWebBackend(Backend):
     """Backend for the TermoWeb brand."""
 
     def _resolve_ws_client_cls(self) -> type[Any]:
+        """Return the websocket client class compatible with this backend."""
         module = import_module("custom_components.termoweb.__init__")
         ws_cls = getattr(module, "WebSocket09Client", None)
         if ws_cls is None:

--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -35,6 +35,7 @@ class GatewayOnlineBinarySensor(
     def __init__(
         self, coordinator: StateCoordinator, entry_id: str, dev_id: str
     ) -> None:
+        """Initialise the connectivity binary sensor."""
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._dev_id = str(dev_id)
@@ -43,6 +44,7 @@ class GatewayOnlineBinarySensor(
         self._unsub_ws = None
 
     async def async_added_to_hass(self) -> None:
+        """Subscribe to websocket status updates when added to hass."""
         await super().async_added_to_hass()
         self._unsub_ws = async_dispatcher_connect(
             self.hass, signal_ws_status(self._entry_id), self._on_ws_status
@@ -50,16 +52,19 @@ class GatewayOnlineBinarySensor(
         self.async_on_remove(lambda: self._unsub_ws() if self._unsub_ws else None)
 
     def _ws_state(self) -> dict[str, Any]:
+        """Return the latest websocket status payload for this device."""
         rec = self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}) or {}
         return (rec.get("ws_state") or {}).get(self._dev_id, {})
 
     @property
     def is_on(self) -> bool:
+        """Return True when the integration reports the gateway is online."""
         data = (self.coordinator.data or {}).get(self._dev_id, {}) or {}
         return bool(data.get("connected"))
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Return Home Assistant device metadata for the gateway."""
         data = (self.coordinator.data or {}).get(self._dev_id, {}) or {}
         version = (self.hass.data.get(DOMAIN, {}).get(self._entry_id, {}) or {}).get(
             "version"
@@ -76,6 +81,7 @@ class GatewayOnlineBinarySensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional gateway diagnostics and websocket state."""
         data = (self.coordinator.data or {}).get(self._dev_id, {}) or {}
         ws = self._ws_state()
         return {
@@ -90,6 +96,7 @@ class GatewayOnlineBinarySensor(
 
     @callback
     def _on_ws_status(self, payload: dict) -> None:
+        """Handle websocket status broadcasts from the integration."""
         if payload.get("dev_id") != self._dev_id:
             return
         self.schedule_update_ha_state()

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -22,12 +22,14 @@ class StateRefreshButton(CoordinatorEntity, ButtonEntity):
     _attr_has_entity_name = True
 
     def __init__(self, coordinator, dev_id: str) -> None:
+        """Initialise the force-refresh button entity."""
         super().__init__(coordinator)
         self._dev_id = dev_id
         self._attr_unique_id = f"{DOMAIN}:{dev_id}:refresh"
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Return the Home Assistant device metadata for this gateway."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._dev_id)},
             name="TermoWeb Gateway",
@@ -37,4 +39,5 @@ class StateRefreshButton(CoordinatorEntity, ButtonEntity):
         )
 
     async def async_press(self) -> None:
+        """Request an immediate coordinator refresh when pressed."""
         await self.coordinator.async_request_refresh()

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import aiohttp_client
 from homeassistant.loader import async_get_integration
 import voluptuous as vol
 
-from .api import BackendAuthError, RESTClient, BackendRateLimitError
+from .api import BackendAuthError, BackendRateLimitError, RESTClient
 from .const import (
     BRAND_DUCAHEAT as CONST_BRAND_DUCAHEAT,
     BRAND_LABELS,
@@ -44,6 +44,7 @@ def _login_schema(
     default_poll: int = DEFAULT_POLL_INTERVAL,
     default_brand: str = DEFAULT_BRAND,
 ) -> vol.Schema:
+    """Build the login form schema with provided defaults."""
     return vol.Schema(
         {
             vol.Required(
@@ -63,6 +64,7 @@ def _login_schema(
 async def _validate_login(
     hass: HomeAssistant, username: str, password: str, brand: str
 ) -> None:
+    """Ensure the provided credentials authenticate successfully."""
     session = aiohttp_client.async_get_clientsession(hass)
     api_base = get_brand_api_base(brand)
     basic_auth = get_brand_basic_auth(brand)
@@ -82,6 +84,7 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Collect credentials and create the config entry."""
         ver = await _get_version(self.hass)
         _LOGGER.info("TermoWeb config flow started (v%s)", ver)
 
@@ -221,9 +224,11 @@ class TermoWebOptionsFlow(config_entries.OptionsFlow):
     """Options flow to tweak poll interval only."""
 
     def __init__(self, entry: ConfigEntry) -> None:
+        """Store the entry being configured."""
         self.entry = entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        """Show or process the poll-interval options form."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
@@ -246,4 +251,5 @@ class TermoWebOptionsFlow(config_entries.OptionsFlow):
 
 
 async def async_get_options_flow(config_entry: ConfigEntry):
+    """Return the options flow handler for this config entry."""
     return TermoWebOptionsFlow(config_entry)

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -102,6 +102,7 @@ class HeaterNodeBase(CoordinatorEntity):
         await super().async_will_remove_from_hass()
 
     def _remove_ws_listener(self) -> None:
+        """Disconnect the websocket listener if it is registered."""
         if self._unsub_ws is None:
             return
         try:
@@ -117,11 +118,13 @@ class HeaterNodeBase(CoordinatorEntity):
 
     @callback
     def _handle_ws_message(self, payload: dict) -> None:
+        """Process websocket payloads addressed to this heater."""
         if not self._payload_matches_heater(payload):
             return
         self._handle_ws_event(payload)
 
     def _payload_matches_heater(self, payload: dict) -> bool:
+        """Return True when the websocket payload targets this heater."""
         if payload.get("dev_id") != self._dev_id:
             return False
         addr = payload.get("addr")
@@ -146,11 +149,13 @@ class HeaterNodeBase(CoordinatorEntity):
         return self._device_available(self._device_record())
 
     def _device_available(self, device_entry: dict[str, Any] | None) -> bool:
+        """Return True when the device entry contains node data."""
         if not isinstance(device_entry, dict):
             return False
         return device_entry.get("nodes") is not None
 
     def _device_record(self) -> dict[str, Any] | None:
+        """Return the coordinator cache entry for this device."""
         data = getattr(self.coordinator, "data", {}) or {}
         getter = getattr(data, "get", None)
 
@@ -164,6 +169,7 @@ class HeaterNodeBase(CoordinatorEntity):
         return record if isinstance(record, dict) else None
 
     def _heater_section(self) -> dict[str, Any]:
+        """Return the heater-specific portion of the coordinator data."""
         record = self._device_record()
         if record is None:
             return {}
@@ -179,10 +185,12 @@ class HeaterNodeBase(CoordinatorEntity):
         return settings if isinstance(settings, dict) else None
 
     def _client(self) -> Any:
+        """Return the REST client used for write operations."""
         hass_data = self.hass.data.get(DOMAIN, {}).get(self._entry_id, {})
         return hass_data.get("client")
 
     def _units(self) -> str:
+        """Return the configured temperature units for this heater."""
         settings = self.heater_settings() or {}
         units = (settings.get("units") or "C").upper()
         return "C" if units not in {"C", "F"} else units

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -50,6 +50,7 @@ class Node:
 
     @name.setter
     def name(self, value: str | None) -> None:
+        """Update the stored friendly name for the node."""
         cleaned = str(value or "").strip()
         self._node_name = cleaned
         if hasattr(self, "_attr_name"):

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1,0 +1,452 @@
+# TermoWeb Function Map
+
+custom_components/termoweb/__init__.py :: _iso_date
+    Convert unix timestamp to ISO date.
+custom_components/termoweb/__init__.py :: _store_statistics
+    Insert statistics using recorder helpers.
+custom_components/termoweb/__init__.py :: _async_import_energy_history
+    Fetch historical hourly samples and insert statistics.
+custom_components/termoweb/__init__.py :: _async_import_energy_history._rate_limited_fetch
+    Fetch heater samples while respecting the shared rate limit.
+custom_components/termoweb/__init__.py :: async_setup_entry
+    Set up the TermoWeb integration for a config entry.
+custom_components/termoweb/__init__.py :: async_setup_entry._start_ws
+    Ensure a websocket client exists and is running for ``dev_id``.
+custom_components/termoweb/__init__.py :: async_setup_entry._recalc_poll_interval
+    Stretch polling if all running WS clients report healthy; else restore.
+custom_components/termoweb/__init__.py :: async_setup_entry._on_ws_status
+    Recalculate polling intervals when websocket status changes.
+custom_components/termoweb/__init__.py :: async_setup_entry._on_coordinator_updated
+    Start websocket clients for newly discovered devices.
+custom_components/termoweb/__init__.py :: async_setup_entry._service_import_energy_history
+    Handle the import_energy_history service call.
+custom_components/termoweb/__init__.py :: async_setup_entry._schedule_import
+    Kick off the initial energy history import task.
+custom_components/termoweb/__init__.py :: async_unload_entry
+    Unload a config entry for TermoWeb.
+custom_components/termoweb/__init__.py :: async_migrate_entry
+    Migrate a config entry; no migrations are needed yet.
+custom_components/termoweb/__init__.py :: async_update_entry_options
+    Handle options updates; recompute interval if needed.
+custom_components/termoweb/api.py :: _redact_bearer
+    Remove Bearer tokens from an arbitrary string (defensive).
+custom_components/termoweb/api.py :: RESTClient.__init__
+    Initialise the REST client with authentication context.
+custom_components/termoweb/api.py :: RESTClient.api_base
+    Expose API base for auxiliary clients (e.g. WS).
+custom_components/termoweb/api.py :: RESTClient._request
+    Perform an HTTP request.
+custom_components/termoweb/api.py :: RESTClient._ensure_token
+    Ensure a bearer token is present; fetch if missing.
+custom_components/termoweb/api.py :: RESTClient._authed_headers
+    Return HTTP headers including a valid bearer token.
+custom_components/termoweb/api.py :: RESTClient.list_devices
+    Return normalized device list: [{'dev_id', ...}, ...].
+custom_components/termoweb/api.py :: RESTClient.device_connected
+    Deprecated: connected endpoint often 404s; return None.
+custom_components/termoweb/api.py :: RESTClient.get_nodes
+    Return raw nodes payload for a device (shape varies by firmware).
+custom_components/termoweb/api.py :: RESTClient.get_node_settings
+    Return settings/state for a node.
+custom_components/termoweb/api.py :: RESTClient._ensure_temperature
+    Normalise a numeric temperature to a string with one decimal.
+custom_components/termoweb/api.py :: RESTClient._ensure_prog
+    Validate and normalise a weekly program list.
+custom_components/termoweb/api.py :: RESTClient._ensure_ptemp
+    Validate preset temperatures and return formatted strings.
+custom_components/termoweb/api.py :: RESTClient._extract_samples
+    Normalise heater samples payloads into {"t", "counter"} lists.
+custom_components/termoweb/api.py :: RESTClient.set_node_settings
+    Update heater settings.
+custom_components/termoweb/api.py :: RESTClient.get_node_samples
+    Return heater samples as list of {"t", "counter"} dicts.
+custom_components/termoweb/api.py :: RESTClient.get_htr_settings
+    Return heater settings/state for a node: GET /htr/{addr}/settings.
+custom_components/termoweb/api.py :: RESTClient.set_htr_settings
+    Update heater settings for the specified node.
+custom_components/termoweb/api.py :: RESTClient.get_htr_samples
+    Return historical heater samples for the specified node.
+custom_components/termoweb/api.py :: RESTClient._resolve_node_descriptor
+    Return ``(node_type, addr)`` for the provided descriptor.
+custom_components/termoweb/api.py :: RESTClient._log_non_htr_payload
+    Log payloads for unsupported node types at DEBUG level.
+custom_components/termoweb/backend/base.py :: HttpClientProto.list_devices
+    Return the list of devices associated with the account.
+custom_components/termoweb/backend/base.py :: HttpClientProto.get_nodes
+    Return the node description for the given device.
+custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_settings
+    Return settings for the specified node.
+custom_components/termoweb/backend/base.py :: HttpClientProto.set_node_settings
+    Update node settings for the specified node.
+custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_samples
+    Return historical samples for the specified node.
+custom_components/termoweb/backend/base.py :: HttpClientProto.get_htr_settings
+    Return heater settings for the specified node.
+custom_components/termoweb/backend/base.py :: HttpClientProto.set_htr_settings
+    Update heater settings for the specified node.
+custom_components/termoweb/backend/base.py :: HttpClientProto.get_htr_samples
+    Return historical heater samples for the specified node.
+custom_components/termoweb/backend/base.py :: WsClientProto.start
+    Start the websocket client.
+custom_components/termoweb/backend/base.py :: WsClientProto.stop
+    Stop the websocket client.
+custom_components/termoweb/backend/base.py :: Backend.__init__
+    Initialize backend metadata.
+custom_components/termoweb/backend/base.py :: Backend.brand
+    Return the configured brand.
+custom_components/termoweb/backend/base.py :: Backend.client
+    Return the HTTP client associated with this backend.
+custom_components/termoweb/backend/base.py :: Backend.create_ws_client
+    Create a websocket client for the given device.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.get_node_settings
+    Fetch and normalise node settings for the Ducaheat API.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.set_node_settings
+    Write heater settings using the segmented endpoints.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.get_node_samples
+    Return samples converting epoch seconds to milliseconds for the API.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_settings
+    Flatten the vendor payload into HA-friendly heater settings.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_acm_capabilities
+    Merge accumulator capability dictionaries into a single mapping.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_acm_capabilities._merge
+    Recursively merge capability dictionaries.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_prog
+    Convert vendor programme payloads into a 168-slot list.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_prog_temps
+    Convert preset temperature payloads into stringified list.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._serialise_prog
+    Serialise the 168-slot programme back to API structure.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._serialise_prog_temps
+    Serialise preset temperatures into the API schema.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._safe_temperature
+    Defensively format inbound temperature values.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatBackend.create_ws_client
+    Instantiate the Socket.IO v2 websocket client.
+custom_components/termoweb/backend/factory.py :: create_backend
+    Create a backend for the given brand.
+custom_components/termoweb/backend/termoweb.py :: TermoWebBackend._resolve_ws_client_cls
+    Return the websocket client class compatible with this backend.
+custom_components/termoweb/backend/termoweb.py :: TermoWebBackend.create_ws_client
+    Instantiate the legacy websocket client used by TermoWeb.
+custom_components/termoweb/binary_sensor.py :: async_setup_entry
+    Set up one connectivity binary sensor per TermoWeb hub (dev_id).
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor.__init__
+    Initialise the connectivity binary sensor.
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor.async_added_to_hass
+    Subscribe to websocket status updates when added to hass.
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor._ws_state
+    Return the latest websocket status payload for this device.
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor.is_on
+    Return True when the integration reports the gateway is online.
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor.device_info
+    Return Home Assistant device metadata for the gateway.
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor.extra_state_attributes
+    Return additional gateway diagnostics and websocket state.
+custom_components/termoweb/binary_sensor.py :: GatewayOnlineBinarySensor._on_ws_status
+    Handle websocket status broadcasts from the integration.
+custom_components/termoweb/button.py :: async_setup_entry
+    Expose only a safe 'Force refresh' hub-level button per device.
+custom_components/termoweb/button.py :: StateRefreshButton.__init__
+    Initialise the force-refresh button entity.
+custom_components/termoweb/button.py :: StateRefreshButton.device_info
+    Return the Home Assistant device metadata for this gateway.
+custom_components/termoweb/button.py :: StateRefreshButton.async_press
+    Request an immediate coordinator refresh when pressed.
+custom_components/termoweb/climate.py :: async_setup_entry
+    Discover heater nodes and create climate entities.
+custom_components/termoweb/climate.py :: async_setup_entry._svc_set_schedule
+    Handle the set_schedule entity service.
+custom_components/termoweb/climate.py :: async_setup_entry._svc_set_preset_temperatures
+    Handle the set_preset_temperatures entity service.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.__init__
+    Initialise the climate entity for a TermoWeb heater.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.async_will_remove_from_hass
+    Clean up pending tasks when the entity is removed.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._slot_label
+    Translate a program slot integer into a label.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._current_prog_slot
+    Return the active program slot index for the heater.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._handle_ws_event
+    React to websocket updates for this heater.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.hvac_mode
+    Return the HA HVAC mode derived from heater settings.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.hvac_action
+    Return the current HVAC action reported by the heater.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.current_temperature
+    Return the measured ambient temperature.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.target_temperature
+    Return the target temperature set on the heater.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.min_temp
+    Return the minimum supported setpoint.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.max_temp
+    Return the maximum supported setpoint.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.icon
+    Return an icon reflecting the heater state.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.extra_state_attributes
+    Return additional metadata about the heater.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.async_set_schedule
+    Write the 7x24 tri-state program to the device.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.async_set_preset_temperatures
+    Write the cold/night/day preset temperatures.
+custom_components/termoweb/climate.py :: HeaterClimateEntity.async_set_temperature
+    Set target temperature; server requires manual+stemp together (stemp string handled by API).
+custom_components/termoweb/climate.py :: HeaterClimateEntity.async_set_hvac_mode
+    Post off/auto/manual.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._ensure_write_task
+    Schedule a debounced write task if one is not running.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._write_after_debounce
+    Batch pending mode/setpoint writes after the debounce interval.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._schedule_refresh_fallback
+    Schedule a refresh if the websocket echo does not arrive.
+custom_components/termoweb/climate.py :: HeaterClimateEntity._schedule_refresh_fallback._fallback
+    Force a heater refresh after the fallback delay.
+custom_components/termoweb/config_flow.py :: _get_version
+    Read integration version from manifest (DRY).
+custom_components/termoweb/config_flow.py :: _login_schema
+    Build the login form schema with provided defaults.
+custom_components/termoweb/config_flow.py :: _validate_login
+    Ensure the provided credentials authenticate successfully.
+custom_components/termoweb/config_flow.py :: TermoWebConfigFlow.async_step_user
+    Collect credentials and create the config entry.
+custom_components/termoweb/config_flow.py :: TermoWebConfigFlow.async_step_reconfigure
+    Reconfigure username/password and poll interval (no use_push).
+custom_components/termoweb/config_flow.py :: TermoWebOptionsFlow.__init__
+    Store the entry being configured.
+custom_components/termoweb/config_flow.py :: TermoWebOptionsFlow.async_step_init
+    Show or process the poll-interval options form.
+custom_components/termoweb/config_flow.py :: async_get_options_flow
+    Return the options flow handler for this config entry.
+custom_components/termoweb/const.py :: get_brand_api_base
+    Return API base URL for the selected brand.
+custom_components/termoweb/const.py :: get_brand_basic_auth
+    Return Base64-encoded client credentials for the brand.
+custom_components/termoweb/const.py :: get_brand_label
+    Return human-readable brand label.
+custom_components/termoweb/const.py :: signal_ws_data
+    Signal name for WS ‘data’ frames dispatched to platforms.
+custom_components/termoweb/const.py :: signal_ws_status
+    Signal name for WS status/health updates.
+custom_components/termoweb/coordinator.py :: StateCoordinator.__init__
+    Initialize the TermoWeb device coordinator.
+custom_components/termoweb/coordinator.py :: StateCoordinator._addrs
+    Return cached heater addresses, rebuilding inventory if needed.
+custom_components/termoweb/coordinator.py :: StateCoordinator.update_nodes
+    Update cached node payload and inventory.
+custom_components/termoweb/coordinator.py :: StateCoordinator.async_refresh_heater
+    Refresh settings for a specific heater and push the update to listeners.
+custom_components/termoweb/coordinator.py :: StateCoordinator._async_update_data
+    Fetch heater settings for a subset of addresses on each poll.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.__init__
+    Initialize the heater energy coordinator.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.update_addresses
+    Replace the tracked heater addresses with ``addrs``.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._async_update_data
+    Fetch recent heater energy samples and derive totals and power.
+custom_components/termoweb/heater.py :: build_heater_name_map
+    Return a mapping of heater address -> friendly name.
+custom_components/termoweb/heater.py :: HeaterNodeBase.__init__
+    Initialise a heater entity tied to a TermoWeb device.
+custom_components/termoweb/heater.py :: HeaterNodeBase.async_added_to_hass
+    Subscribe to websocket updates once the entity is added to hass.
+custom_components/termoweb/heater.py :: HeaterNodeBase.async_will_remove_from_hass
+    Tidy up websocket listeners before the entity is removed.
+custom_components/termoweb/heater.py :: HeaterNodeBase._remove_ws_listener
+    Disconnect the websocket listener if it is registered.
+custom_components/termoweb/heater.py :: HeaterNodeBase._handle_ws_message
+    Process websocket payloads addressed to this heater.
+custom_components/termoweb/heater.py :: HeaterNodeBase._payload_matches_heater
+    Return True when the websocket payload targets this heater.
+custom_components/termoweb/heater.py :: HeaterNodeBase._handle_ws_event
+    Schedule a state refresh after a websocket update.
+custom_components/termoweb/heater.py :: HeaterNodeBase.should_poll
+    Home Assistant should not poll heater entities.
+custom_components/termoweb/heater.py :: HeaterNodeBase.available
+    Return whether the backing device exposes heater data.
+custom_components/termoweb/heater.py :: HeaterNodeBase._device_available
+    Return True when the device entry contains node data.
+custom_components/termoweb/heater.py :: HeaterNodeBase._device_record
+    Return the coordinator cache entry for this device.
+custom_components/termoweb/heater.py :: HeaterNodeBase._heater_section
+    Return the heater-specific portion of the coordinator data.
+custom_components/termoweb/heater.py :: HeaterNodeBase.heater_settings
+    Return the cached settings for this heater, if available.
+custom_components/termoweb/heater.py :: HeaterNodeBase._client
+    Return the REST client used for write operations.
+custom_components/termoweb/heater.py :: HeaterNodeBase._units
+    Return the configured temperature units for this heater.
+custom_components/termoweb/heater.py :: HeaterNodeBase.device_info
+    Expose Home Assistant device metadata for the heater.
+custom_components/termoweb/nodes.py :: Node.__init__
+    Initialise a node with normalised metadata.
+custom_components/termoweb/nodes.py :: Node.name
+    Return the friendly name for the node.
+custom_components/termoweb/nodes.py :: Node.name
+    Update the stored friendly name for the node.
+custom_components/termoweb/nodes.py :: Node.as_dict
+    Return a serialisable snapshot of core node metadata.
+custom_components/termoweb/nodes.py :: HeaterNode.__init__
+    Initialise a heater node.
+custom_components/termoweb/nodes.py :: HeaterNode.supports_boost
+    Return whether the node natively exposes boost/runback control.
+custom_components/termoweb/nodes.py :: AccumulatorNode.supports_boost
+    Return whether the accumulator exposes boost/runback.
+custom_components/termoweb/nodes.py :: PowerMonitorNode.__init__
+    Initialise a power monitor node.
+custom_components/termoweb/nodes.py :: PowerMonitorNode.power_level
+    Return the reported power level (stub).
+custom_components/termoweb/nodes.py :: ThermostatNode.__init__
+    Initialise a thermostat node.
+custom_components/termoweb/nodes.py :: ThermostatNode.capabilities
+    Return thermostat capabilities (stub).
+custom_components/termoweb/nodes.py :: _iter_node_payload
+    Yield node dictionaries from a payload returned by the API.
+custom_components/termoweb/nodes.py :: _resolve_node_class
+    Return the most appropriate node class for ``node_type``.
+custom_components/termoweb/nodes.py :: build_node_inventory
+    Return a list of :class:`Node` instances for the provided payload.
+custom_components/termoweb/sensor.py :: _looks_like_integer_string
+    Return True if the string looks like an integer number.
+custom_components/termoweb/sensor.py :: _normalise_energy_value
+    Try to coerce a raw energy reading into kWh.
+custom_components/termoweb/sensor.py :: async_setup_entry
+    Set up sensors for each heater node.
+custom_components/termoweb/sensor.py :: HeaterTemperatureSensor.__init__
+    Initialise the heater temperature sensor entity.
+custom_components/termoweb/sensor.py :: HeaterTemperatureSensor.native_value
+    Return the latest temperature reported by the heater.
+custom_components/termoweb/sensor.py :: HeaterTemperatureSensor.extra_state_attributes
+    Return metadata describing the heater temperature source.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase.__init__
+    Initialise a heater energy-derived sensor entity.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase._device_available
+    Return True when the heater has a device entry.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase._metric_section
+    Return the dictionary with the requested metric values.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase._raw_native_value
+    Return the raw metric value for this heater address.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase._coerce_native_value
+    Convert the raw metric value into a float.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase.native_value
+    Return the processed metric value for Home Assistant.
+custom_components/termoweb/sensor.py :: HeaterEnergyBase.extra_state_attributes
+    Return identifiers that locate the heater metric.
+custom_components/termoweb/sensor.py :: HeaterEnergyTotalSensor._coerce_native_value
+    Normalise the raw energy metric into kWh.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.__init__
+    Initialise the installation-wide energy sensor.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.async_added_to_hass
+    Register websocket callbacks once the entity is added.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.device_info
+    Return the Home Assistant device metadata for the gateway.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor._on_ws_data
+    Handle websocket payloads that may update the totals.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.available
+    Return True if the latest coordinator data contains totals.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.native_value
+    Return the summed energy usage across all heaters.
+custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.extra_state_attributes
+    Return identifiers describing the aggregated energy value.
+custom_components/termoweb/utils.py :: addresses_by_type
+    Return unique addresses for nodes whose ``type`` matches ``node_types``.
+custom_components/termoweb/utils.py :: addresses_by_node_type
+    Return mapping of node type to address list, tracking unknown types.
+custom_components/termoweb/utils.py :: float_or_none
+    Return value as ``float`` if possible, else ``None``.
+custom_components/termoweb/ws_client_legacy.py :: HandshakeError.__init__
+    Capture context for failed Socket.IO handshakes.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client.__init__
+    Initialise the legacy Socket.IO client wrapper.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client.start
+    Start the websocket client background task.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client.stop
+    Cancel tasks and close WS cleanly.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client.is_running
+    Return True if the websocket client task is active.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._runner
+    Manage reconnection loops and websocket lifecycle.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._handshake
+    GET /socket.io/1/?token=<Bearer>&dev_id=<dev_id>&t=<ms>
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._connect_ws
+    Establish the websocket connection using the handshake session id.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._join_namespace
+    Enter the API namespace required for TermoWeb events.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._send_snapshot_request
+    Request the initial device snapshot after connecting.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._subscribe_htr_samples
+    Request push updates for heater energy samples.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._heartbeat_loop
+    Send periodic heartbeat frames to keep the connection alive.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._read_loop
+    Consume websocket frames and route events.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._handle_event
+    Expecting: {"name": "data", "args": [ [ {"path": "...", "body": {...}}, ... ] ]}
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._handle_event._ensure_type_bucket
+    Return the node bucket for ``node_type``, creating defaults.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._handle_event._extract_type_addr
+    Extract the node type and address from a websocket path.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._parse_handshake_body
+    Parse the Socket.IO handshake response into (sid, timeout).
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._send_text
+    Send a raw Socket.IO text frame if the websocket is open.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._get_token
+    Reuse the REST client token for websocket authentication.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._force_refresh_token
+    Force the REST client to fetch a fresh access token.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._api_base
+    Return the base REST API URL used for websocket routes.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._update_status
+    Publish the websocket status to Home Assistant listeners.
+custom_components/termoweb/ws_client_legacy.py :: WebSocket09Client._mark_event
+    Record receipt of a websocket event batch for health tracking.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient.__init__
+    Initialize the client.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient.start
+    Start the background runner.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient.stop
+    Stop the runner.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient.ws_url
+    Return the websocket URL using the API client's token helper.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._runner
+    Background task waiting for stop events.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._on_frame
+    Process an incoming Socket.IO frame.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._handle_handshake
+    Process the initial handshake payload from the server.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._handle_dev_data
+    Handle the first full snapshot of nodes from the websocket.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._handle_update
+    Merge incremental node updates from the websocket feed.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._extract_nodes
+    Extract the nodes dictionary from a websocket payload.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._dispatch_nodes
+    Publish the node snapshot to the coordinator and listeners.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._dispatch_nodes._send
+    Fire the dispatcher signal with the latest node payload.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._build_nodes_snapshot
+    Normalise the nodes payload for consumers.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._mark_event
+    Record the timestamp of the most recent websocket event.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._merge_nodes
+    Deep-merge incremental node updates into the stored snapshot.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._update_status
+    Update bookkeeping for the websocket connection health.
+custom_components/termoweb/ws_client_v2.py :: DucaheatWSClient._update_status._send
+    Emit the websocket status update to Home Assistant.
+scripts/generate_function_map.py :: DocExtractor.__init__
+    Initialise the extractor for ``file_path``.
+scripts/generate_function_map.py :: DocExtractor.visit_ClassDef
+    Visit a class and traverse into its body.
+scripts/generate_function_map.py :: DocExtractor.visit_FunctionDef
+    Visit a function definition and record its docstring.
+scripts/generate_function_map.py :: DocExtractor.visit_AsyncFunctionDef
+    Visit an async function definition and record its docstring.
+scripts/generate_function_map.py :: DocExtractor.functions
+    Return the collected functions.
+scripts/generate_function_map.py :: iter_python_files
+    Yield Python files under ``root`` excluding tests directories.
+scripts/generate_function_map.py :: build_map
+    Parse each Python file and collect function docstrings.
+scripts/generate_function_map.py :: format_entries
+    Format function docstrings into a human-readable map.
+scripts/generate_function_map.py :: main
+    CLI entry point.

--- a/scripts/generate_function_map.py
+++ b/scripts/generate_function_map.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Generate a consolidated map of functions and docstrings for the integration."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+
+@dataclass
+class FunctionDoc:
+    """Container for discovered function docstrings."""
+
+    file: Path
+    lineno: int
+    qualname: str
+    summary: str
+
+
+class DocExtractor(ast.NodeVisitor):
+    """AST visitor that collects function docstrings with qualified names."""
+
+    def __init__(self, file_path: Path) -> None:
+        """Initialise the extractor for ``file_path``."""
+        self._file_path = file_path
+        self._stack: list[str] = []
+        self._functions: list[FunctionDoc] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        """Visit a class and traverse into its body."""
+
+        self._stack.append(node.name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Visit a function definition and record its docstring."""
+
+        self._handle_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        """Visit an async function definition and record its docstring."""
+
+        self._handle_function(node)
+
+    def _handle_function(self, node: ast.AST) -> None:
+        doc = ast.get_docstring(node)
+        qualname_parts = [*self._stack, node.name] if self._stack else [node.name]  # type: ignore[attr-defined]
+        qualname = ".".join(qualname_parts)
+        if doc:
+            summary = doc.strip().splitlines()[0].strip()
+            self._functions.append(
+                FunctionDoc(self._file_path, node.lineno, qualname, summary)
+            )
+        self._stack.append(node.name)  # type: ignore[attr-defined]
+        self.generic_visit(node)
+        self._stack.pop()
+
+    @property
+    def functions(self) -> list[FunctionDoc]:
+        """Return the collected functions."""
+
+        return self._functions
+
+
+def iter_python_files(root: Path) -> Iterable[Path]:
+    """Yield Python files under ``root`` excluding tests directories."""
+
+    for path in sorted(root.rglob("*.py")):
+        if any(part == "tests" for part in path.parts):
+            continue
+        yield path
+
+
+def build_map(root: Path) -> list[FunctionDoc]:
+    """Parse each Python file and collect function docstrings."""
+
+    functions: list[FunctionDoc] = []
+    for file_path in iter_python_files(root):
+        try:
+            tree = ast.parse(file_path.read_text())
+        except SyntaxError as err:  # pragma: no cover - defensive
+            sys.stderr.write(f"Skipping {file_path}: {err}\n")
+            continue
+        extractor = DocExtractor(file_path)
+        extractor.visit(tree)
+        functions.extend(extractor.functions)
+    functions.sort(key=lambda item: (item.file, item.lineno, item.qualname))
+    return functions
+
+
+def format_entries(entries: Iterable[FunctionDoc], root: Path) -> str:
+    """Format function docstrings into a human-readable map."""
+
+    lines = ["# TermoWeb Function Map", ""]
+    for entry in entries:
+        rel_path = entry.file.relative_to(root)
+        lines.append(
+            f"{rel_path} :: {entry.qualname}\n    {entry.summary}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """CLI entry point."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root (defaults to repo two levels up).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("docs/function_map.txt"),
+        help="Output text file (defaults to docs/function_map.txt).",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    entries = build_map(root)
+    output_text = format_entries(entries, root)
+
+    output_path = args.output if args.output.is_absolute() else root / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(output_text, encoding="utf-8")
+    sys.stdout.write(f"Wrote {len(entries)} functions to {output_path}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add one-line docstrings across the TermoWeb integration to describe function behaviour
- add `scripts/generate_function_map.py` and check in the generated `docs/function_map.txt`
- extend `AGENTS.md` with instructions for the new mapping script

## Testing
- `pytest`
- `ruff check --fix` *(fails: existing lint issues in legacy modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f0520930832989d4c713c25df0e7