### PR TITLE
Refactor heater node handling for typed caches

### DIFF
--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -31,7 +31,27 @@ def test_build_heater_name_map_handles_invalid_entries() -> None:
 
     result = build_heater_name_map(nodes, lambda addr: f"Heater {addr}")
 
-    assert result == {"5": "Heater 5", "6": "Heater 6"}
+    assert result.get(("htr", "5")) == "Heater 5"
+    assert result.get(("htr", "6")) == "Heater 6"
+    assert result.get("htr") == {"5": "Heater 5", "6": "Heater 6"}
+    assert result.get("by_type", {}).get("htr") == {"5": "Heater 5", "6": "Heater 6"}
+
+
+def test_heater_base_unique_id_includes_node_type() -> None:
+    coordinator = SimpleNamespace(hass=None)
+    heater = HeaterNodeBase(
+        coordinator,
+        "entry",
+        "dev",
+        "A",
+        "Heater A",
+        node_type="acm",
+    )
+
+    expected = f"{heater_module.DOMAIN}:dev:acm:A"
+    assert heater._attr_unique_id == expected
+    if hasattr(heater, "unique_id"):
+        assert heater.unique_id == expected
 
 
 def test_heater_base_async_added_without_hass() -> None:

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -196,10 +196,8 @@ def test_sensor_async_setup_entry_creates_entities_and_reuses_coordinator() -> N
             assert isinstance(energy_coord, EnergyStateCoordinator)
             assert refresh_mock.await_count == 1
 
-            heater_addrs = sensor_module.addresses_by_type(
-                record["node_inventory"], sensor_module.HEATER_NODE_TYPES
-            )
-            expected_count = len(heater_addrs) * 3 + 1
+            heater_addrs = energy_coord._addresses_by_type
+            expected_count = sum(len(addrs) for addrs in heater_addrs.values()) * 3 + 1
             assert len(add_calls) == 1
             assert len(add_calls[0]) == expected_count
             assert len(added_entities) == expected_count


### PR DESCRIPTION
## Summary
- track heater node names by node type and expose both `(node_type, addr)` and legacy `"htr"` views while preserving unique IDs that incorporate the node type
- teach the state and energy coordinators to maintain typed node caches, update per-type address maps, and expose the legacy `"htr"` alias for existing consumers
- update climate and sensor setup plus unit tests to use the typed mapping, pass node types through to entities, and verify the new data structures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d78481381c832991b9b306041cd0fd