### PR TITLE
Add accumulator node support for climate and sensors

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -157,6 +157,14 @@ class HeaterNodeBase(CoordinatorEntity):
         """Return True when the websocket payload targets this heater."""
         if payload.get("dev_id") != self._dev_id:
             return False
+        payload_type = payload.get("node_type")
+        if payload_type is not None:
+            try:
+                payload_type_str = str(payload_type).strip().lower()
+            except Exception:  # pragma: no cover - defensive
+                payload_type_str = ""
+            if payload_type_str and payload_type_str != self._node_type:
+                return False
         addr = payload.get("addr")
         if addr is None:
             return True
@@ -240,11 +248,12 @@ class HeaterNodeBase(CoordinatorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Expose Home Assistant device metadata for the heater."""
+        model = "Accumulator" if self._node_type == "acm" else "Heater"
         return DeviceInfo(
             identifiers={(DOMAIN, self._dev_id, self._addr)},
             name=self._device_name,
             manufacturer="TermoWeb",
-            model="Heater",
+            model=model,
             via_device=(DOMAIN, self._dev_id),
         )
 


### PR DESCRIPTION
## Summary
- create heater and accumulator climate entities from typed node inventory with new accumulator class and optimistic updates
- update state and energy coordinators plus base heater entity to handle typed node descriptors and device metadata
- extend sensor setup for typed nodes, add accumulator sensors, and cover new paths in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d790c5619083298f5982f05ea32edb