### PR TITLE
Refactor tests to use shared FakeCoordinator stub

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -208,6 +208,19 @@ def test_ensure_token_missing_access_token() -> None:
     asyncio.run(_run())
 
 
+def test_resolve_node_descriptor_validations() -> None:
+    client = RESTClient(FakeSession(), "user", "pass")
+
+    with pytest.raises(ValueError, match="Unsupported node descriptor"):
+        client._resolve_node_descriptor("htr")
+
+    with pytest.raises(ValueError, match="Invalid node type"):
+        client._resolve_node_descriptor(("  ", "1"))
+
+    with pytest.raises(ValueError, match="Invalid node address"):
+        client._resolve_node_descriptor(("htr", ""))
+
+
 def test_ensure_token_non_numeric_expires_in(monkeypatch) -> None:
     fake_time = 1000.0
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -12,7 +12,7 @@ from typing import Any, Callable
 import pytest
 from unittest.mock import AsyncMock
 
-from conftest import _install_stubs
+from conftest import FakeCoordinator, _install_stubs
 
 _install_stubs()
 
@@ -51,47 +51,6 @@ class FakeWSClient:
     async def stop(self) -> None:
         self.stop_calls += 1
 
-
-class FakeCoordinator:
-    instances: list["FakeCoordinator"] = []
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        client: Any,
-        base_interval: int,
-        dev_id: str,
-        dev: dict[str, Any],
-        nodes: dict[str, Any],
-        node_inventory: list[Any] | None = None,
-    ) -> None:
-        self.hass = hass
-        self.client = client
-        self.base_interval = base_interval
-        self.dev_id = dev_id
-        self.dev = dev
-        self.nodes = nodes
-        self.node_inventory = list(node_inventory or [])
-        self.update_interval = timedelta(seconds=base_interval)
-        self.data: dict[str, Any] = {dev_id: dev}
-        self.listeners: list[Callable[[], None]] = []
-        self.refresh_calls = 0
-        type(self).instances.append(self)
-
-    async def async_config_entry_first_refresh(self) -> None:
-        self.refresh_calls += 1
-
-    def async_add_listener(self, listener: Callable[[], None]) -> None:
-        self.listeners.append(listener)
-
-    def update_nodes(
-        self,
-        nodes: dict[str, Any],
-        node_inventory: list[Any] | None = None,
-    ) -> None:
-        self.nodes = nodes
-        if node_inventory is not None:
-            self.node_inventory = list(node_inventory)
 
 
 class BaseFakeClient:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import types
+
 import pytest
 
 from custom_components.termoweb.nodes import build_node_inventory
-from custom_components.termoweb.utils import HEATER_NODE_TYPES, addresses_by_type, float_or_none
+
+from custom_components.termoweb.utils import (
+    HEATER_NODE_TYPES,
+    addresses_by_node_type,
+    addresses_by_type,
+    float_or_none,
+)
 
 
 def test_addresses_by_type_filters_and_deduplicates() -> None:
@@ -28,6 +36,17 @@ def test_addresses_by_type_handles_missing_types() -> None:
     assert addresses_by_type(inventory, [None]) == []
 
 
+def test_addresses_by_node_type_skips_invalid_entries() -> None:
+    nodes = [
+        types.SimpleNamespace(type=" ", addr="skip"),
+        types.SimpleNamespace(type="acm", addr=""),
+        types.SimpleNamespace(type="acm", addr="B"),
+        types.SimpleNamespace(type="acm", addr="B"),
+    ]
+
+    mapping, unknown = addresses_by_node_type(nodes, known_types=["htr"])
+    assert mapping == {"acm": ["B"]}
+    assert unknown == {"acm"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a reusable FakeCoordinator helper to conftest so tests share the same stub implementation
- update climate tests to construct coordinators through the shared helper instead of bespoke inline classes
- switch init setup tests to import the common FakeCoordinator so coordinator bookkeeping lives in one place

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d79964ff64832995f87d6a5c339271