### PR TITLE
Refactor websocket client lifecycle helpers

### DIFF
--- a/custom_components/termoweb/ws_shared.py
+++ b/custom_components/termoweb/ws_shared.py
@@ -1,0 +1,173 @@
+"""Shared helpers for TermoWeb websocket clients."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+import contextlib
+from dataclasses import dataclass
+import logging
+import time
+from typing import Any
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import DOMAIN, signal_ws_status
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HandshakeError(RuntimeError):
+    """Raised when the websocket handshake fails."""
+
+    def __init__(self, status: int, url: str, body_snippet: str) -> None:
+        """Store response information for logging and retries."""
+
+        super().__init__(f"handshake failed (status={status})")
+        self.status = status
+        self.url = url
+        self.body_snippet = body_snippet
+
+
+@dataclass
+class WSStats:
+    """Simple counter bucket for websocket activity."""
+
+    frames_total: int = 0
+    events_total: int = 0
+    last_event_ts: float = 0.0
+    last_paths: list[str] | None = None
+
+
+class TermoWebWSShared:
+    """Mixin providing lifecycle and status helpers for websocket clients."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry_id: str,
+        dev_id: str,
+        task_name: str | None = None,
+    ) -> None:
+        """Initialize shared websocket bookkeeping fields."""
+
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self._runner_task_name_value = task_name
+        self._task: asyncio.Task | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._hb_task: asyncio.Task | None = None
+        self._closing = False
+        self._connected_since: float | None = None
+        self._healthy_since: float | None = None
+        self._stats = WSStats()
+
+    # ----------------- Public control -----------------
+
+    def start(self) -> asyncio.Task:
+        """Start the websocket runner task if not already running."""
+
+        if self._task and not self._task.done():
+            return self._task
+        self._closing = False
+        name = self._runner_task_name()
+        self._task = self.hass.loop.create_task(self._runner(), name=name)
+        return self._task
+
+    async def stop(self) -> None:
+        """Stop the websocket client and cancel background tasks."""
+
+        self._closing = True
+        if self._hb_task:
+            self._hb_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._hb_task
+            self._hb_task = None
+
+        if self._ws:
+            with contextlib.suppress(*self._ws_close_exceptions()):
+                await self._ws.close(
+                    code=aiohttp.WSCloseCode.GOING_AWAY, message=b"client stop"
+                )
+            self._ws = None
+
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+        self._update_status("stopped")
+
+    def is_running(self) -> bool:
+        """Return True if the websocket runner task is active."""
+
+        return bool(self._task and not self._task.done())
+
+    # ----------------- Helpers -----------------
+
+    def _runner_task_name(self) -> str:
+        return self._runner_task_name_value or f"{DOMAIN}-ws-{self.dev_id}"
+
+    def _ws_close_exceptions(self) -> Iterable[type[BaseException]]:
+        return (TimeoutError, aiohttp.ClientError, RuntimeError)
+
+    def _update_status(self, status: str) -> None:
+        """Update shared websocket state and dispatch notifications."""
+
+        state_bucket = self.hass.data[DOMAIN][self.entry_id].setdefault("ws_state", {})
+        state = state_bucket.setdefault(self.dev_id, {})
+        now = time.time()
+        state["status"] = status
+        state["last_event_at"] = self._stats.last_event_ts or None
+        state["healthy_since"] = self._healthy_since
+        state["healthy_minutes"] = (
+            int((now - self._healthy_since) / 60) if self._healthy_since else 0
+        )
+        state["frames_total"] = self._stats.frames_total
+        state["events_total"] = self._stats.events_total
+
+        async_dispatcher_send(
+            self.hass,
+            signal_ws_status(self.entry_id),
+            {"dev_id": self.dev_id, "status": status},
+        )
+
+    def _mark_event(self, *, paths: list[str] | None) -> None:
+        """Record websocket activity and update health state."""
+
+        now = time.time()
+        self._stats.last_event_ts = now
+        if paths:
+            self._stats.events_total += 1
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                uniq: list[str] = []
+                for path in paths:
+                    if path not in uniq:
+                        uniq.append(path)
+                    if len(uniq) >= 5:
+                        break
+                self._stats.last_paths = uniq
+
+        domain_bucket: dict[str, Any] = self.hass.data.setdefault(DOMAIN, {})
+        entry_bucket: dict[str, Any] = domain_bucket.setdefault(self.entry_id, {})
+        state_bucket: dict[str, dict[str, Any]] = entry_bucket.setdefault(
+            "ws_state", {}
+        )
+        state: dict[str, Any] = state_bucket.setdefault(self.dev_id, {})
+        state["last_event_at"] = now
+        state["frames_total"] = self._stats.frames_total
+        state["events_total"] = self._stats.events_total
+
+        if (
+            self._connected_since
+            and not self._healthy_since
+            and (now - self._connected_since) >= 300
+        ):
+            self._healthy_since = now
+            self._update_status("healthy")
+

--- a/custom_components/termoweb/ws_shared.py
+++ b/custom_components/termoweb/ws_shared.py
@@ -119,7 +119,7 @@ class TermoWebWSShared:
     def _update_status(self, status: str) -> None:
         """Update shared websocket state and dispatch notifications."""
 
-        state_bucket = self.hass.data[DOMAIN][self.entry_id].setdefault("ws_state", {})
+        state_bucket = self._state_bucket()
         state = state_bucket.setdefault(self.dev_id, {})
         now = time.time()
         state["status"] = status
@@ -153,11 +153,7 @@ class TermoWebWSShared:
                         break
                 self._stats.last_paths = uniq
 
-        domain_bucket: dict[str, Any] = self.hass.data.setdefault(DOMAIN, {})
-        entry_bucket: dict[str, Any] = domain_bucket.setdefault(self.entry_id, {})
-        state_bucket: dict[str, dict[str, Any]] = entry_bucket.setdefault(
-            "ws_state", {}
-        )
+        state_bucket = self._state_bucket()
         state: dict[str, Any] = state_bucket.setdefault(self.dev_id, {})
         state["last_event_at"] = now
         state["frames_total"] = self._stats.frames_total
@@ -170,4 +166,11 @@ class TermoWebWSShared:
         ):
             self._healthy_since = now
             self._update_status("healthy")
+
+    def _state_bucket(self) -> dict[str, dict[str, Any]]:
+        """Return the websocket state bucket, creating it if necessary."""
+
+        domain_bucket: dict[str, Any] = self.hass.data.setdefault(DOMAIN, {})
+        entry_bucket: dict[str, Any] = domain_bucket.setdefault(self.entry_id, {})
+        return entry_bucket.setdefault("ws_state", {})
 

--- a/tests/test_ws_shared.py
+++ b/tests/test_ws_shared.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+
+import custom_components.termoweb.ws_shared as ws_shared
+
+
+class DummyWS(ws_shared.TermoWebWSShared):
+    async def _runner(self) -> None:  # pragma: no cover - never awaited in tests
+        raise AssertionError("_runner should not be executed during unit tests")
+
+
+def _make_hass() -> types.SimpleNamespace:
+    loop = types.SimpleNamespace(create_task=lambda *args, **kwargs: None)
+    return types.SimpleNamespace(loop=loop, data={})
+
+
+def test_update_status_initialises_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = _make_hass()
+
+    dispatched: list[tuple[str, dict[str, str]]] = []
+
+    def fake_dispatcher(hass_obj, signal: str, payload: dict[str, str]) -> None:
+        dispatched.append((signal, payload))
+
+    monkeypatch.setattr(ws_shared, "async_dispatcher_send", fake_dispatcher)
+    monkeypatch.setattr(ws_shared.time, "time", lambda: 220.0)
+
+    client = DummyWS(hass, entry_id="entry", dev_id="dev")
+    client._stats.frames_total = 4
+    client._stats.events_total = 2
+    client._stats.last_event_ts = 123.0
+    client._healthy_since = 100.0
+
+    client._update_status("connected")
+
+    state = hass.data[ws_shared.DOMAIN]["entry"]["ws_state"]["dev"]
+
+    assert state == {
+        "status": "connected",
+        "last_event_at": 123.0,
+        "healthy_since": 100.0,
+        "healthy_minutes": 2,
+        "frames_total": 4,
+        "events_total": 2,
+    }
+
+    assert dispatched == [
+        (
+            ws_shared.signal_ws_status("entry"),
+            {"dev_id": "dev", "status": "connected"},
+        )
+    ]
+
+
+def test_mark_event_tracks_health(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = _make_hass()
+    client = DummyWS(hass, entry_id="entry", dev_id="dev")
+
+    statuses: list[str] = []
+
+    def fake_update(status: str) -> None:
+        statuses.append(status)
+
+    client._update_status = fake_update  # type: ignore[assignment]
+    client._stats.frames_total = 7
+    client._connected_since = 100.0
+
+    monkeypatch.setattr(ws_shared.time, "time", lambda: 401.0)
+    monkeypatch.setattr(ws_shared._LOGGER, "isEnabledFor", lambda level: True)
+
+    client._mark_event(paths=["/a", "/b", "/a"])
+
+    state = hass.data[ws_shared.DOMAIN]["entry"]["ws_state"]["dev"]
+
+    assert state["events_total"] == 1
+    assert state["frames_total"] == 7
+    assert state["last_event_at"] == 401.0
+    # Healthy transition should trigger exactly once.
+    assert statuses == ["healthy"]
+    assert client._healthy_since == pytest.approx(401.0)
+    assert client._stats.last_paths == ["/a", "/b"]
+


### PR DESCRIPTION
## Summary
- add a shared websocket helper that consolidates lifecycle bookkeeping and status reporting
- update both websocket clients to use the shared helper while keeping protocol specific behaviour intact
- update websocket tests to patch the shared dispatcher/logger hooks introduced by the helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d7a847d2a8832988d24e8603034e51