### PR TITLE
Fix websocket handshake attribute collision

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -104,7 +104,7 @@ class TermoWebSocketClient:
         self._engineio_ping_timeout: float = 60.0
         self._engineio_last_pong: float | None = None
 
-        self._handshake: dict[str, Any] | None = None
+        self._handshake_payload: dict[str, Any] | None = None
         self._nodes: dict[str, Any] = {}
         self._nodes_raw: dict[str, Any] = {}
 
@@ -880,7 +880,7 @@ class TermoWebSocketClient:
     def _handle_handshake(self, data: Any) -> None:
         """Process the initial handshake payload from the server."""
         if isinstance(data, dict):
-            self._handshake = deepcopy(data)
+            self._handshake_payload = deepcopy(data)
             self._update_status("connected")
         else:
             _LOGGER.debug("WS %s: invalid handshake payload", self.dev_id)

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -2123,8 +2123,8 @@ def test_engineio_ws_client_flow(
         )
         await asyncio.sleep(0)
         handshake_payload["devs"][0]["id"] = "mutated"
-        assert client._handshake is not None
-        assert client._handshake["devs"][0]["id"] == "dev"
+        assert client._handshake_payload is not None
+        assert client._handshake_payload["devs"][0]["id"] == "dev"
 
         initial_update = {
             "nodes": {


### PR DESCRIPTION
## Summary
- rename the stored handshake payload attribute so the `_handshake` coroutine is no longer shadowed
- update the websocket client tests to reference the renamed handshake payload attribute

## Testing
- pytest tests/test_ws_client.py::test_runner_handles_handshake_events_and_disconnect -v
- pytest tests/test_ws_client.py::test_handshake_success_resets_backoff -v

------
https://chatgpt.com/codex/tasks/task_e_68d7f94247488329acc7de11789618d9