### PR TITLE
Remove unused addresses_by_type helper

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -55,33 +55,6 @@ def ensure_node_inventory(
     return []
 
 
-def addresses_by_type(nodes: Iterable[Node], node_types: Iterable[str]) -> list[str]:
-    """Return unique addresses for nodes whose ``type`` matches ``node_types``."""
-
-    valid_types: set[str] = set()
-    for node_type in node_types:
-        if node_type is None:
-            continue
-        valid_types.add(str(node_type).strip().lower())
-    result: list[str] = []
-    seen: set[str] = set()
-
-    if not valid_types:
-        return result
-
-    for node in nodes:
-        node_type = str(getattr(node, "type", "")).strip().lower()
-        if node_type not in valid_types:
-            continue
-        addr = str(getattr(node, "addr", "")).strip()
-        if not addr or addr in seen:
-            continue
-        seen.add(addr)
-        result.append(addr)
-
-    return result
-
-
 def addresses_by_node_type(
     nodes: Iterable[Node],
     *,

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -346,8 +346,6 @@ custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.native_val
     Return the summed energy usage across all heaters.
 custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.extra_state_attributes
     Return identifiers describing the aggregated energy value.
-custom_components/termoweb/utils.py :: addresses_by_type
-    Return unique addresses for nodes whose ``type`` matches ``node_types``.
 custom_components/termoweb/utils.py :: addresses_by_node_type
     Return mapping of node type to address list, tracking unknown types.
 custom_components/termoweb/utils.py :: float_or_none

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,31 +10,9 @@ from custom_components.termoweb.nodes import build_node_inventory
 from custom_components.termoweb.utils import (
     HEATER_NODE_TYPES,
     addresses_by_node_type,
-    addresses_by_type,
     ensure_node_inventory,
     float_or_none,
 )
-
-
-def test_addresses_by_type_filters_and_deduplicates() -> None:
-    inventory = build_node_inventory(
-        {
-            "nodes": [
-                {"type": "htr", "addr": "A"},
-                {"type": "foo", "addr": "B"},
-                {"type": "acm", "addr": 1},
-                {"type": "HTR", "addr": "A"},
-            ]
-        }
-    )
-
-    assert addresses_by_type(inventory, HEATER_NODE_TYPES) == ["A", "1"]
-
-
-def test_addresses_by_type_handles_missing_types() -> None:
-    inventory = build_node_inventory({"nodes": [{"type": "htr", "addr": "A"}]})
-
-    assert addresses_by_type(inventory, [None]) == []
 
 
 def test_ensure_node_inventory_returns_cached_copy() -> None:


### PR DESCRIPTION
## Summary
- remove the unused `addresses_by_type` helper from the utils module and tidy the function map documentation
- drop the dedicated unit tests that exercised the removed helper

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d8141e587c83298b3120bf8dd8d9b7