### PR TITLE
Refactor accumulator sensors to reuse heater sensor classes

### DIFF
--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -117,17 +117,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 continue
             base_name = resolve_name(node_type, addr_str)
             uid_prefix = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}"
-            temp_cls: type[HeaterTemperatureSensor]
-            energy_cls: type[HeaterEnergyTotalSensor]
-            power_cls: type[HeaterPowerSensor]
-            if node_type == "acm":
-                temp_cls = AccumulatorTemperatureSensor
-                energy_cls = AccumulatorEnergyTotalSensor
-                power_cls = AccumulatorPowerSensor
-            else:
-                temp_cls = HeaterTemperatureSensor
-                energy_cls = HeaterEnergyTotalSensor
-                power_cls = HeaterPowerSensor
+            temp_cls: type[HeaterTemperatureSensor] = HeaterTemperatureSensor
+            energy_cls: type[HeaterEnergyTotalSensor] = HeaterEnergyTotalSensor
+            power_cls: type[HeaterPowerSensor] = HeaterPowerSensor
 
             new_entities.append(
                 temp_cls(
@@ -326,20 +318,6 @@ class HeaterPowerSensor(HeaterEnergyBase):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "W"
     _metric_key = "power"
-
-
-class AccumulatorTemperatureSensor(HeaterTemperatureSensor):
-    """Temperature sensor for accumulator nodes."""
-
-
-class AccumulatorEnergyTotalSensor(HeaterEnergyTotalSensor):
-    """Total energy sensor for accumulator nodes."""
-
-
-class AccumulatorPowerSensor(HeaterPowerSensor):
-    """Power sensor for accumulator nodes."""
-
-
 class InstallationTotalEnergySensor(CoordinatorEntity, SensorEntity):
     """Total energy consumption across all heaters."""
 

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -27,8 +27,6 @@ EnergyStateCoordinator = coordinator_module.EnergyStateCoordinator
 HeaterTemperatureSensor = sensor_module.HeaterTemperatureSensor
 HeaterEnergyTotalSensor = sensor_module.HeaterEnergyTotalSensor
 HeaterPowerSensor = sensor_module.HeaterPowerSensor
-AccumulatorEnergyTotalSensor = sensor_module.AccumulatorEnergyTotalSensor
-AccumulatorPowerSensor = sensor_module.AccumulatorPowerSensor
 InstallationTotalEnergySensor = sensor_module.InstallationTotalEnergySensor
 async_setup_sensor_entry = sensor_module.async_setup_entry
 signal_ws_data = const_module.signal_ws_data
@@ -94,7 +92,7 @@ def test_coordinator_and_sensors() -> None:
                 f"{DOMAIN}:1:htr:A:power",
                 "Heater",
             ),
-            ("acm", "energy"): AccumulatorEnergyTotalSensor(
+            ("acm", "energy"): HeaterEnergyTotalSensor(
                 coord,
                 "entry",
                 "1",
@@ -104,7 +102,7 @@ def test_coordinator_and_sensors() -> None:
                 "Accumulator",
                 node_type="acm",
             ),
-            ("acm", "power"): AccumulatorPowerSensor(
+            ("acm", "power"): HeaterPowerSensor(
                 coord,
                 "entry",
                 "1",


### PR DESCRIPTION
## Summary
- remove the accumulator sensor subclasses and rely on the heater sensors for all node types
- ensure async_setup_entry passes node_type when creating accumulator entities so naming and metadata stay intact
- update heater energy sensor tests to reference the consolidated classes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d81412128883299420ef85786c2d9b