### PR TITLE
Refactor heater address normalization helper

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -134,3 +134,53 @@ def float_or_none(value: Any) -> float | None:
         return num if math.isfinite(num) else None
     except Exception:
         return None
+
+
+def normalize_heater_addresses(
+    addrs: Iterable[Any] | Mapping[Any, Iterable[Any]] | None,
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    """Return canonical heater addresses and compatibility aliases."""
+
+    cleaned_map: dict[str, list[str]] = {}
+    compat_aliases: dict[str, str] = {}
+
+    if addrs is None:
+        sources: Iterable[tuple[Any, Iterable[Any] | Any]] = []
+    elif isinstance(addrs, Mapping):
+        sources = addrs.items()
+    else:
+        sources = [("htr", addrs)]
+
+    for raw_type, values in sources:
+        node_type = str(raw_type or "").strip().lower()
+        if not node_type:
+            continue
+
+        alias_target: str | None = None
+        if node_type in {"heater", "heaters", "htr"}:
+            alias_target = "htr"
+        if alias_target is not None and node_type != alias_target:
+            compat_aliases[node_type] = alias_target
+            node_type = alias_target
+
+        if node_type not in HEATER_NODE_TYPES:
+            continue
+
+        if isinstance(values, str) or not isinstance(values, Iterable):
+            candidates = [values]
+        else:
+            candidates = list(values)
+
+        bucket = cleaned_map.setdefault(node_type, [])
+        seen: set[str] = set(bucket)
+        for candidate in candidates:
+            addr = "" if candidate is None else str(candidate).strip()
+            if not addr or addr in seen:
+                continue
+            seen.add(addr)
+            bucket.append(addr)
+
+    cleaned_map.setdefault("htr", [])
+    compat_aliases["htr"] = "htr"
+
+    return cleaned_map, compat_aliases


### PR DESCRIPTION
## Summary
- add a normalize_heater_addresses utility to consolidate heater address deduplication and alias handling
- refactor EnergyStateCoordinator and energy history import to use the shared helper
- extend unit tests to cover the shared helper usage paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d813cb91748329a69a56f8ccf5a97d