### PR TITLE
Use shared address helper for heater platform

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_data
 from .nodes import Node, build_node_inventory
-from .utils import HEATER_NODE_TYPES, ensure_node_inventory
+from .utils import HEATER_NODE_TYPES, addresses_by_node_type, ensure_node_inventory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,14 +109,13 @@ def prepare_heater_platform_data(
         if addr and getattr(node, "name", "").strip():
             explicit_names.add((node_type, addr))
 
+    type_to_addresses, _unknown = addresses_by_node_type(
+        inventory, known_types=HEATER_NODE_TYPES
+    )
+
     addrs_by_type: dict[str, list[str]] = {}
     for node_type in HEATER_NODE_TYPES:
-        addresses: list[str] = []
-        for node in nodes_by_type.get(node_type, []):
-            addr_str = str(getattr(node, "addr", "")).strip()
-            if addr_str:
-                addresses.append(addr_str)
-        addrs_by_type[node_type] = addresses
+        addrs_by_type[node_type] = list(type_to_addresses.get(node_type, []))
 
     name_map = build_heater_name_map(nodes, default_name_simple)
     names_by_type: dict[str, dict[str, str]] = name_map.get("by_type", {})

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -31,6 +31,8 @@ def test_prepare_heater_platform_data_groups_nodes() -> None:
                 {"type": "acm", "addr": "2"},
                 {"type": "thm", "addr": "3"},
                 {"type": "htr", "addr": "4"},
+                {"type": "HTR", "addr": "4"},
+                {"type": "ACM", "addr": "2"},
             ]
         }
     }
@@ -43,9 +45,15 @@ def test_prepare_heater_platform_data_groups_nodes() -> None:
     )
 
     assert entry_data["node_inventory"] == inventory
-    assert [node.addr for node in nodes_by_type.get("htr", [])] == ["1", "4"]
+    htr_nodes = nodes_by_type.get("htr", [])
+    assert [node.addr for node in htr_nodes] == ["1", "4", "4"]
+    assert all(hasattr(node, "addr") for node in htr_nodes)
     assert addrs_by_type["htr"] == ["1", "4"]
+    assert len(addrs_by_type["htr"]) == len(set(addrs_by_type["htr"]))
+    acm_nodes = nodes_by_type.get("acm", [])
+    assert [node.addr for node in acm_nodes] == ["2", "2"]
     assert addrs_by_type["acm"] == ["2"]
+    assert len(addrs_by_type["acm"]) == len(set(addrs_by_type["acm"]))
     assert resolve_name("htr", "1") == "Lounge"
     assert resolve_name("htr", "4") == "Heater 4"
     assert resolve_name("acm", "2") == "Accumulator 2"


### PR DESCRIPTION
## Summary
- reuse `addresses_by_node_type` when preparing heater platform metadata so address lists are deduplicated for heater and accumulator nodes
- extend the heater platform data test to cover duplicate addresses while confirming the node lists still return Node objects

## Testing
- `pytest --cov=custom_components.termoweb --cov-report=term-missing` *(fails: killed by OOM/time limit in CI environment)*
- `pytest tests/test_climate.py tests/test_heater_base.py tests/test_heater_energy_sensor.py tests/test_ws_client.py` *(fails: killed by OOM/time limit in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d81b72967c832996c8916c80a6d107