### PR TITLE
Add tests to reach full coverage

### DIFF
--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -92,6 +92,24 @@ def test_update_nodes_uses_provided_inventory(monkeypatch: pytest.MonkeyPatch) -
     assert builder_called is False
 
 
+def test_set_inventory_from_nodes_defaults_to_empty() -> None:
+    client = types.SimpleNamespace(get_node_settings=AsyncMock())
+    hass = HomeAssistant()
+    coord = StateCoordinator(
+        hass,
+        client,
+        30,
+        "dev",
+        {"name": "Device"},
+        {},
+    )
+
+    result = coord._set_inventory_from_nodes(None)
+
+    assert result == []
+    assert coord._node_inventory == []
+
+
 def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
         client = types.SimpleNamespace()

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any
 
@@ -134,6 +135,18 @@ def test_build_heater_name_map_accepts_iterables_of_dicts() -> None:
 
     assert result.get(("acm", "2")) == "Heater 2"
     assert result.get("htr", {}).get("1") == "Heater 1"
+
+
+def test_log_skipped_nodes_defaults_platform_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    nodes_by_type = {"thm": [SimpleNamespace(addr="7")]}
+
+    with caplog.at_level(logging.DEBUG):
+        heater_module.log_skipped_nodes("", nodes_by_type, skipped_types=["thm"])
+
+    messages = [record.message for record in caplog.records]
+    assert any("platform" in message for message in messages)
 
 
 def test_iter_nodes_yields_existing_node_objects() -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -2256,6 +2256,77 @@ def test_dispatch_nodes_uses_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dispatcher_calls
 
 
+def test_dispatch_nodes_returns_empty_for_non_mapping() -> None:
+    module = _load_ws_client()
+
+    loop = types.SimpleNamespace(call_soon_threadsafe=None, create_task=lambda *a, **k: None)
+    hass = types.SimpleNamespace(loop=loop, data={module.DOMAIN: {"entry": {}}})
+    coordinator = types.SimpleNamespace()
+    api = types.SimpleNamespace(_session=None)
+
+    client = module.WebSocket09Client(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api,
+        coordinator=coordinator,
+    )
+
+    result = client._dispatch_nodes([1, 2, 3])
+
+    assert result == {}
+
+
+def test_dispatch_nodes_handles_missing_raw_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_ws_client()
+
+    dispatched: list[tuple[str, dict[str, Any]]] = []
+
+    def fake_dispatcher(hass: Any, signal: str, payload: dict[str, Any]) -> None:
+        dispatched.append((signal, payload))
+
+    monkeypatch.setattr(module, "async_dispatcher_send", fake_dispatcher)
+
+    captured_raw: list[Any] = []
+
+    def fake_builder(raw: Any) -> list[Any]:
+        captured_raw.append(raw)
+        return []
+
+    monkeypatch.setattr(module, "build_node_inventory", fake_builder)
+    monkeypatch.setattr(module, "addresses_by_node_type", lambda _inv, **_kw: ({}, set()))
+    monkeypatch.setattr(module, "normalize_heater_addresses", lambda addr_map: (addr_map, {}))
+
+    loop = types.SimpleNamespace(
+        call_soon_threadsafe=lambda callback, *args: callback(*args),
+        create_task=lambda *a, **k: None,
+    )
+    hass = types.SimpleNamespace(loop=loop, data={module.DOMAIN: {"entry": {}}})
+    coordinator = types.SimpleNamespace(update_nodes=MagicMock(), data={"dev": {}})
+    api = types.SimpleNamespace(_session=None)
+
+    client = module.WebSocket09Client(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api,
+        coordinator=coordinator,
+    )
+
+    payload = {"nodes": None, "nodes_by_type": {}}
+
+    result = client._dispatch_nodes(payload)
+
+    assert captured_raw == [None]
+    coordinator.update_nodes.assert_called_once_with({}, [])
+    assert dispatched
+    signal, dispatched_payload = dispatched[0]
+    assert signal == module.signal_ws_data("entry")
+    assert dispatched_payload["dev_id"] == "dev"
+    assert result == {}
+
+    record = hass.data[module.DOMAIN]["entry"]
+    assert record.get("nodes") == {}
 def test_mark_event_promotes_to_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_ws_client()
     module.async_dispatcher_send = MagicMock()


### PR DESCRIPTION
## Summary
- add coverage for coordinator inventory fallback and heater logging edge cases
- ensure energy import ignores unavailable addresses and utility helpers handle missing data
- validate websocket dispatchers with non-mapping payloads and absent node snapshots

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d82ee85124832982f154b447eb0af4