### PR TITLE
Refactor ws state bucket helper

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -47,7 +47,7 @@ from .utils import (
 )
 
 # Re-export legacy WS client for backward compatibility (tests may patch it).
-from .ws_client import TermoWebSocketClient as WebSocket09Client  # noqa: F401
+from .ws_client import WebSocketClient as WebSocket09Client  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -8,7 +8,7 @@ from typing import Any
 from ..api import RESTClient
 from ..const import BRAND_DUCAHEAT
 from ..nodes import Node
-from ..ws_client import TermoWebSocketClient
+from ..ws_client import WebSocketClient
 from .base import Backend, WsClientProto
 
 _LOGGER = logging.getLogger(__name__)
@@ -419,7 +419,7 @@ class DucaheatBackend(Backend):
     ) -> WsClientProto:
         """Instantiate the unified websocket client for Ducaheat."""
 
-        return TermoWebSocketClient(
+        return WebSocketClient(
             hass,
             entry_id=entry_id,
             dev_id=dev_id,

--- a/custom_components/termoweb/backend/termoweb.py
+++ b/custom_components/termoweb/backend/termoweb.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
-from ..ws_client import TermoWebSocketClient
+from ..ws_client import WebSocketClient
 from .base import Backend, WsClientProto
 
 
@@ -18,7 +18,7 @@ class TermoWebBackend(Backend):
         ws_cls = getattr(module, "WebSocket09Client", None)
         if isinstance(ws_cls, type):
             return ws_cls
-        return TermoWebSocketClient
+        return WebSocketClient
 
     def create_ws_client(
         self,
@@ -36,7 +36,7 @@ class TermoWebBackend(Backend):
             "api_client": self.client,
             "coordinator": coordinator,
         }
-        if issubclass(ws_cls, TermoWebSocketClient):
+        if issubclass(ws_cls, WebSocketClient):
             kwargs["protocol"] = "socketio09"
         return ws_cls(
             hass,

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -60,7 +60,7 @@ class HandshakeError(RuntimeError):
         self.body_snippet = body_snippet
 
 
-class TermoWebSocketClient:
+class WebSocketClient:
     """Unified websocket client supporting legacy and Engine.IO endpoints."""
 
     def __init__(
@@ -1034,7 +1034,7 @@ class TermoWebSocketClient:
             if isinstance(value, dict):
                 existing = target.get(key)
                 if isinstance(existing, dict):
-                    TermoWebSocketClient._merge_nodes(existing, value)
+                    WebSocketClient._merge_nodes(existing, value)
                 else:
                     target[key] = deepcopy(value)
             else:
@@ -1156,14 +1156,14 @@ class TermoWebSocketClient:
 # ----------------------------------------------------------------------
 # Backwards compatibility aliases
 # ----------------------------------------------------------------------
-WebSocket09Client = TermoWebSocketClient
-DucaheatWSClient = TermoWebSocketClient
+WebSocket09Client = WebSocketClient
+DucaheatWSClient = WebSocketClient
 
 __all__ = [
     "DucaheatWSClient",
     "EngineIOHandshake",
     "HandshakeError",
-    "TermoWebSocketClient",
     "WSStats",
     "WebSocket09Client",
+    "WebSocketClient",
 ]

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -114,11 +114,8 @@ class TermoWebSocketClient:
         self._nodes: dict[str, Any] = {}
         self._nodes_raw: dict[str, Any] = {}
 
-        if not hasattr(self.hass, "data") or self.hass.data is None:  # type: ignore[attr-defined]
-            setattr(self.hass, "data", {})  # type: ignore[attr-defined]
-        domain_bucket = self.hass.data.setdefault(DOMAIN, {})  # type: ignore[attr-defined]
-        entry_bucket = domain_bucket.setdefault(self.entry_id, {})
-        entry_bucket.setdefault("ws_state", {})
+        self._ws_state: dict[str, Any] | None = None
+        self._ws_state_bucket()
 
     # ------------------------------------------------------------------
     # Public control
@@ -1087,14 +1084,24 @@ class TermoWebSocketClient:
             return base.rstrip("/")
         return API_BASE
 
+    def _ws_state_bucket(self) -> dict[str, Any]:
+        """Return the websocket state bucket for this device."""
+        if self._ws_state is None:
+            if not hasattr(self.hass, "data") or self.hass.data is None:  # type: ignore[attr-defined]
+                setattr(self.hass, "data", {})  # type: ignore[attr-defined]
+            domain_bucket = self.hass.data.setdefault(DOMAIN, {})  # type: ignore[attr-defined]
+            entry_bucket = domain_bucket.setdefault(self.entry_id, {})
+            ws_state = entry_bucket.setdefault("ws_state", {})
+            self._ws_state = ws_state.setdefault(self.dev_id, {})
+        return self._ws_state
+
     def _update_status(self, status: str) -> None:
         """Publish the websocket status to Home Assistant listeners."""
         if status == self._status and status not in {"healthy", "connected"}:
             return
         self._status = status
         now = time.time()
-        state_bucket = self.hass.data[DOMAIN][self.entry_id].setdefault("ws_state", {})
-        state = state_bucket.setdefault(self.dev_id, {})
+        state = self._ws_state_bucket()
         last_event = self._stats.last_event_ts or self._last_event_at
         state["status"] = status
         state["last_event_at"] = last_event or None
@@ -1129,12 +1136,7 @@ class TermoWebSocketClient:
                 self._stats.last_paths = uniq
         elif count_event:
             self._stats.events_total += 1
-        state_bucket: dict[str, Any] = (
-            self.hass.data.setdefault(DOMAIN, {})
-            .setdefault(self.entry_id, {})
-            .setdefault("ws_state", {})
-        )
-        state: dict[str, Any] = state_bucket.setdefault(self.dev_id, {})
+        state: dict[str, Any] = self._ws_state_bucket()
         state["last_event_at"] = now
         state["frames_total"] = self._stats.frames_total
         state["events_total"] = self._stats.events_total

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ The TermoWeb integration bridges Home Assistant to the vendor cloud that supervi
 - **REST client** – `RESTClient` performs authenticated HTTP requests to enumerate devices, read heater settings, and push schedule/temperature updates back to the cloud API.【F:custom_components/termoweb/api.py†L269-L360】
 - **Polling coordinator** – `StateCoordinator` periodically refreshes node state via the REST client and maintains cached per-device data that HA platforms consume.【F:custom_components/termoweb/coordinator.py†L22-L211】
 - **Entities** – climate/sensor/binary-sensor/button entities subscribe to coordinator data and the dispatcher, then send writes through the shared REST client (e.g., updating schedules or presets) for the supported node types.【F:custom_components/termoweb/heater.py†L61-L136】【F:custom_components/termoweb/climate.py†L245-L420】
-- **WebSocket client** – `TermoWebSocketClient` automatically detects whether the account requires the legacy Socket.IO 0.9 handshake or the newer Engine.IO/WebSocket upgrade, manages reconnection/heartbeat loops for both protocols, merges push events into coordinator caches, and dispatches connection health/status signals for entities and setup logic.【F:custom_components/termoweb/ws_client.py†L57-L449】
+- **WebSocket client** – `WebSocketClient` automatically detects whether the account requires the legacy Socket.IO 0.9 handshake or the newer Engine.IO/WebSocket upgrade, manages reconnection/heartbeat loops for both protocols, merges push events into coordinator caches, and dispatches connection health/status signals for entities and setup logic.【F:custom_components/termoweb/ws_client.py†L57-L449】
 - **Energy history importer** – the `import_energy_history` service gathers hourly energy counters via REST, rate-limits calls, and writes the resulting statistics into Home Assistant’s recorder database.【F:custom_components/termoweb/__init__.py†L160-L670】
 - **TermoWeb cloud & hardware** – the documented API provides REST endpoints for device metadata, heater settings, and energy samples alongside a Socket.IO push channel, all representing the household gateway and heaters managed by the vendor backend.【F:docs/termoweb_api.md†L1-L176】
 
@@ -25,7 +25,7 @@ flowchart LR
         Client["RESTClient\n(REST helper)"]
         Coord["StateCoordinator\n(polling cache)"]
         Entities["Platforms & Entities\n(climate / sensor / binary_sensor / button)"]
-    WS["TermoWebSocketClient\n(WS protocol detector)"]
+    WS["WebSocketClient\n(WS protocol detector)"]
         Service[import_energy_history Service]
         Recorder[HA Recorder / Statistics]
     end
@@ -96,7 +96,7 @@ The flow shows how configuration and runtime components share the authenticated 
   - **StateRefreshButton** (`ButtonEntity`) – triggers immediate coordinator refreshes for the gateway device.【F:custom_components/termoweb/button.py†L18-L40】
   - **InstallationTotalEnergySensor** (`SensorEntity`) – aggregates heater energy metrics across the installation using the energy coordinator feed.【F:custom_components/termoweb/sensor.py†L281-L337】
 - **Websocket client**
-  - **TermoWebSocketClient** – unified websocket manager that supports both Socket.IO 0.9 polling/websocket upgrade and Engine.IO v2 websockets while streaming updates into coordinator caches and dispatcher channels.【F:custom_components/termoweb/ws_client.py†L57-L449】
+  - **WebSocketClient** – unified websocket manager that supports both Socket.IO 0.9 polling/websocket upgrade and Engine.IO v2 websockets while streaming updates into coordinator caches and dispatcher channels.【F:custom_components/termoweb/ws_client.py†L57-L449】
 
 ### Class relationships diagram
 
@@ -114,7 +114,7 @@ classDiagram
 
     %% Integration classes
     class RESTClient
-    class TermoWebSocketClient
+    class WebSocketClient
     class TermoWebConfigFlow
     class TermoWebOptionsFlow
     class StateCoordinator
@@ -155,7 +155,7 @@ classDiagram
     TermoWebOptionsFlow --> StateCoordinator : adjusts interval
     StateCoordinator --> RESTClient : polls
     EnergyStateCoordinator --> RESTClient : fetches energy
-    TermoWebSocketClient --> StateCoordinator : pushes updates
+    WebSocketClient --> StateCoordinator : pushes updates
     HeaterNodeBase --> StateCoordinator : consumes data
     HeaterEnergyBase --> EnergyStateCoordinator : reads samples
     GatewayOnlineBinarySensor --> StateCoordinator : monitors status

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 from custom_components.termoweb.api import RESTClient
 from custom_components.termoweb.backend.ducaheat import DucaheatBackend, DucaheatRESTClient
-from custom_components.termoweb.ws_client import DucaheatWSClient, TermoWebSocketClient
+from custom_components.termoweb.ws_client import DucaheatWSClient, WebSocketClient
 
 
 class DummyClient:
@@ -59,7 +59,7 @@ def test_ducaheat_backend_creates_ws_client() -> None:
     finally:
         loop.close()
 
-    assert isinstance(ws_client, TermoWebSocketClient)
+    assert isinstance(ws_client, WebSocketClient)
     assert isinstance(ws_client, DucaheatWSClient)
     assert ws_client.dev_id == "dev"
     assert ws_client.entry_id == "entry"

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -12,7 +12,7 @@ from custom_components.termoweb.backend.ducaheat import DucaheatBackend
 from custom_components.termoweb.backend.termoweb import TermoWebBackend
 from custom_components.termoweb.const import BRAND_DUCAHEAT
 from custom_components.termoweb.ws_client import (
-    TermoWebSocketClient,
+    WebSocketClient,
     WebSocket09Client,
 )
 
@@ -93,7 +93,7 @@ def test_termoweb_backend_creates_ws_client() -> None:
     finally:
         loop.close()
 
-    assert isinstance(ws_client, TermoWebSocketClient)
+    assert isinstance(ws_client, WebSocketClient)
     assert isinstance(ws_client, WebSocket09Client)
     assert ws_client.dev_id == "device456"
     assert ws_client.entry_id == "entry123"
@@ -119,7 +119,7 @@ def test_termoweb_backend_fallback_ws_resolution(monkeypatch: pytest.MonkeyPatch
     finally:
         loop.close()
 
-    assert isinstance(ws_client, TermoWebSocketClient)
+    assert isinstance(ws_client, WebSocketClient)
     assert isinstance(ws_client, WebSocket09Client)
     assert ws_client._protocol_hint == "socketio09"
 
@@ -138,7 +138,7 @@ def test_termoweb_backend_resolve_ws_client_cls_fallback(
     monkeypatch.setattr(termoweb_backend, "import_module", fake_import)
 
     resolved = backend._resolve_ws_client_cls()
-    assert resolved is TermoWebSocketClient
+    assert resolved is WebSocketClient
 
 
 def test_termoweb_backend_legacy_ws_class(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -421,18 +421,18 @@ def test_engineio_handshake_parsing_and_errors() -> None:
             await client._engineio_handshake()
         assert err2.value.status == -1
 
-        parsed = module.TermoWebSocketClient._parse_engineio_handshake(
+        parsed = module.WebSocketClient._parse_engineio_handshake(
             '0{"sid":"sid-x","pingInterval":"bad","pingTimeout":null}'
         )
         assert parsed.ping_interval == 25.0
         assert parsed.ping_timeout == 60.0
 
         with pytest.raises(RuntimeError):
-            module.TermoWebSocketClient._parse_engineio_handshake("no-json")
+            module.WebSocketClient._parse_engineio_handshake("no-json")
         with pytest.raises(RuntimeError):
-            module.TermoWebSocketClient._parse_engineio_handshake("0{}")
+            module.WebSocketClient._parse_engineio_handshake("0{}")
         with pytest.raises(RuntimeError):
-            module.TermoWebSocketClient._parse_engineio_handshake(
+            module.WebSocketClient._parse_engineio_handshake(
                 '0{"sid":"abc","pingInterval":bad}'
             )
 
@@ -3027,7 +3027,7 @@ def test_detect_protocol_uses_hint_and_base() -> None:
     loop = types.SimpleNamespace(create_task=lambda *_args, **_kwargs: None)
     hass = types.SimpleNamespace(loop=loop, data={module.DOMAIN: {"entry": {}}})
     coordinator = types.SimpleNamespace()
-    client = module.TermoWebSocketClient(
+    client = module.WebSocketClient(
         hass,
         entry_id="entry",
         dev_id="dev",
@@ -3091,7 +3091,7 @@ def test_engineio_ws_client_flow(
             async def _authed_headers(self) -> dict[str, str]:
                 return {"Authorization": "Bearer tok"}
 
-        client = module.TermoWebSocketClient(
+        client = module.WebSocketClient(
             hass,
             entry_id="entry",
             dev_id="dev",
@@ -3251,7 +3251,7 @@ def test_engineio_logs_unknown_types(
             async def _authed_headers(self) -> dict[str, str]:
                 return {"Authorization": "Bearer tok"}
 
-        client = module.TermoWebSocketClient(
+        client = module.WebSocketClient(
             hass,
             entry_id="entry",
             dev_id="dev",
@@ -3305,7 +3305,7 @@ def test_engineio_stop_handles_cancelled_task(
             async def _authed_headers(self) -> dict[str, str]:
                 return {"Authorization": "Bearer token"}
 
-        client = module.TermoWebSocketClient(
+        client = module.WebSocketClient(
             hass,
             entry_id="entry",
             dev_id="dev",
@@ -3314,7 +3314,7 @@ def test_engineio_stop_handles_cancelled_task(
             protocol="engineio2",
         )
 
-        async def hanging_runner(self: module.TermoWebSocketClient) -> None:
+        async def hanging_runner(self: module.WebSocketClient) -> None:
             self._protocol = "engineio2"
             self._update_status("connecting")
             try:
@@ -3363,7 +3363,7 @@ def test_engineio_ws_url_requires_token() -> None:
             async def _authed_headers(self) -> dict[str, str]:
                 return {}
 
-        client = module.TermoWebSocketClient(
+        client = module.WebSocketClient(
             hass,
             entry_id="entry",
             dev_id="dev",

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -2256,6 +2256,40 @@ def test_dispatch_nodes_uses_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dispatcher_calls
 
 
+def test_dispatch_nodes_handles_empty_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_ws_client()
+    module.async_dispatcher_send = MagicMock()
+    monkeypatch.setattr(ws_core, "async_dispatcher_send", module.async_dispatcher_send)
+
+    class DummyLoop:
+        def call_soon_threadsafe(self, callback: Any) -> None:
+            callback()
+
+    hass = types.SimpleNamespace(
+        loop=DummyLoop(),
+        data={module.DOMAIN: {"entry": {"ws_state": {}}}},
+    )
+
+    coordinator = types.SimpleNamespace(update_nodes=MagicMock(), data={"dev": {}})
+    api = types.SimpleNamespace(_session=None)
+    client = module.WebSocket09Client(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api,
+        coordinator=coordinator,
+    )
+
+    assert client._dispatch_nodes(None) == {}
+    coordinator.update_nodes.assert_not_called()
+
+    result = client._dispatch_nodes({"nodes": None, "nodes_by_type": {}})
+    coordinator.update_nodes.assert_called_with({}, [])
+    assert result == {}
+
+
 def test_mark_event_promotes_to_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_ws_client()
     module.async_dispatcher_send = MagicMock()
@@ -2294,6 +2328,45 @@ def test_mark_event_promotes_to_healthy(monkeypatch: pytest.MonkeyPatch) -> None
         module.signal_ws_status("entry"),
         {"dev_id": "dev", "status": "healthy"},
     )
+    loop.close()
+
+
+def test_status_and_event_share_state_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_ws_client()
+    module.async_dispatcher_send = MagicMock()
+    loop = asyncio.new_event_loop()
+    hass = types.SimpleNamespace(loop=loop, data={})
+    coordinator = types.SimpleNamespace()
+    api = types.SimpleNamespace(_session=None)
+    client = module.WebSocket09Client(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api,
+        coordinator=coordinator,
+    )
+
+    state = hass.data[module.DOMAIN]["entry"]["ws_state"]["dev"]
+    assert client._ws_state_bucket() is state
+
+    monkeypatch.setattr(module.time, "time", lambda: 1000.0)
+    client._update_status("connecting")
+    assert hass.data[module.DOMAIN]["entry"]["ws_state"]["dev"] is state
+    assert state["status"] == "connecting"
+
+    client._stats.frames_total = 4
+    client._stats.events_total = 2
+    monkeypatch.setattr(module.time, "time", lambda: 1500.0)
+    client._mark_event(paths=None, count_event=True)
+
+    assert hass.data[module.DOMAIN]["entry"]["ws_state"]["dev"] is state
+    assert state["status"] == "connecting"
+    assert state["frames_total"] == 4
+    assert state["events_total"] == 3
+    assert state["last_event_at"] == 1500.0
+
     loop.close()
 
 


### PR DESCRIPTION
## Summary
- add a dedicated `_ws_state_bucket` helper to cache the per-device websocket state dictionary
- update status and event tracking to rely on the helper instead of duplicating setdefault chains
- extend websocket tests to cover shared state updates and guard the empty payload path

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d832fdc39c8329b7a050e667f8f9bd