### PR TITLE
Use ensure_node_inventory when dispatching websocket nodes

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -911,16 +911,13 @@ class TermoWebSocketClient:
             snapshot = {"nodes": deepcopy(raw_nodes), "nodes_by_type": {}}
 
         record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
-        inventory: list[Any] = []
-        try:
-            inventory = build_node_inventory(raw_nodes)
-        except Exception as err:  # pragma: no cover - defensive  # noqa: BLE001
-            _LOGGER.debug(
-                "WS %s: failed to build node inventory: %s",
-                self.dev_id,
-                err,
-                exc_info=err,
-            )
+        record_map: Mapping[str, Any]
+        if isinstance(record, Mapping):
+            record_map = record
+        else:
+            record_map = {}
+
+        inventory = ensure_node_inventory(record_map, nodes=raw_nodes)
 
         addr_map, unknown_types = addresses_by_node_type(
             inventory, known_types=NODE_CLASS_BY_TYPE
@@ -948,8 +945,9 @@ class TermoWebSocketClient:
 
         if isinstance(record, dict):
             record["nodes"] = raw_nodes
+            record["node_inventory"] = inventory
 
-        self._apply_heater_addresses(addr_map, inventory=inventory)
+        self._apply_heater_addresses(addr_map, inventory=None)
 
         payload_copy = {
             "dev_id": self.dev_id,


### PR DESCRIPTION
## Summary
- reuse the ensure_node_inventory helper when dispatching websocket node payloads
- share the helper's returned inventory list across coordinator and record caches
- extend websocket unit tests to exercise cached inventory reuse

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d832f7611c83298c8ecdd9270d69ba