### PR TITLE
Refactor heater address mapping to shared helper

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -40,11 +40,13 @@ from .const import (
 from .coordinator import StateCoordinator
 from .nodes import build_node_inventory
 from .utils import (
-    HEATER_NODE_TYPES,
-    addresses_by_node_type,
+    HEATER_NODE_TYPES as _HEATER_NODE_TYPES,
+    build_heater_address_map,
     ensure_node_inventory,
     normalize_heater_addresses,
 )
+
+HEATER_NODE_TYPES = _HEATER_NODE_TYPES
 
 # Re-export legacy WS client for backward compatibility (tests may patch it).
 from .ws_client import TermoWebSocketClient as WebSocket09Client  # noqa: F401
@@ -115,29 +117,6 @@ def _store_statistics(
     async_add_external_statistics(hass, ext_meta, stats)
 
 
-def _heater_address_map(
-    inventory: Iterable[Any],
-) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
-    """Return mapping of heater node types to addresses and reverse lookup."""
-
-    raw_map, _unknown = addresses_by_node_type(
-        inventory,
-        known_types=HEATER_NODE_TYPES,
-    )
-    by_type = {
-        node_type: addresses
-        for node_type, addresses in raw_map.items()
-        if node_type in HEATER_NODE_TYPES and addresses
-    }
-
-    reverse: dict[str, set[str]] = {}
-    for node_type, addresses in by_type.items():
-        for address in addresses:
-            reverse.setdefault(address, set()).add(node_type)
-
-    return by_type, reverse
-
-
 async def _async_import_energy_history(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -164,7 +143,7 @@ async def _async_import_energy_history(
     dev_id: str = rec["dev_id"]
     inventory: list[Any] = ensure_node_inventory(rec)
 
-    by_type, reverse_lookup = _heater_address_map(inventory)
+    by_type, reverse_lookup = build_heater_address_map(inventory)
 
     requested_map: dict[str, list[str]] | None
     if nodes is None:
@@ -811,7 +790,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if not ent:
                     continue
                 inventory: Iterable[Any] = rec.get("node_inventory") or []
-                by_type, _ = _heater_address_map(inventory)
+                by_type, _ = build_heater_address_map(inventory)
                 tasks.append(
                     _async_import_energy_history(
                         hass,

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_data
 from .nodes import Node, build_node_inventory
-from .utils import HEATER_NODE_TYPES, addresses_by_node_type, ensure_node_inventory
+from .utils import HEATER_NODE_TYPES, build_heater_address_map, ensure_node_inventory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,13 +143,12 @@ def prepare_heater_platform_data(
         if addr and getattr(node, "name", "").strip():
             explicit_names.add((node_type, addr))
 
-    type_to_addresses, _unknown = addresses_by_node_type(
-        inventory, known_types=HEATER_NODE_TYPES
-    )
+    type_to_addresses, _reverse_lookup = build_heater_address_map(inventory)
 
-    addrs_by_type: dict[str, list[str]] = {}
-    for node_type in HEATER_NODE_TYPES:
-        addrs_by_type[node_type] = list(type_to_addresses.get(node_type, []))
+    addrs_by_type: dict[str, list[str]] = {
+        node_type: list(type_to_addresses.get(node_type, []))
+        for node_type in HEATER_NODE_TYPES
+    }
 
     name_map = build_heater_name_map(nodes, default_name_simple)
     names_by_type: dict[str, dict[str, str]] = name_map.get("by_type", {})

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -12,6 +12,7 @@ _install_stubs()
 
 from custom_components.termoweb import heater as heater_module
 from custom_components.termoweb.nodes import HeaterNode, build_node_inventory
+from custom_components.termoweb.utils import build_heater_address_map
 from homeassistant.core import HomeAssistant
 
 HeaterNodeBase = heater_module.HeaterNodeBase
@@ -54,6 +55,12 @@ def test_prepare_heater_platform_data_groups_nodes() -> None:
     assert [node.addr for node in acm_nodes] == ["2", "2"]
     assert addrs_by_type["acm"] == ["2"]
     assert len(addrs_by_type["acm"]) == len(set(addrs_by_type["acm"]))
+    helper_map, helper_reverse = build_heater_address_map(inventory)
+    assert addrs_by_type == {
+        node_type: helper_map.get(node_type, [])
+        for node_type in heater_module.HEATER_NODE_TYPES
+    }
+    assert helper_reverse == {"1": {"htr"}, "2": {"acm"}, "4": {"htr"}}
     assert resolve_name("htr", "1") == "Lounge"
     assert resolve_name("htr", "4") == "Heater 4"
     assert resolve_name("acm", "2") == "Accumulator 2"
@@ -96,13 +103,15 @@ def test_prepare_heater_platform_data_skips_blank_types(
 
     entry_data: dict[str, Any] = {}
 
-    _, nodes_by_type, addrs_by_type, _ = prepare_heater_platform_data(
+    inventory, nodes_by_type, addrs_by_type, _ = prepare_heater_platform_data(
         entry_data,
         default_name_simple=lambda addr: f"Heater {addr}",
     )
 
     assert [node.addr for node in nodes_by_type.get("htr", [])] == ["6"]
     assert addrs_by_type["htr"] == ["6"]
+    helper_map, _ = build_heater_address_map(inventory)
+    assert helper_map == {"htr": ["6"]}
 
 
 def test_build_heater_name_map_handles_invalid_entries() -> None:

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -13,6 +13,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from custom_components.termoweb import utils as utils_module
+
 from conftest import _install_stubs
 
 _install_stubs()
@@ -1349,7 +1351,9 @@ def test_import_energy_history_requested_map_filters(monkeypatch: pytest.MonkeyP
                 set(),
             )
 
-        monkeypatch.setattr(mod, "addresses_by_node_type", fake_addresses_by_node_type)
+        monkeypatch.setattr(
+            utils_module, "addresses_by_node_type", fake_addresses_by_node_type
+        )
 
         original_normalize = mod.normalize_heater_addresses
 
@@ -1472,7 +1476,9 @@ def test_import_energy_history_resets_requested_progress(
             assert known_types == mod.HEATER_NODE_TYPES
             return ({"pmo": ["X"]}, set())
 
-        monkeypatch.setattr(mod, "addresses_by_node_type", fake_addresses_by_node_type)
+        monkeypatch.setattr(
+            utils_module, "addresses_by_node_type", fake_addresses_by_node_type
+        )
 
         fake_now = 5 * 86_400
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -21,6 +21,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as entity_registry_mod
 
+from custom_components.termoweb.utils import build_heater_address_map
+
 
 class FakeWSClient:
     def __init__(
@@ -188,7 +190,7 @@ def test_async_setup_entry_happy_path(
     assert isinstance(record["client"], HappyClient)
     assert isinstance(record["coordinator"], FakeCoordinator)
     assert record["coordinator"].refresh_calls == 1
-    by_type, _ = termoweb_init._heater_address_map(record["node_inventory"])
+    by_type, _ = build_heater_address_map(record["node_inventory"])
     assert by_type == {"htr": ["A"], "acm": ["B"]}
     assert [node.addr for node in record["node_inventory"]] == ["A", "B"]
     assert [node.type for node in record["node_inventory"]] == ["htr", "acm"]
@@ -202,7 +204,7 @@ def test_async_setup_entry_happy_path(
     import_mock.assert_awaited_once_with(stub_hass, entry)
 
 
-def test_heater_address_map_filters_invalid_nodes(termoweb_init: Any) -> None:
+def test_build_heater_address_map_filters_invalid_nodes(termoweb_init: Any) -> None:
     inventory = [
         SimpleNamespace(type="htr", addr="A"),
         SimpleNamespace(type="acm", addr=" "),
@@ -210,7 +212,7 @@ def test_heater_address_map_filters_invalid_nodes(termoweb_init: Any) -> None:
         SimpleNamespace(type="pmo", addr=""),
     ]
 
-    by_type, reverse = termoweb_init._heater_address_map(inventory)
+    by_type, reverse = build_heater_address_map(inventory)
 
     assert by_type == {"htr": ["A"]}
     assert reverse == {"A": {"htr"}}


### PR DESCRIPTION
## Summary
- add a shared `build_heater_address_map` helper and re-export heater node types for compatibility
- use the shared helper inside the heater platform setup and energy history importer
- expand heater and importer tests to exercise the shared helper and validate address selection

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d832fbe57083298746cb055e824400