### PR TITLE
Refine heater subscription normalization flow

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -389,7 +389,10 @@ class WebSocketClient:
                 addr_map["htr"] = [
                     str(addr).strip() for addr in fallback if str(addr).strip()
                 ]
-        normalized_map, _compat_aliases = normalize_heater_addresses(addr_map)
+        inventory_or_none = inventory or None
+        normalized_map = self._apply_heater_addresses(
+            addr_map, inventory=inventory_or_none
+        )
         if not any(normalized_map.values()):
             return
         other_types = sorted(
@@ -406,7 +409,6 @@ class WebSocketClient:
                 await self._send_text(
                     f"5::{WS_NAMESPACE}:{json.dumps(payload, separators=(',', ':'))}"
                 )
-        self._apply_heater_addresses(normalized_map, inventory=inventory or None)
 
     def _ensure_type_bucket(
         self,


### PR DESCRIPTION
## Summary
- call `_apply_heater_addresses` from `_subscribe_htr_samples` to normalize inventory-derived heater address maps once and reuse the result for subscriptions
- update websocket client tests to assert the helper is invoked and its normalized output controls the subscription payload order

## Testing
- `pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check custom_components/termoweb/ws_client.py tests/test_ws_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8ec428c988329bd0e63e6398e028b