### PR TITLE
Refactor NodeDescriptor alias into nodes module

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -18,7 +18,7 @@ from .const import (
     TOKEN_PATH,
     USER_AGENT,
 )
-from .nodes import Node
+from .nodes import Node, NodeDescriptor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,9 +32,6 @@ class BackendAuthError(Exception):
 
 class BackendRateLimitError(Exception):
     """Server rate-limited the client (HTTP 429)."""
-
-
-NodeDescriptor = Node | tuple[str, str | int]
 
 
 def _redact_bearer(text: str | None) -> str:

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -5,9 +5,7 @@ from abc import ABC, abstractmethod
 from asyncio import Task
 from typing import Any, Protocol
 
-from ..nodes import Node
-
-NodeDescriptor = Node | tuple[str, str | int]
+from ..nodes import NodeDescriptor
 
 
 class HttpClientProto(Protocol):

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -7,16 +7,13 @@ from typing import Any
 
 from ..api import RESTClient
 from ..const import BRAND_DUCAHEAT
-from ..nodes import Node
+from ..nodes import NodeDescriptor
 from ..ws_client import WebSocketClient
 from .base import Backend, WsClientProto
 
 _LOGGER = logging.getLogger(__name__)
 
 _DAY_ORDER = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
-
-NodeDescriptor = Node | tuple[str, str | int]
-
 
 class DucaheatRESTClient(RESTClient):
     """HTTP adapter that speaks the segmented Ducaheat API."""

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -66,6 +66,9 @@ class Node:
         }
 
 
+NodeDescriptor = Node | tuple[str, str | int]
+
+
 class HeaterNode(Node):
     """Heater node (type ``htr``)."""
 


### PR DESCRIPTION
## Summary
- expose the `NodeDescriptor` alias from `custom_components/termoweb/nodes.py` for reuse
- update the API and Ducaheat backend modules to import the shared alias instead of redefining it

## Testing
- pytest tests/test_api.py tests/test_backend_ducaheat.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f3109ecc8329a86056e02b7a61a9