### PR TITLE
Remove deprecated RESTClient helpers

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -286,10 +286,6 @@ class RESTClient:
         )
         return []
 
-    async def device_connected(self, dev_id: str) -> bool | None:
-        """Deprecated: connected endpoint often 404s; return None."""
-        return None
-
     async def get_nodes(self, dev_id: str) -> Any:
         """Return raw nodes payload for a device (shape varies by firmware)."""
         headers = await self._authed_headers()
@@ -506,11 +502,6 @@ class RESTClient:
         )
         return self._extract_samples(data)
 
-    async def get_htr_settings(self, dev_id: str, addr: str | int) -> Any:
-        """Return heater settings/state for a node: GET /htr/{addr}/settings."""
-
-        return await self.get_node_settings(dev_id, ("htr", addr))
-
     async def set_htr_settings(
         self,
         dev_id: str,
@@ -534,16 +525,6 @@ class RESTClient:
             units=units,
         )
 
-    async def get_htr_samples(
-        self,
-        dev_id: str,
-        addr: str | int,
-        start: float,
-        end: float,
-    ) -> list[dict[str, str | int]]:
-        """Return historical heater samples for the specified node."""
-
-        return await self.get_node_samples(dev_id, ("htr", addr), start, end)
     def _resolve_node_descriptor(self, node: NodeDescriptor) -> tuple[str, str]:
         """Return ``(node_type, addr)`` for the provided descriptor."""
 

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -42,9 +42,6 @@ class HttpClientProto(Protocol):
     ) -> list[dict[str, str | int]]:
         """Return historical samples for the specified node."""
 
-    async def get_htr_settings(self, dev_id: str, addr: str | int) -> Any:
-        """Return heater settings for the specified node."""
-
     async def set_htr_settings(
         self,
         dev_id: str,
@@ -57,15 +54,6 @@ class HttpClientProto(Protocol):
         units: str = "C",
     ) -> Any:
         """Update heater settings for the specified node."""
-
-    async def get_htr_samples(
-        self,
-        dev_id: str,
-        addr: str | int,
-        start: float,
-        stop: float,
-    ) -> list[dict[str, str | int]]:
-        """Return historical heater samples for the specified node."""
 
 
 class WsClientProto(Protocol):

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -46,8 +46,6 @@ custom_components/termoweb/api.py :: RESTClient._authed_headers
     Return HTTP headers including a valid bearer token.
 custom_components/termoweb/api.py :: RESTClient.list_devices
     Return normalized device list: [{'dev_id', ...}, ...].
-custom_components/termoweb/api.py :: RESTClient.device_connected
-    Deprecated: connected endpoint often 404s; return None.
 custom_components/termoweb/api.py :: RESTClient.get_nodes
     Return raw nodes payload for a device (shape varies by firmware).
 custom_components/termoweb/api.py :: RESTClient.get_node_settings
@@ -64,12 +62,8 @@ custom_components/termoweb/api.py :: RESTClient.set_node_settings
     Update heater settings.
 custom_components/termoweb/api.py :: RESTClient.get_node_samples
     Return heater samples as list of {"t", "counter"} dicts.
-custom_components/termoweb/api.py :: RESTClient.get_htr_settings
-    Return heater settings/state for a node: GET /htr/{addr}/settings.
 custom_components/termoweb/api.py :: RESTClient.set_htr_settings
     Update heater settings for the specified node.
-custom_components/termoweb/api.py :: RESTClient.get_htr_samples
-    Return historical heater samples for the specified node.
 custom_components/termoweb/api.py :: RESTClient._resolve_node_descriptor
     Return ``(node_type, addr)`` for the provided descriptor.
 custom_components/termoweb/api.py :: RESTClient._log_non_htr_payload
@@ -84,12 +78,8 @@ custom_components/termoweb/backend/base.py :: HttpClientProto.set_node_settings
     Update node settings for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_samples
     Return historical samples for the specified node.
-custom_components/termoweb/backend/base.py :: HttpClientProto.get_htr_settings
-    Return heater settings for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.set_htr_settings
     Update heater settings for the specified node.
-custom_components/termoweb/backend/base.py :: HttpClientProto.get_htr_samples
-    Return historical heater samples for the specified node.
 custom_components/termoweb/backend/base.py :: WsClientProto.start
     Start the websocket client.
 custom_components/termoweb/backend/base.py :: WsClientProto.stop

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -27,8 +27,11 @@ class DummyHttpClient:
     async def get_nodes(self, dev_id: str) -> dict[str, Any]:
         return {"dev_id": dev_id}
 
-    async def get_htr_settings(self, dev_id: str, addr: str | int) -> dict[str, Any]:
-        return {"dev_id": dev_id, "addr": addr}
+    async def get_node_settings(
+        self, dev_id: str, node: tuple[str, str | int]
+    ) -> dict[str, Any]:
+        node_type, addr = node
+        return {"dev_id": dev_id, "node_type": node_type, "addr": addr}
 
     async def set_htr_settings(
         self,
@@ -51,14 +54,17 @@ class DummyHttpClient:
             "units": units,
         }
 
-    async def get_htr_samples(
+    async def get_node_samples(
         self,
         dev_id: str,
-        addr: str | int,
+        node: tuple[str, str | int],
         start: float,
         stop: float,
     ) -> list[dict[str, str | int]]:
-        return [{"t": int(start), "counter": "1"}, {"t": int(stop), "counter": "2"}]
+        return [
+            {"t": int(start), "counter": "1"},
+            {"t": int(stop), "counter": "2"},
+        ]
 
 
 def test_create_backend_returns_termoweb_backend() -> None:

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -47,12 +47,6 @@ else:
 def test_coordinator_and_sensors() -> None:
     async def _run() -> None:
         client = types.SimpleNamespace()
-        client.get_htr_samples = AsyncMock(
-            side_effect=[
-                [{"t": 1000, "counter": "1.0"}],
-                [{"t": 1900, "counter": "1.5"}],
-            ]
-        )
         client.get_node_samples = AsyncMock(
             side_effect=[
                 [{"t": 1000, "counter": "1.0"}],
@@ -215,7 +209,6 @@ def test_coordinator_and_sensors() -> None:
         for sensor in sensors.values():
             sensor.schedule_update_ha_state.assert_not_called()
 
-        assert client.get_htr_samples.await_count == 0
         assert client.get_node_samples.await_count == 4
         call_args = [call.args[:2] for call in client.get_node_samples.await_args_list]
         assert call_args[:4] == [

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -154,9 +154,6 @@ async def _load_module(
         async def get_nodes(self, dev_id: str) -> dict[str, Any]:
             return {"nodes": [{"type": "htr", "addr": "A"}]}
 
-        async def get_htr_settings(self, dev_id: str, addr: str) -> dict[str, Any]:
-            return {}
-
         async def get_node_settings(
             self, dev_id: str, node: tuple[str, str | int]
         ) -> dict[str, Any]:
@@ -170,16 +167,6 @@ async def _load_module(
             stop: int | None = None,
         ) -> list[dict[str, Any]]:
             return []
-
-        async def get_htr_samples(
-            self,
-            dev_id: str,
-            addr: str,
-            start: int | None = None,
-            stop: int | None = None,
-        ) -> list[dict[str, Any]]:
-            return await self.get_node_samples(dev_id, ("htr", addr), start, stop)
-
     monkeypatch.setattr(api_module, "RESTClient", _FakeRESTClient)
 
     ws_module = importlib.import_module("custom_components.termoweb.ws_client")
@@ -1727,7 +1714,6 @@ def test_energy_polling_matches_import(monkeypatch: pytest.MonkeyPatch) -> None:
                 ]
             )
         )
-        client.get_htr_samples = client.get_node_samples
 
         coordinator = coord_mod.EnergyStateCoordinator(
             hass,


### PR DESCRIPTION
## Summary
- drop the unused RESTClient helpers for device connectivity and heater-specific GET wrappers
- update HttpClientProto and test fixtures to rely on node-based accessors
- refresh docs/function_map to match the streamlined API surface

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d911cbb3908329bc5544c221f40736