### PR TITLE
Enable accumulator boost support

### DIFF
--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -95,7 +95,7 @@ class AccumulatorNode(HeaterNode):
     def supports_boost(self) -> bool:
         """Return whether the accumulator exposes boost/runback."""
 
-        return False
+        return True
 
 
 class PowerMonitorNode(Node):

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -31,7 +31,13 @@ def test_accumulator_node_defaults() -> None:
     assert node.name == ""
     assert node.addr == "007"
     assert node.type == "acm"
-    assert node.supports_boost() is False
+    assert node.supports_boost() is True
+
+
+def test_accumulator_supports_boost() -> None:
+    node = AccumulatorNode(name="Storage", addr=3)
+
+    assert node.supports_boost() is True
 
 
 def test_power_monitor_stub() -> None:


### PR DESCRIPTION
## Summary
- set `AccumulatorNode.supports_boost` to report boost capability
- extend node tests to assert accumulator boost support

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d92901c23083298f889578b5a6a511