### PR TITLE
Pass inventory to heater name map

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -241,7 +241,7 @@ def prepare_heater_platform_data(
         for node_type in HEATER_NODE_TYPES
     }
 
-    name_map = build_heater_name_map(nodes, default_name_simple)
+    name_map = build_heater_name_map(inventory, default_name_simple)
     names_by_type: dict[str, dict[str, str]] = name_map.get("by_type", {})
     legacy_names: dict[str, str] = name_map.get("htr", {})
 


### PR DESCRIPTION
## Summary
- build heater name mappings from the prepared inventory instead of the raw node payload
- update heater tests to reflect the new behaviour and ensure the inventory is forwarded to the name map helper

## Testing
- pytest tests/test_heater_base.py tests/test_heater_energy_sensor.py tests/test_climate.py
- ruff check custom_components/termoweb/heater.py tests/test_heater_base.py

------
https://chatgpt.com/codex/tasks/task_e_68d92de380888329af0eb423b0ee8c8a