### PR TITLE
Refactor TermoWeb config flow login handling

### DIFF
--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -1,3 +1,5 @@
+"""Config flow handlers for the TermoWeb integration."""
+
 from __future__ import annotations
 
 import logging
@@ -83,23 +85,41 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Collect credentials and create the config entry."""
-        ver = await _get_version(self.hass)
-        _LOGGER.info("TermoWeb config flow started (v%s)", ver)
+    async def _handle_login_workflow(
+        self,
+        *,
+        step_id: str,
+        user_input: dict[str, Any] | None,
+        defaults: dict[str, Any],
+        version: str,
+    ) -> tuple[FlowResult | None, dict[str, Any]]:
+        """Handle shared login form validation and error handling."""
+
+        default_user = (defaults.get("username") or "").strip()
+        default_poll = int(defaults.get("poll_interval", DEFAULT_POLL_INTERVAL))
+        default_brand = defaults.get(CONF_BRAND, DEFAULT_BRAND)
+        if default_brand not in BRAND_LABELS:
+            default_brand = DEFAULT_BRAND
 
         if user_input is None:
             schema = _login_schema(
-                default_user="",
-                default_poll=DEFAULT_POLL_INTERVAL,
-                default_brand=DEFAULT_BRAND,
+                default_user=default_user,
+                default_poll=default_poll,
+                default_brand=default_brand,
             )
-            return self.async_show_form(step_id="user", data_schema=schema, description_placeholders={"version": ver})
+            return (
+                self.async_show_form(
+                    step_id=step_id,
+                    data_schema=schema,
+                    description_placeholders={"version": version},
+                ),
+                {},
+            )
 
-        username = (user_input.get("username") or "").strip()
+        username = (user_input.get("username") or default_user).strip()
         password = user_input.get("password") or ""
-        poll_interval = int(user_input.get("poll_interval", DEFAULT_POLL_INTERVAL))
-        brand_in = user_input.get(CONF_BRAND) or DEFAULT_BRAND
+        poll_interval = int(user_input.get("poll_interval", default_poll))
+        brand_in = user_input.get(CONF_BRAND, default_brand)
         brand = brand_in if brand_in in BRAND_LABELS else DEFAULT_BRAND
 
         errors: dict[str, str] = {}
@@ -112,20 +132,24 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ClientError:
             errors["base"] = "cannot_connect"
         except Exception:
-            _LOGGER.exception("Unexpected error in login")
+            _LOGGER.exception("Unexpected error during %s step", step_id)
             errors["base"] = "unknown"
 
         if errors:
             schema = _login_schema(
-                default_user=username,
+                default_user=username or default_user,
                 default_poll=poll_interval,
                 default_brand=brand,
             )
-            return self.async_show_form(step_id="user", data_schema=schema, errors=errors, description_placeholders={"version": ver})
-
-        unique_id = username if brand == BRAND_TERMOWEB else f"{brand}:{username}"
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+            return (
+                self.async_show_form(
+                    step_id=step_id,
+                    data_schema=schema,
+                    errors=errors,
+                    description_placeholders={"version": version},
+                ),
+                {},
+            )
 
         data = {
             "username": username,
@@ -133,6 +157,34 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "poll_interval": poll_interval,
             CONF_BRAND: brand,
         }
+        return None, data
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Collect credentials and create the config entry."""
+        ver = await _get_version(self.hass)
+        _LOGGER.info("TermoWeb config flow started (v%s)", ver)
+
+        result, data = await self._handle_login_workflow(
+            step_id="user",
+            user_input=user_input,
+            defaults={
+                "username": "",
+                "poll_interval": DEFAULT_POLL_INTERVAL,
+                CONF_BRAND: DEFAULT_BRAND,
+            },
+            version=ver,
+        )
+
+        if result is not None:
+            return result
+
+        username = data["username"]
+        brand = data[CONF_BRAND]
+
+        unique_id = username if brand == BRAND_TERMOWEB else f"{brand}:{username}"
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
         title = f"{get_brand_label(brand)} ({username})"
         return self.async_create_entry(title=title, data=data)
 
@@ -149,40 +201,24 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current_poll = int(entry.options.get("poll_interval", entry.data.get("poll_interval", DEFAULT_POLL_INTERVAL)))
         current_brand = entry.data.get(CONF_BRAND, DEFAULT_BRAND)
 
-        if user_input is None:
-            schema = _login_schema(
-                default_user=current_user,
-                default_poll=current_poll,
-                default_brand=current_brand,
-            )
-            return self.async_show_form(step_id="reconfigure", data_schema=schema, description_placeholders={"version": ver})
+        result, data = await self._handle_login_workflow(
+            step_id="reconfigure",
+            user_input=user_input,
+            defaults={
+                "username": current_user,
+                "poll_interval": current_poll,
+                CONF_BRAND: current_brand,
+            },
+            version=ver,
+        )
 
-        username = (user_input.get("username") or "").strip()
-        password = user_input.get("password") or ""
-        poll_interval = int(user_input.get("poll_interval", current_poll))
-        brand_in = user_input.get(CONF_BRAND, current_brand)
-        brand = brand_in if brand_in in BRAND_LABELS else DEFAULT_BRAND
+        if result is not None:
+            return result
 
-        errors: dict[str, str] = {}
-        try:
-            await _validate_login(self.hass, username, password, brand)
-        except BackendAuthError:
-            errors["base"] = "invalid_auth"
-        except BackendRateLimitError:
-            errors["base"] = "rate_limited"
-        except ClientError:
-            errors["base"] = "cannot_connect"
-        except Exception:
-            _LOGGER.exception("Unexpected error during reconfigure")
-            errors["base"] = "unknown"
-
-        if errors:
-            schema = _login_schema(
-                default_user=username or current_user,
-                default_poll=poll_interval,
-                default_brand=brand,
-            )
-            return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors, description_placeholders={"version": ver})
+        username = data["username"]
+        password = data["password"]
+        poll_interval = data["poll_interval"]
+        brand = data[CONF_BRAND]
 
         new_data = dict(entry.data)
         new_data.update(
@@ -212,7 +248,7 @@ class TermoWebOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        from .const import (  # local import to avoid circulars
+        from .const import (  # noqa: PLC0415 - local import to avoid circulars
             DEFAULT_POLL_INTERVAL,
             MAX_POLL_INTERVAL,
             MIN_POLL_INTERVAL,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -248,6 +248,36 @@ def test_async_step_reconfigure_initial_form(
     assert _schema_default(schema, "brand") == config_flow.BRAND_DUCAHEAT
 
 
+def test_async_step_reconfigure_invalid_brand_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = HomeAssistant()
+    entry = ConfigEntry(
+        "entry-id",
+        data={
+            "username": "existing",
+            "poll_interval": 150,
+            config_flow.CONF_BRAND: "legacy",
+        },
+        options={"poll_interval": 150},
+    )
+    hass.config_entries.add_entry(entry)
+
+    flow = _create_flow(hass)
+    flow.context = {"entry_id": entry.entry_id}
+
+    async def fake_version(_hass: HomeAssistant) -> str:
+        return "7.7.7"
+
+    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+
+    result = asyncio.run(flow.async_step_reconfigure())
+
+    assert result["type"] == "form"
+    schema = result["data_schema"]
+    assert _schema_default(schema, "brand") == config_flow.DEFAULT_BRAND
+
+
 def test_async_step_reconfigure_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- extract the shared login form/validation workflow into a TermoWebConfigFlow helper
- refactor the user and reconfigure steps to call the helper with appropriate defaults
- extend config flow tests, including coverage for invalid stored brand defaults

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d92df688288329bc9e4c4c9ec2bccb