### PR TITLE
Refactor integration version retrieval

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -14,7 +14,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.loader import async_get_integration
 
 from . import energy as energy_module
 from .api import BackendAuthError, BackendRateLimitError, RESTClient
@@ -46,6 +45,7 @@ from .energy import (
 from .nodes import build_node_inventory
 from .utils import (
     HEATER_NODE_TYPES as _HEATER_NODE_TYPES,
+    async_get_integration_version as _async_get_integration_version,
     build_heater_address_map as _build_heater_address_map,
     ensure_node_inventory as _ensure_node_inventory,
     normalize_heater_addresses as _normalize_heater_addresses,
@@ -114,9 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_base = get_brand_api_base(brand)
     basic_auth = get_brand_basic_auth(brand)
 
-    # DRY version: read from manifest
-    integration = await async_get_integration(hass, DOMAIN)
-    version = integration.version or "unknown"
+    version = await _async_get_integration_version(hass)
 
     client_cls = DucaheatRESTClient if brand == BRAND_DUCAHEAT else RESTClient
     client = client_cls(

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
-from homeassistant.loader import async_get_integration
 import voluptuous as vol
 
 from .api import BackendAuthError, BackendRateLimitError, RESTClient
@@ -27,6 +26,7 @@ from .const import (
     get_brand_basic_auth,
     get_brand_label,
 )
+from .utils import async_get_integration_version
 
 BRAND_DUCAHEAT = CONST_BRAND_DUCAHEAT
 
@@ -35,8 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def _get_version(hass: HomeAssistant) -> str:
     """Read integration version from manifest (DRY)."""
-    integ = await async_get_integration(hass, DOMAIN)
-    return integ.version or "unknown"
+    return await async_get_integration_version(hass)
 
 
 def _login_schema(

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -8,11 +8,19 @@ from typing import Any, cast
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.loader import async_get_integration
 
 from .const import DOMAIN
 from .nodes import Node, build_node_inventory
 
 HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
+
+
+async def async_get_integration_version(hass: HomeAssistant) -> str:
+    """Return the installed integration version string."""
+
+    integration = await async_get_integration(hass, DOMAIN)
+    return integration.version or "unknown"
 
 
 def build_heater_energy_unique_id(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -51,7 +51,8 @@ def test_get_version_returns_unknown_when_missing(
         return DummyIntegration("")
 
     monkeypatch.setattr(
-        config_flow, "async_get_integration", fake_get_integration
+        "custom_components.termoweb.utils.async_get_integration",
+        fake_get_integration,
     )
 
     result = asyncio.run(config_flow._get_version(hass))
@@ -114,7 +115,7 @@ def test_async_step_user_initial_form(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_version(_hass: HomeAssistant) -> str:
         return "1.2.3"
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
 
     result = asyncio.run(flow.async_step_user())
 
@@ -143,7 +144,7 @@ def test_async_step_user_success(monkeypatch: pytest.MonkeyPatch) -> None:
     ) -> None:
         calls.append((username, password, brand))
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     result = asyncio.run(
@@ -191,7 +192,7 @@ def test_async_step_user_errors(
     ) -> None:
         raise raised_factory()
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     user_input = {
@@ -233,7 +234,7 @@ def test_async_step_reconfigure_initial_form(
     async def fake_version(_hass: HomeAssistant) -> str:
         return "3.3.3"
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
 
     result = asyncio.run(flow.async_step_reconfigure())
 
@@ -278,7 +279,7 @@ def test_async_step_reconfigure_success(
         assert password == "new-pass"
         assert brand == config_flow.BRAND_DUCAHEAT
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     result = asyncio.run(
@@ -346,7 +347,7 @@ def test_async_step_reconfigure_errors(
     ) -> None:
         raise raised_factory()
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     user_input = {
@@ -384,7 +385,7 @@ def test_options_flow_init_and_submit(
     async def fake_version(_hass: HomeAssistant) -> str:
         return "6.6.6"
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
 
     initial = asyncio.run(options_flow.async_step_init())
     assert initial["type"] == "form"


### PR DESCRIPTION
## Summary
- add a shared `async_get_integration_version` helper in `utils` that wraps `async_get_integration`
- use the new helper when retrieving the manifest version during setup and config flows
- update config flow tests to patch the helper when stubbing version strings

## Testing
- ruff check --fix *(fails: existing repository lint violations unrelated to this change)*
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d92eb9cde48329a35965c7b1abac78