### PR TITLE
Refactor TermoWeb client creation and update tests

### DIFF
--- a/custom_components/termoweb/client.py
+++ b/custom_components/termoweb/client.py
@@ -1,0 +1,53 @@
+"""Helpers for creating REST clients and shared API calls."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import ClientError
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from .api import BackendAuthError, BackendRateLimitError, RESTClient
+from .backend import DucaheatRESTClient
+from .const import (
+    BRAND_DUCAHEAT,
+    DEFAULT_BRAND,
+    get_brand_api_base,
+    get_brand_basic_auth,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def create_rest_client(
+    hass: HomeAssistant, username: str, password: str, brand: str | None
+) -> RESTClient:
+    """Return a REST client configured for the requested brand."""
+
+    normalized = brand or DEFAULT_BRAND
+    session = aiohttp_client.async_get_clientsession(hass)
+    api_base = get_brand_api_base(normalized)
+    basic_auth = get_brand_basic_auth(normalized)
+    client_cls = DucaheatRESTClient if normalized == BRAND_DUCAHEAT else RESTClient
+    return client_cls(
+        session,
+        username,
+        password,
+        api_base=api_base,
+        basic_auth_b64=basic_auth,
+    )
+
+
+async def async_list_devices_with_logging(client: RESTClient) -> Any:
+    """Call ``list_devices`` logging consistent diagnostic information."""
+
+    try:
+        return await client.list_devices()
+    except BackendAuthError as err:
+        _LOGGER.info("list_devices auth error: %s", err)
+        raise
+    except (TimeoutError, ClientError, BackendRateLimitError) as err:
+        _LOGGER.info("list_devices connection error: %s", err)
+        raise

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -8,11 +8,11 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import aiohttp_client
 from homeassistant.loader import async_get_integration
 import voluptuous as vol
 
-from .api import BackendAuthError, BackendRateLimitError, RESTClient
+from .api import BackendAuthError, BackendRateLimitError
+from .client import async_list_devices_with_logging, create_rest_client
 from .const import (
     BRAND_DUCAHEAT as CONST_BRAND_DUCAHEAT,
     BRAND_LABELS,
@@ -23,8 +23,6 @@ from .const import (
     DOMAIN,
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
-    get_brand_api_base,
-    get_brand_basic_auth,
     get_brand_label,
 )
 
@@ -65,17 +63,9 @@ async def _validate_login(
     hass: HomeAssistant, username: str, password: str, brand: str
 ) -> None:
     """Ensure the provided credentials authenticate successfully."""
-    session = aiohttp_client.async_get_clientsession(hass)
-    api_base = get_brand_api_base(brand)
-    basic_auth = get_brand_basic_auth(brand)
-    client = RESTClient(
-        session,
-        username,
-        password,
-        api_base=api_base,
-        basic_auth_b64=basic_auth,
-    )
-    await client.list_devices()
+
+    client = create_rest_client(hass, username, password, brand)
+    await async_list_devices_with_logging(client)
 
 
 class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -1,0 +1,114 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from conftest import _install_stubs
+
+_install_stubs()
+
+from custom_components.termoweb import client as client_helpers
+from homeassistant.core import HomeAssistant
+
+
+def test_create_rest_client_uses_termoweb_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = HomeAssistant()
+    session = object()
+    calls: list[tuple[Any, ...]] = []
+
+    class DummyClient:
+        def __init__(
+            self,
+            sess: Any,
+            username: str,
+            password: str,
+            *,
+            api_base: str,
+            basic_auth_b64: str,
+        ) -> None:
+            calls.append((sess, username, password, api_base, basic_auth_b64))
+
+    monkeypatch.setattr(
+        client_helpers.aiohttp_client,
+        "async_get_clientsession",
+        lambda hass_arg: session if hass_arg is hass else object(),
+    )
+    monkeypatch.setattr(client_helpers, "RESTClient", DummyClient)
+    monkeypatch.setattr(client_helpers, "DucaheatRESTClient", object())
+
+    client_helpers.create_rest_client(hass, "user@example.com", "pw", "termoweb")
+
+    assert calls == [
+        (
+            session,
+            "user@example.com",
+            "pw",
+            client_helpers.get_brand_api_base("termoweb"),
+            client_helpers.get_brand_basic_auth("termoweb"),
+        )
+    ]
+
+
+def test_create_rest_client_uses_ducaheat_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = HomeAssistant()
+    session = object()
+    calls: list[tuple[Any, ...]] = []
+
+    class DummyDucaheat:
+        def __init__(
+            self,
+            sess: Any,
+            username: str,
+            password: str,
+            *,
+            api_base: str,
+            basic_auth_b64: str,
+        ) -> None:
+            calls.append((sess, username, password, api_base, basic_auth_b64))
+
+    monkeypatch.setattr(
+        client_helpers.aiohttp_client,
+        "async_get_clientsession",
+        lambda hass_arg: session if hass_arg is hass else object(),
+    )
+    monkeypatch.setattr(client_helpers, "DucaheatRESTClient", DummyDucaheat)
+    monkeypatch.setattr(client_helpers, "RESTClient", object())
+
+    client_helpers.create_rest_client(
+        hass, "user@example.com", "pw", client_helpers.BRAND_DUCAHEAT
+    )
+
+    assert calls == [
+        (
+            session,
+            "user@example.com",
+            "pw",
+            client_helpers.get_brand_api_base(client_helpers.BRAND_DUCAHEAT),
+            client_helpers.get_brand_basic_auth(client_helpers.BRAND_DUCAHEAT),
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        client_helpers.BackendAuthError("bad"),
+        TimeoutError("timeout"),
+        client_helpers.BackendRateLimitError("slow"),
+    ],
+)
+def test_async_list_devices_with_logging_propagates(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    class DummyClient:
+        async def list_devices(self) -> None:
+            raise exc
+
+    client = DummyClient()
+    monkeypatch.setattr(client_helpers._LOGGER, "info", lambda *args, **kwargs: None)
+
+    async def _run() -> None:
+        await client_helpers.async_list_devices_with_logging(client)  # type: ignore[arg-type]
+
+    with pytest.raises(type(exc)):
+        asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a shared helper for building REST clients and performing list_devices with consistent logging
- update config flow and setup to use the helper and reuse error handling
- adjust and extend unit tests to cover the helper usage and new behavior

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d92ec39bfc8329869951e645447b97