### PR TITLE
Refactor TermoWeb client creation and update tests

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -12,13 +12,12 @@ from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.loader import async_get_integration
 
 from . import energy as energy_module
 from .api import BackendAuthError, BackendRateLimitError, RESTClient
-from .backend import Backend, DucaheatRESTClient, WsClientProto, create_backend
+from .backend import Backend, WsClientProto, create_backend
+from .client import async_list_devices_with_logging, create_rest_client
 from .const import (
     BRAND_DUCAHEAT,
     CONF_BRAND,
@@ -27,8 +26,6 @@ from .const import (
     DOMAIN,
     MIN_POLL_INTERVAL,
     STRETCHED_POLL_INTERVAL,
-    get_brand_api_base,
-    get_brand_basic_auth,
     signal_ws_status,
 )
 from .coordinator import StateCoordinator
@@ -37,15 +34,16 @@ from .energy import (
     OPTION_ENERGY_HISTORY_IMPORTED as ENERGY_OPTION_ENERGY_HISTORY_IMPORTED,
     OPTION_ENERGY_HISTORY_PROGRESS as ENERGY_OPTION_ENERGY_HISTORY_PROGRESS,
     OPTION_MAX_HISTORY_RETRIEVED as ENERGY_OPTION_MAX_HISTORY_RETRIEVED,
-    default_samples_rate_limit_state,
-    reset_samples_rate_limit_state,
+    async_import_energy_history as _async_import_energy_history_impl,
     async_register_import_energy_history_service,
     async_schedule_initial_energy_import,
-    async_import_energy_history as _async_import_energy_history_impl,
+    default_samples_rate_limit_state,
+    reset_samples_rate_limit_state,
 )
 from .nodes import build_node_inventory
 from .utils import (
     HEATER_NODE_TYPES as _HEATER_NODE_TYPES,
+    async_get_integration_version as _async_get_integration_version,
     build_heater_address_map as _build_heater_address_map,
     ensure_node_inventory as _ensure_node_inventory,
     normalize_heater_addresses as _normalize_heater_addresses,
@@ -102,7 +100,6 @@ async def _async_import_energy_history(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the TermoWeb integration for a config entry."""
-    session = aiohttp_client.async_get_clientsession(hass)
     username = entry.data["username"]
     password = entry.data["password"]
     base_interval = int(
@@ -111,29 +108,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
     brand = entry.data.get(CONF_BRAND, DEFAULT_BRAND)
-    api_base = get_brand_api_base(brand)
-    basic_auth = get_brand_basic_auth(brand)
 
-    # DRY version: read from manifest
-    integration = await async_get_integration(hass, DOMAIN)
-    version = integration.version or "unknown"
+    version = await _async_get_integration_version(hass)
 
-    client_cls = DucaheatRESTClient if brand == BRAND_DUCAHEAT else RESTClient
-    client = client_cls(
-        session,
-        username,
-        password,
-        api_base=api_base,
-        basic_auth_b64=basic_auth,
-    )
+    client: RESTClient = create_rest_client(hass, username, password, brand)
     backend = create_backend(brand=brand, client=client)
     try:
-        devices = await client.list_devices()
+        devices = await async_list_devices_with_logging(client)
     except BackendAuthError as err:
-        _LOGGER.info("list_devices auth error: %s", err)
         raise ConfigEntryAuthFailed from err
     except (TimeoutError, ClientError, BackendRateLimitError) as err:
-        _LOGGER.info("list_devices connection error: %s", err)
         raise ConfigEntryNotReady from err
 
     if not devices:

--- a/custom_components/termoweb/client.py
+++ b/custom_components/termoweb/client.py
@@ -1,0 +1,53 @@
+"""Helpers for creating REST clients and shared API calls."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import ClientError
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from .api import BackendAuthError, BackendRateLimitError, RESTClient
+from .backend import DucaheatRESTClient
+from .const import (
+    BRAND_DUCAHEAT,
+    DEFAULT_BRAND,
+    get_brand_api_base,
+    get_brand_basic_auth,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def create_rest_client(
+    hass: HomeAssistant, username: str, password: str, brand: str | None
+) -> RESTClient:
+    """Return a REST client configured for the requested brand."""
+
+    normalized = brand or DEFAULT_BRAND
+    session = aiohttp_client.async_get_clientsession(hass)
+    api_base = get_brand_api_base(normalized)
+    basic_auth = get_brand_basic_auth(normalized)
+    client_cls = DucaheatRESTClient if normalized == BRAND_DUCAHEAT else RESTClient
+    return client_cls(
+        session,
+        username,
+        password,
+        api_base=api_base,
+        basic_auth_b64=basic_auth,
+    )
+
+
+async def async_list_devices_with_logging(client: RESTClient) -> Any:
+    """Call ``list_devices`` logging consistent diagnostic information."""
+
+    try:
+        return await client.list_devices()
+    except BackendAuthError as err:
+        _LOGGER.info("list_devices auth error: %s", err)
+        raise
+    except (TimeoutError, ClientError, BackendRateLimitError) as err:
+        _LOGGER.info("list_devices connection error: %s", err)
+        raise

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -1,3 +1,5 @@
+"""Config flow handlers for the TermoWeb integration."""
+
 from __future__ import annotations
 
 import logging
@@ -8,11 +10,10 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import aiohttp_client
-from homeassistant.loader import async_get_integration
 import voluptuous as vol
 
-from .api import BackendAuthError, BackendRateLimitError, RESTClient
+from .api import BackendAuthError, BackendRateLimitError
+from .client import async_list_devices_with_logging, create_rest_client
 from .const import (
     BRAND_DUCAHEAT as CONST_BRAND_DUCAHEAT,
     BRAND_LABELS,
@@ -23,10 +24,9 @@ from .const import (
     DOMAIN,
     MAX_POLL_INTERVAL,
     MIN_POLL_INTERVAL,
-    get_brand_api_base,
-    get_brand_basic_auth,
     get_brand_label,
 )
+from .utils import async_get_integration_version
 
 BRAND_DUCAHEAT = CONST_BRAND_DUCAHEAT
 
@@ -35,8 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def _get_version(hass: HomeAssistant) -> str:
     """Read integration version from manifest (DRY)."""
-    integ = await async_get_integration(hass, DOMAIN)
-    return integ.version or "unknown"
+    return await async_get_integration_version(hass)
 
 
 def _login_schema(
@@ -65,17 +64,9 @@ async def _validate_login(
     hass: HomeAssistant, username: str, password: str, brand: str
 ) -> None:
     """Ensure the provided credentials authenticate successfully."""
-    session = aiohttp_client.async_get_clientsession(hass)
-    api_base = get_brand_api_base(brand)
-    basic_auth = get_brand_basic_auth(brand)
-    client = RESTClient(
-        session,
-        username,
-        password,
-        api_base=api_base,
-        basic_auth_b64=basic_auth,
-    )
-    await client.list_devices()
+
+    client = create_rest_client(hass, username, password, brand)
+    await async_list_devices_with_logging(client)
 
 
 class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -83,23 +74,41 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
-        """Collect credentials and create the config entry."""
-        ver = await _get_version(self.hass)
-        _LOGGER.info("TermoWeb config flow started (v%s)", ver)
+    async def _handle_login_workflow(
+        self,
+        *,
+        step_id: str,
+        user_input: dict[str, Any] | None,
+        defaults: dict[str, Any],
+        version: str,
+    ) -> tuple[FlowResult | None, dict[str, Any]]:
+        """Handle shared login form validation and error handling."""
+
+        default_user = (defaults.get("username") or "").strip()
+        default_poll = int(defaults.get("poll_interval", DEFAULT_POLL_INTERVAL))
+        default_brand = defaults.get(CONF_BRAND, DEFAULT_BRAND)
+        if default_brand not in BRAND_LABELS:
+            default_brand = DEFAULT_BRAND
 
         if user_input is None:
             schema = _login_schema(
-                default_user="",
-                default_poll=DEFAULT_POLL_INTERVAL,
-                default_brand=DEFAULT_BRAND,
+                default_user=default_user,
+                default_poll=default_poll,
+                default_brand=default_brand,
             )
-            return self.async_show_form(step_id="user", data_schema=schema, description_placeholders={"version": ver})
+            return (
+                self.async_show_form(
+                    step_id=step_id,
+                    data_schema=schema,
+                    description_placeholders={"version": version},
+                ),
+                {},
+            )
 
-        username = (user_input.get("username") or "").strip()
+        username = (user_input.get("username") or default_user).strip()
         password = user_input.get("password") or ""
-        poll_interval = int(user_input.get("poll_interval", DEFAULT_POLL_INTERVAL))
-        brand_in = user_input.get(CONF_BRAND) or DEFAULT_BRAND
+        poll_interval = int(user_input.get("poll_interval", default_poll))
+        brand_in = user_input.get(CONF_BRAND, default_brand)
         brand = brand_in if brand_in in BRAND_LABELS else DEFAULT_BRAND
 
         errors: dict[str, str] = {}
@@ -112,20 +121,24 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ClientError:
             errors["base"] = "cannot_connect"
         except Exception:
-            _LOGGER.exception("Unexpected error in login")
+            _LOGGER.exception("Unexpected error during %s step", step_id)
             errors["base"] = "unknown"
 
         if errors:
             schema = _login_schema(
-                default_user=username,
+                default_user=username or default_user,
                 default_poll=poll_interval,
                 default_brand=brand,
             )
-            return self.async_show_form(step_id="user", data_schema=schema, errors=errors, description_placeholders={"version": ver})
-
-        unique_id = username if brand == BRAND_TERMOWEB else f"{brand}:{username}"
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
+            return (
+                self.async_show_form(
+                    step_id=step_id,
+                    data_schema=schema,
+                    errors=errors,
+                    description_placeholders={"version": version},
+                ),
+                {},
+            )
 
         data = {
             "username": username,
@@ -133,6 +146,34 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "poll_interval": poll_interval,
             CONF_BRAND: brand,
         }
+        return None, data
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Collect credentials and create the config entry."""
+        ver = await _get_version(self.hass)
+        _LOGGER.info("TermoWeb config flow started (v%s)", ver)
+
+        result, data = await self._handle_login_workflow(
+            step_id="user",
+            user_input=user_input,
+            defaults={
+                "username": "",
+                "poll_interval": DEFAULT_POLL_INTERVAL,
+                CONF_BRAND: DEFAULT_BRAND,
+            },
+            version=ver,
+        )
+
+        if result is not None:
+            return result
+
+        username = data["username"]
+        brand = data[CONF_BRAND]
+
+        unique_id = username if brand == BRAND_TERMOWEB else f"{brand}:{username}"
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
         title = f"{get_brand_label(brand)} ({username})"
         return self.async_create_entry(title=title, data=data)
 
@@ -149,40 +190,24 @@ class TermoWebConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current_poll = int(entry.options.get("poll_interval", entry.data.get("poll_interval", DEFAULT_POLL_INTERVAL)))
         current_brand = entry.data.get(CONF_BRAND, DEFAULT_BRAND)
 
-        if user_input is None:
-            schema = _login_schema(
-                default_user=current_user,
-                default_poll=current_poll,
-                default_brand=current_brand,
-            )
-            return self.async_show_form(step_id="reconfigure", data_schema=schema, description_placeholders={"version": ver})
+        result, data = await self._handle_login_workflow(
+            step_id="reconfigure",
+            user_input=user_input,
+            defaults={
+                "username": current_user,
+                "poll_interval": current_poll,
+                CONF_BRAND: current_brand,
+            },
+            version=ver,
+        )
 
-        username = (user_input.get("username") or "").strip()
-        password = user_input.get("password") or ""
-        poll_interval = int(user_input.get("poll_interval", current_poll))
-        brand_in = user_input.get(CONF_BRAND, current_brand)
-        brand = brand_in if brand_in in BRAND_LABELS else DEFAULT_BRAND
+        if result is not None:
+            return result
 
-        errors: dict[str, str] = {}
-        try:
-            await _validate_login(self.hass, username, password, brand)
-        except BackendAuthError:
-            errors["base"] = "invalid_auth"
-        except BackendRateLimitError:
-            errors["base"] = "rate_limited"
-        except ClientError:
-            errors["base"] = "cannot_connect"
-        except Exception:
-            _LOGGER.exception("Unexpected error during reconfigure")
-            errors["base"] = "unknown"
-
-        if errors:
-            schema = _login_schema(
-                default_user=username or current_user,
-                default_poll=poll_interval,
-                default_brand=brand,
-            )
-            return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors, description_placeholders={"version": ver})
+        username = data["username"]
+        password = data["password"]
+        poll_interval = data["poll_interval"]
+        brand = data[CONF_BRAND]
 
         new_data = dict(entry.data)
         new_data.update(
@@ -212,7 +237,7 @@ class TermoWebOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        from .const import (  # local import to avoid circulars
+        from .const import (  # noqa: PLC0415 - local import to avoid circulars
             DEFAULT_POLL_INTERVAL,
             MAX_POLL_INTERVAL,
             MIN_POLL_INTERVAL,

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -241,7 +241,7 @@ def prepare_heater_platform_data(
         for node_type in HEATER_NODE_TYPES
     }
 
-    name_map = build_heater_name_map(nodes, default_name_simple)
+    name_map = build_heater_name_map(inventory, default_name_simple)
     names_by_type: dict[str, dict[str, str]] = name_map.get("by_type", {})
     legacy_names: dict[str, str] = name_map.get("htr", {})
 

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -8,11 +8,19 @@ from typing import Any, cast
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.loader import async_get_integration
 
 from .const import DOMAIN
 from .nodes import Node, build_node_inventory
 
 HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
+
+
+async def async_get_integration_version(hass: HomeAssistant) -> str:
+    """Return the installed integration version string."""
+
+    integration = await async_get_integration(hass, DOMAIN)
+    return integration.version or "unknown"
 
 
 def build_heater_energy_unique_id(

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -1,0 +1,114 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from conftest import _install_stubs
+
+_install_stubs()
+
+from custom_components.termoweb import client as client_helpers
+from homeassistant.core import HomeAssistant
+
+
+def test_create_rest_client_uses_termoweb_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = HomeAssistant()
+    session = object()
+    calls: list[tuple[Any, ...]] = []
+
+    class DummyClient:
+        def __init__(
+            self,
+            sess: Any,
+            username: str,
+            password: str,
+            *,
+            api_base: str,
+            basic_auth_b64: str,
+        ) -> None:
+            calls.append((sess, username, password, api_base, basic_auth_b64))
+
+    monkeypatch.setattr(
+        client_helpers.aiohttp_client,
+        "async_get_clientsession",
+        lambda hass_arg: session if hass_arg is hass else object(),
+    )
+    monkeypatch.setattr(client_helpers, "RESTClient", DummyClient)
+    monkeypatch.setattr(client_helpers, "DucaheatRESTClient", object())
+
+    client_helpers.create_rest_client(hass, "user@example.com", "pw", "termoweb")
+
+    assert calls == [
+        (
+            session,
+            "user@example.com",
+            "pw",
+            client_helpers.get_brand_api_base("termoweb"),
+            client_helpers.get_brand_basic_auth("termoweb"),
+        )
+    ]
+
+
+def test_create_rest_client_uses_ducaheat_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = HomeAssistant()
+    session = object()
+    calls: list[tuple[Any, ...]] = []
+
+    class DummyDucaheat:
+        def __init__(
+            self,
+            sess: Any,
+            username: str,
+            password: str,
+            *,
+            api_base: str,
+            basic_auth_b64: str,
+        ) -> None:
+            calls.append((sess, username, password, api_base, basic_auth_b64))
+
+    monkeypatch.setattr(
+        client_helpers.aiohttp_client,
+        "async_get_clientsession",
+        lambda hass_arg: session if hass_arg is hass else object(),
+    )
+    monkeypatch.setattr(client_helpers, "DucaheatRESTClient", DummyDucaheat)
+    monkeypatch.setattr(client_helpers, "RESTClient", object())
+
+    client_helpers.create_rest_client(
+        hass, "user@example.com", "pw", client_helpers.BRAND_DUCAHEAT
+    )
+
+    assert calls == [
+        (
+            session,
+            "user@example.com",
+            "pw",
+            client_helpers.get_brand_api_base(client_helpers.BRAND_DUCAHEAT),
+            client_helpers.get_brand_basic_auth(client_helpers.BRAND_DUCAHEAT),
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        client_helpers.BackendAuthError("bad"),
+        TimeoutError("timeout"),
+        client_helpers.BackendRateLimitError("slow"),
+    ],
+)
+def test_async_list_devices_with_logging_propagates(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    class DummyClient:
+        async def list_devices(self) -> None:
+            raise exc
+
+    client = DummyClient()
+    monkeypatch.setattr(client_helpers._LOGGER, "info", lambda *args, **kwargs: None)
+
+    async def _run() -> None:
+        await client_helpers.async_list_devices_with_logging(client)  # type: ignore[arg-type]
+
+    with pytest.raises(type(exc)):
+        asyncio.run(_run())

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import pytest
 import voluptuous as vol
+from unittest.mock import AsyncMock
+
 from conftest import _install_stubs
 
 _install_stubs()
@@ -51,7 +53,8 @@ def test_get_version_returns_unknown_when_missing(
         return DummyIntegration("")
 
     monkeypatch.setattr(
-        config_flow, "async_get_integration", fake_get_integration
+        "custom_components.termoweb.utils.async_get_integration",
+        fake_get_integration,
     )
 
     result = asyncio.run(config_flow._get_version(hass))
@@ -59,28 +62,28 @@ def test_get_version_returns_unknown_when_missing(
     assert result == "unknown"
 
 
-def test_validate_login_uses_brand_settings(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_validate_login_invokes_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     hass = HomeAssistant()
-    calls: list[tuple[Any, str, str, str, str]] = []
+    created: list[tuple[Any, str, str, str]] = []
+    clients: list[Any] = []
 
     class DummyClient:
-        def __init__(
-            self,
-            session: object,
-            username: str,
-            password: str,
-            *,
-            api_base: str,
-            basic_auth_b64: str,
-        ) -> None:
-            calls.append((session, username, password, api_base, basic_auth_b64))
+        pass
 
-        async def list_devices(self) -> None:
-            calls.append(("listed",))
+    def fake_create(
+        hass_arg: HomeAssistant, username: str, password: str, brand: str
+    ) -> DummyClient:
+        created.append((hass_arg, username, password, brand))
+        client = DummyClient()
+        clients.append(client)
+        return client
 
-    monkeypatch.setattr(config_flow, "RESTClient", DummyClient)
+    async_mock = AsyncMock(return_value=[{"dev_id": "123"}])
+
+    monkeypatch.setattr(config_flow, "create_rest_client", fake_create)
+    monkeypatch.setattr(
+        config_flow, "async_list_devices_with_logging", async_mock
+    )
 
     asyncio.run(
         config_flow._validate_login(
@@ -88,13 +91,28 @@ def test_validate_login_uses_brand_settings(
         )
     )
 
-    assert calls
-    _session, username, password, api_base, basic_auth = calls[0]
-    assert username == "user@example.com"
-    assert password == "pw"
-    assert api_base == config_flow.get_brand_api_base(config_flow.BRAND_DUCAHEAT)
-    assert basic_auth == config_flow.get_brand_basic_auth(config_flow.BRAND_DUCAHEAT)
-    assert calls[-1] == ("listed",)
+    assert created == [
+        (hass, "user@example.com", "pw", config_flow.BRAND_DUCAHEAT)
+    ]
+    assert async_mock.await_count == 1
+    assert async_mock.await_args.args == (clients[0],)
+
+
+def test_validate_login_propagates_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    hass = HomeAssistant()
+    client = object()
+    monkeypatch.setattr(
+        config_flow, "create_rest_client", lambda *args, **kwargs: client
+    )
+    async_mock = AsyncMock(side_effect=config_flow.BackendAuthError("boom"))
+    monkeypatch.setattr(
+        config_flow, "async_list_devices_with_logging", async_mock
+    )
+
+    with pytest.raises(config_flow.BackendAuthError):
+        asyncio.run(config_flow._validate_login(hass, "user", "pw", "brand"))
+
+    async_mock.assert_awaited_once_with(client)
 
 
 def test_async_step_reconfigure_missing_entry_aborts() -> None:
@@ -114,7 +132,7 @@ def test_async_step_user_initial_form(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_version(_hass: HomeAssistant) -> str:
         return "1.2.3"
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
 
     result = asyncio.run(flow.async_step_user())
 
@@ -143,7 +161,7 @@ def test_async_step_user_success(monkeypatch: pytest.MonkeyPatch) -> None:
     ) -> None:
         calls.append((username, password, brand))
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     result = asyncio.run(
@@ -191,7 +209,7 @@ def test_async_step_user_errors(
     ) -> None:
         raise raised_factory()
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     user_input = {
@@ -233,7 +251,7 @@ def test_async_step_reconfigure_initial_form(
     async def fake_version(_hass: HomeAssistant) -> str:
         return "3.3.3"
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
 
     result = asyncio.run(flow.async_step_reconfigure())
 
@@ -246,6 +264,36 @@ def test_async_step_reconfigure_initial_form(
     assert _schema_default(schema, "username") == "existing"
     assert _schema_default(schema, "poll_interval") == 180
     assert _schema_default(schema, "brand") == config_flow.BRAND_DUCAHEAT
+
+
+def test_async_step_reconfigure_invalid_brand_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hass = HomeAssistant()
+    entry = ConfigEntry(
+        "entry-id",
+        data={
+            "username": "existing",
+            "poll_interval": 150,
+            config_flow.CONF_BRAND: "legacy",
+        },
+        options={"poll_interval": 150},
+    )
+    hass.config_entries.add_entry(entry)
+
+    flow = _create_flow(hass)
+    flow.context = {"entry_id": entry.entry_id}
+
+    async def fake_version(_hass: HomeAssistant) -> str:
+        return "7.7.7"
+
+    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+
+    result = asyncio.run(flow.async_step_reconfigure())
+
+    assert result["type"] == "form"
+    schema = result["data_schema"]
+    assert _schema_default(schema, "brand") == config_flow.DEFAULT_BRAND
 
 
 def test_async_step_reconfigure_success(
@@ -278,7 +326,7 @@ def test_async_step_reconfigure_success(
         assert password == "new-pass"
         assert brand == config_flow.BRAND_DUCAHEAT
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     result = asyncio.run(
@@ -346,7 +394,7 @@ def test_async_step_reconfigure_errors(
     ) -> None:
         raise raised_factory()
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
     monkeypatch.setattr(config_flow, "_validate_login", fake_validate)
 
     user_input = {
@@ -384,7 +432,7 @@ def test_options_flow_init_and_submit(
     async def fake_version(_hass: HomeAssistant) -> str:
         return "6.6.6"
 
-    monkeypatch.setattr(config_flow, "_get_version", fake_version)
+    monkeypatch.setattr(config_flow, "async_get_integration_version", fake_version)
 
     initial = asyncio.run(options_flow.async_step_init())
     assert initial["type"] == "form"

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -59,7 +59,7 @@ def test_ensure_inventory_rebuilds_and_refreshes_cache(
 
     assert inventory is sentinel
     assert coord._nodes_by_type == {"htr": ["1"]}
-    assert coord._addr_lookup == {"1": "htr"}
+    assert coord._addr_lookup == {"1": {"htr"}}
 
 
 def test_update_nodes_uses_provided_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -88,7 +88,7 @@ def test_update_nodes_uses_provided_inventory(monkeypatch: pytest.MonkeyPatch) -
 
     assert coord._node_inventory == provided
     assert coord._nodes_by_type == {"acm": ["2"]}
-    assert coord._addr_lookup == {"2": "acm"}
+    assert coord._addr_lookup == {"2": {"acm"}}
     assert builder_called is False
 
 
@@ -309,7 +309,7 @@ def test_register_node_address_strips_and_skips_blank() -> None:
     coord._register_node_address(" htr ", " A ")
 
     assert coord._nodes_by_type == {"htr": ["A"]}
-    assert coord._addr_lookup == {"A": "htr"}
+    assert coord._addr_lookup == {"A": {"htr"}}
 
 
 def test_refresh_heater_updates_existing_and_new_data() -> None:
@@ -456,7 +456,7 @@ def test_async_refresh_heater_adds_missing_type() -> None:
         )
 
         coord._nodes_by_type = {"htr": ["A"]}
-        coord._addr_lookup = {"A": "htr"}
+        coord._addr_lookup = {"A": {"htr"}}
         coord.data = {
             "dev": {
                 "nodes_by_type": {"htr": {"addrs": ["A"], "settings": {"A": {"mode": "manual"}}}}


### PR DESCRIPTION
## Summary
- add a shared helper for building REST clients and performing list_devices with consistent logging
- update config flow and setup to use the helper and reuse error handling
- adjust and extend unit tests to cover the helper usage and new behavior

## Testing
- ruff check custom_components/termoweb/client.py
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d92ec39bfc8329869951e645447b97