### PR TITLE
Refactor websocket heartbeat scheduling

### DIFF
--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -488,7 +488,9 @@ def test_engineio_connect_and_send() -> None:
     asyncio.run(_run())
 
 
-def test_engineio_ping_loop_handles_cancel_and_failures() -> None:
+def test_engineio_ping_loop_handles_cancel_and_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     module = _load_ws_client()
 
     async def _run() -> None:
@@ -513,14 +515,36 @@ def test_engineio_ping_loop_handles_cancel_and_failures() -> None:
             protocol="engineio2",
         )
 
-        client._engineio_ping_interval = 0.0
-        client._engineio_send = AsyncMock(return_value=None)
+        client._engineio_ping_interval = 1.0
+
+        send_calls: list[str] = []
+        send_event = asyncio.Event()
+
+        async def fake_send(data: str) -> None:
+            send_calls.append(data)
+            if len(send_calls) >= 3:
+                send_event.set()
+
+        client._engineio_send = AsyncMock(side_effect=fake_send)
+
+        orig_sleep = asyncio.sleep
+        sleep_calls: list[float] = []
+
+        async def fast_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+            await orig_sleep(0)
+
+        monkeypatch.setattr(module.asyncio, "sleep", fast_sleep)
+        monkeypatch.setattr(ws_core.asyncio, "sleep", fast_sleep)
 
         task = asyncio.create_task(client._engineio_ping_loop())
-        await asyncio.sleep(0)
+        await asyncio.wait_for(send_event.wait(), timeout=0.2)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
+
+        assert send_calls[:3] == ["2", "2", "2"]
+        assert sleep_calls[:3] == [pytest.approx(1.0)] * 3
 
         client._engineio_send = AsyncMock(side_effect=RuntimeError("fail"))
         client._engineio_ping_interval = 0.0


### PR DESCRIPTION
## Summary
- add a reusable heartbeat runner in the websocket client
- reuse the helper for legacy heartbeats and engine.io ping intervals
- extend the websocket tests to assert the ping cadence for engine.io

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d93b9365bc832992f5e98789be7378