### PR TITLE
Add normalization helpers for node metadata

### DIFF
--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -110,6 +110,21 @@ def test_set_inventory_from_nodes_defaults_to_empty() -> None:
     assert coord._node_inventory == []
 
 
+def test_normalise_type_section_cleans_addresses() -> None:
+    section = {
+        "addrs": [" 1 ", None, "2"],
+        "settings": {" 1 ": {"mode": "auto"}, None: {"mode": "skip"}},
+    }
+
+    normalized = StateCoordinator._normalise_type_section("htr", section, [" 3 ", ""])
+
+    assert normalized["addrs"] == ["1", "None", "2"]
+    assert normalized["settings"] == {
+        "1": {"mode": "auto"},
+        "None": {"mode": "skip"},
+    }
+
+
 def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
         client = types.SimpleNamespace()

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -180,6 +180,23 @@ def test_build_heater_name_map_accepts_iterables_of_dicts() -> None:
     assert result.get("htr", {}).get("1") == "Heater 1"
 
 
+def test_prepare_heater_platform_data_resolves_normalized_inputs() -> None:
+    entry_data = {
+        "nodes": {
+            "nodes": [
+                {"type": " hTr ", "addr": " 8 ", "name": "Hall"},
+            ]
+        }
+    }
+
+    _, _, _, resolve_name = prepare_heater_platform_data(
+        entry_data,
+        default_name_simple=lambda addr: f"Heater {addr}",
+    )
+
+    assert resolve_name(" HTR ", " 8 ") == "Hall"
+
+
 def test_log_skipped_nodes_defaults_platform_name(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -14,6 +14,7 @@ from custom_components.termoweb.nodes import (
     ThermostatNode,
     build_node_inventory,
 )
+from custom_components.termoweb.utils import normalize_node_addr, normalize_node_type
 
 
 def test_heater_node_normalises_inputs() -> None:
@@ -134,3 +135,17 @@ def test_build_node_inventory_handles_list_payload(caplog: pytest.LogCaptureFixt
 
 def test_build_node_inventory_tolerates_empty_payload() -> None:
     assert build_node_inventory({"nodes": []}) == []
+
+
+def test_utils_normalization_matches_node_inventory() -> None:
+    payload = {"nodes": [{"type": " HTR ", "addr": " 01 "}]}
+
+    nodes = build_node_inventory(payload)
+    assert len(nodes) == 1
+    node = nodes[0]
+
+    assert normalize_node_type(" HTR ") == node.type
+    assert normalize_node_addr(" 01 ") == node.addr
+    assert (
+        normalize_node_type(None, default="htr", use_default_when_falsey=True) == "htr"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,8 @@ from custom_components.termoweb.utils import (
     ensure_node_inventory,
     float_or_none,
     normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
     parse_heater_energy_unique_id,
 )
 
@@ -113,6 +115,52 @@ def test_float_or_none(value, expected) -> None:
 @pytest.mark.parametrize("value", ["nan", "inf"])
 def test_float_or_none_non_finite_strings(value) -> None:
     assert float_or_none(value) is None
+
+
+@pytest.mark.parametrize(
+    "value,default,use_default_when_falsey,expected",
+    [
+        (" HTR ", "htr", False, "htr"),
+        ("AcM", "htr", False, "acm"),
+        (None, "htr", True, "htr"),
+        ("  ", "htr", False, "htr"),
+        (None, "", False, "none"),
+    ],
+)
+def test_normalize_node_type_cases(
+    value: Any, default: str, use_default_when_falsey: bool, expected: str
+) -> None:
+    assert (
+        normalize_node_type(
+            value,
+            default=default,
+            use_default_when_falsey=use_default_when_falsey,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "value,default,use_default_when_falsey,expected",
+    [
+        (" 01 ", "", False, "01"),
+        ("  ", "fallback", False, "fallback"),
+        (None, "", True, ""),
+        (None, "fallback", False, "None"),
+        ("none", "", False, "none"),
+    ],
+)
+def test_normalize_node_addr_cases(
+    value: Any, default: str, use_default_when_falsey: bool, expected: str
+) -> None:
+    assert (
+        normalize_node_addr(
+            value,
+            default=default,
+            use_default_when_falsey=use_default_when_falsey,
+        )
+        == expected
+    )
 
 
 def test_entry_gateway_record_handles_invalid_sources() -> None:


### PR DESCRIPTION
## Summary
- add shared helpers to normalize node types and addresses and replace inline normalization in heater and coordinator helpers
- update utility mappings to rely on the new helpers for consistent node handling
- extend heater, coordinator, node, and utils tests to exercise the normalization helpers

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d93bb1473083298a3114efbb0169a7