### PR TITLE
Normalise node descriptors via shared helpers

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -19,6 +19,7 @@ from .const import (
     USER_AGENT,
 )
 from .nodes import Node, NodeDescriptor
+from .utils import normalize_node_addr, normalize_node_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -537,12 +538,12 @@ class RESTClient:
                 raise ValueError(msg)
             node_type, addr = node
 
-        node_type_str = str(node_type or "").strip().lower()
+        node_type_str = normalize_node_type(node_type)
         if not node_type_str:
             msg = f"Invalid node type extracted from descriptor: {node!r}"
             raise ValueError(msg)
 
-        addr_str = str(addr or "").strip()
+        addr_str = normalize_node_addr(addr)
         if not addr_str:
             msg = f"Invalid node address extracted from descriptor: {node!r}"
             raise ValueError(msg)

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -194,7 +194,15 @@ def build_node_inventory(raw_nodes: Any) -> list[Node]:
             continue
 
         name = payload.get("name") or payload.get("title") or payload.get("label")
-        addr = payload.get("addr") or payload.get("address")
+        addr = normalize_node_addr(
+            payload.get("addr"),
+            use_default_when_falsey=True,
+        )
+        if not addr:
+            addr = normalize_node_addr(
+                payload.get("address"),
+                use_default_when_falsey=True,
+            )
 
         node_cls = _resolve_node_class(node_type)
         if node_cls is Node:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -221,6 +221,15 @@ def test_resolve_node_descriptor_validations() -> None:
         client._resolve_node_descriptor(("htr", ""))
 
 
+def test_resolve_node_descriptor_normalises_values() -> None:
+    client = RESTClient(FakeSession(), "user", "pass")
+
+    node = AccumulatorNode(name=" Storage ", addr=" 007 ")
+    assert client._resolve_node_descriptor(node) == ("acm", "007")
+
+    assert client._resolve_node_descriptor(("HTR", " 08 ")) == ("htr", "08")
+
+
 def test_ensure_token_non_numeric_expires_in(monkeypatch) -> None:
     fake_time = 1000.0
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -147,6 +147,15 @@ def test_build_node_inventory_falls_back_to_node_type_field() -> None:
     assert nodes[0].addr == "05"
 
 
+def test_build_node_inventory_falls_back_to_address_field() -> None:
+    payload = {"nodes": [{"type": "HTR", "addr": " ", "address": " 09 "}]}
+
+    nodes = build_node_inventory(payload)
+
+    assert len(nodes) == 1
+    assert nodes[0].addr == "09"
+
+
 def test_utils_normalization_matches_node_inventory() -> None:
     payload = {"nodes": [{"type": " HTR ", "addr": " 01 "}]}
 


### PR DESCRIPTION
## Summary
- normalise node addresses and types in the node inventory builder using the shared helpers
- ensure RESTClient resolves node descriptors via the same helpers and adjust tests accordingly

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d9490be8a88329a5f423f8bb7f17eb