### PR TITLE
Refactor TermoWeb coordinator helpers

### DIFF
--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -29,6 +29,40 @@ EnergyStateCoordinator = coord_module.EnergyStateCoordinator
 StateCoordinator = coord_module.StateCoordinator
 
 
+def test_device_display_name_helper() -> None:
+    """Helpers should trim names and fall back to device id."""
+
+    assert coord_module._device_display_name({"name": " Device "}, "dev") == "Device"
+    assert coord_module._device_display_name({"name": ""}, "dev") == "Device dev"
+    assert coord_module._device_display_name({}, "dev") == "Device dev"
+    assert coord_module._device_display_name({"name": 1234}, "dev") == "1234"
+
+
+def test_ensure_heater_section_helper() -> None:
+    """The helper must reuse existing sections or insert defaults."""
+
+    nodes_by_type: dict[str, dict[str, Any]] = {
+        "htr": {"addrs": ["1"], "settings": {"1": {}}}
+    }
+    existing = coord_module._ensure_heater_section(nodes_by_type, lambda: {})
+    assert existing is nodes_by_type["htr"]
+
+    nodes_by_type = {}
+    created = coord_module._ensure_heater_section(
+        nodes_by_type, lambda: {"addrs": ["A"], "settings": {}}
+    )
+    assert created == {"addrs": ["A"], "settings": {}}
+    assert nodes_by_type["htr"] == {"addrs": ["A"], "settings": {}}
+
+    nodes_by_type = {"htr": []}  # type: ignore[assignment]
+    replaced = coord_module._ensure_heater_section(
+        nodes_by_type,
+        lambda: {"addrs": ["B"], "settings": {"B": {"mode": "auto"}}},
+    )
+    assert replaced == {"addrs": ["B"], "settings": {"B": {"mode": "auto"}}}
+    assert nodes_by_type["htr"] == replaced
+
+
 def test_ensure_inventory_rebuilds_and_refreshes_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add private helpers to compute trimmed device names and guarantee heater sections
- refactor state and energy coordinator update paths to use the new helpers
- extend coordinator tests to cover the helper behaviours

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d94916a9f883299e6c4a2529533ceb