### PR TITLE
Normalize heater metadata using shared helpers

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -25,7 +25,7 @@ from .heater import (
     prepare_heater_platform_data,
 )
 from .nodes import HeaterNode
-from .utils import float_or_none
+from .utils import float_or_none, normalize_node_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,8 +150,12 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
     ) -> None:
         """Initialise the climate entity for a TermoWeb heater."""
         HeaterNode.__init__(self, name=name, addr=addr)
-        resolved_type = str(node_type or getattr(self, "type", "htr")).strip().lower()
-        if resolved_type and resolved_type != getattr(self, "type", ""):
+        resolved_type = normalize_node_type(
+            node_type,
+            default=getattr(self, "type", "htr"),
+            use_default_when_falsey=True,
+        ) or "htr"
+        if resolved_type != getattr(self, "type", ""):
             self.type = resolved_type
         HeaterNodeBase.__init__(
             self,

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -320,7 +320,7 @@ class HeaterNodeBase(CoordinatorEntity):
         super().__init__(coordinator)
         self._entry_id = entry_id
         self._dev_id = dev_id
-        self._addr = str(addr)
+        self._addr = normalize_node_addr(addr)
         self._attr_name = name
         resolved_type = normalize_node_type(
             node_type,
@@ -367,7 +367,7 @@ class HeaterNodeBase(CoordinatorEntity):
         addr = payload.get("addr")
         if addr is None:
             return True
-        return str(addr) == self._addr
+        return normalize_node_addr(addr) == self._addr
 
     @callback
     def _handle_ws_event(self, _payload: dict) -> None:

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -31,8 +31,8 @@ def build_heater_energy_unique_id(
     """Return the canonical unique ID for a heater energy sensor."""
 
     dev = str(dev_id).strip()
-    node = str(node_type).strip()
-    address = str(addr).strip()
+    node = normalize_node_type(node_type)
+    address = normalize_node_addr(addr)
     if not dev or not node or not address:
         raise ValueError("dev_id, node_type and addr must be provided")
     return f"{DOMAIN}:{dev}:{node}:{address}:energy"

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -82,6 +82,27 @@ def test_termoweb_heater_is_heater_node() -> None:
     assert heater.name == "Living Room"
 
 
+def test_heater_climate_entity_normalizes_node_type() -> None:
+    _reset_environment()
+    hass = HomeAssistant()
+    dev_id = "dev-acm"
+    coordinator_data = {dev_id: {"htr": {"settings": {}}, "nodes": {}}}
+    coordinator = _make_coordinator(hass, dev_id, coordinator_data[dev_id])
+
+    heater = HeaterClimateEntity(
+        coordinator,
+        "entry",
+        dev_id,
+        "1",
+        "Heater",
+        node_type=" ACM ",
+    )
+
+    assert heater.type == "acm"
+    assert getattr(heater, "_node_type", "") == "acm"
+    assert heater._attr_unique_id == f"{DOMAIN}:{dev_id}:acm:{heater._addr}"
+
+
 def test_async_setup_entry_creates_entities() -> None:
     async def _run() -> None:
         _reset_environment()

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from conftest import _install_stubs, make_ws_payload
+
+_install_stubs()
+
+from custom_components.termoweb import heater as heater_module
+
+HeaterNodeBase = heater_module.HeaterNodeBase
+
+
+def test_heater_node_base_normalizes_address() -> None:
+    coordinator = SimpleNamespace(hass=None)
+    heater = HeaterNodeBase(coordinator, "entry", "dev", " 01 ", " Heater 01 ")
+
+    assert heater._addr == "01"
+    assert heater.device_info["identifiers"] == {
+        (heater_module.DOMAIN, "dev", "01")
+    }
+    assert heater._attr_unique_id == f"{heater_module.DOMAIN}:dev:htr:01"
+
+
+def test_heater_node_base_payload_matching_normalizes_address() -> None:
+    coordinator = SimpleNamespace(hass=None)
+    heater = HeaterNodeBase(coordinator, "entry", "dev", " 01 ", "Heater 01")
+
+    assert heater._payload_matches_heater(make_ws_payload("dev", " 01 "))
+    assert not heater._payload_matches_heater(make_ws_payload("dev", "02"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -239,15 +239,21 @@ def test_get_brand_api_base_fallback() -> None:
 
 
 def test_build_heater_energy_unique_id_round_trip() -> None:
-    unique_id = build_heater_energy_unique_id("dev", "htr", "01")
+    unique_id = build_heater_energy_unique_id(" dev ", " ACM ", " 01 ")
 
-    assert unique_id == f"{DOMAIN}:dev:htr:01:energy"
-    assert parse_heater_energy_unique_id(unique_id) == ("dev", "htr", "01")
+    assert unique_id == f"{DOMAIN}:dev:acm:01:energy"
+    assert parse_heater_energy_unique_id(unique_id) == ("dev", "acm", "01")
 
 
 @pytest.mark.parametrize(
     "dev_id, node_type, addr",
-    [("", "htr", "01"), ("dev", "", "01"), ("dev", "htr", "")],
+    [
+        ("", "htr", "01"),
+        ("dev", "", "01"),
+        ("dev", "htr", ""),
+        ("dev", " ", "01"),
+        ("dev", "htr", "  "),
+    ],
 )
 def test_build_heater_energy_unique_id_requires_components(
     dev_id: str, node_type: str, addr: str


### PR DESCRIPTION
## Summary
- normalise stored heater addresses and websocket payload matching through `normalize_node_addr`
- resolve heater climate node types and energy sensor unique IDs with the shared helper utilities
- extend heater, climate, and utils tests to cover the normalised behaviour

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d94912b7dc8329bee4094aed590c84