### PR TITLE
Normalize node metadata with helpers

### DIFF
--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -133,6 +133,14 @@ def test_build_node_inventory_handles_list_payload(caplog: pytest.LogCaptureFixt
     assert any("Skipping node with missing type" in message for message in caplog.messages)
 
 
+def test_build_node_inventory_skips_none_type() -> None:
+    payload = [
+        {"type": None, "addr": "03", "name": "Null type"},
+    ]
+
+    assert build_node_inventory(payload) == []
+
+
 def test_build_node_inventory_tolerates_empty_payload() -> None:
     assert build_node_inventory({"nodes": []}) == []
 


### PR DESCRIPTION
## Summary
- add a helper to normalise node type/address candidates when building node inventories
- ensure the node inventory tests cover None-valued types that should be skipped

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing
- pytest tests/test_nodes.py tests/test_api.py --cov=custom_components.termoweb.nodes --cov=custom_components.termoweb.api --cov-report=term-missing
- ruff check custom_components/termoweb/nodes.py tests/test_nodes.py

------
https://chatgpt.com/codex/tasks/task_e_68d94ad633248329a0a40dc8df350be2