### PR TITLE
Deduplicate websocket handshake tests

### DIFF
--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -154,11 +154,12 @@ def test_build_heater_name_map_handles_invalid_entries() -> None:
         "nodes": [
             123,
             {"type": "HTR", "addr": None, "name": "Ignored"},
-            {"type": "foo", "addr": "B", "name": "Skip"},
-            {"type": "htr", "addr": 5, "name": "  "},
-            {"type": "htr", "addr": "6", "name": None},
-        ]
-    }
+        {"type": "foo", "addr": "B", "name": "Skip"},
+        {"type": "htr", "addr": 5, "name": "  "},
+        {"type": "htr", "addr": "6", "name": None},
+        {"type": "htr", "addr": " None ", "name": "Skip None"},
+    ]
+}
 
     result = build_heater_name_map(nodes, lambda addr: f"Heater {addr}")
 


### PR DESCRIPTION
## Summary
- merge the duplicated websocket handshake error tests into a single parametrized case
- extend the heater name map test data to cover addresses that normalize to "none"

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d94b30e48c8329afe4dba2f2e0e896