### PR TITLE
Fix coroutine detection in import energy history tests

### DIFF
--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 from datetime import datetime, timezone, timedelta
 import importlib
+import inspect
 import itertools
 import logging
 import sys
@@ -70,7 +71,7 @@ async def _load_module(
     class _RecorderInstance:
         def __init__(self) -> None:
             async def _call(func, *args, **kwargs):
-                if asyncio.iscoroutinefunction(func):
+                if inspect.iscoroutinefunction(func):
                     return await func(*args, **kwargs)
                 return func(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
- update the import energy history test helpers to use `inspect.iscoroutinefunction` instead of the deprecated `asyncio.iscoroutinefunction`
- add the necessary `inspect` import for the coroutine detection helper

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d94d0410948329b67a252944f83c43