### PR TITLE
Refactor websocket node payload handling

### DIFF
--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -857,8 +857,18 @@ def test_handle_payload_helpers_update_nodes() -> None:
         initial_payload = {"nodes": {"htr": {"status": {"01": {"temp": 20}}}}}
         client._handle_dev_data(initial_payload)
 
+        assert client._nodes_raw == initial_payload["nodes"]
+        assert client._nodes_raw is not initial_payload["nodes"]
+        assert client._nodes["nodes"]["htr"]["status"]["01"]["temp"] == 20
+
         incremental = {"nodes": {"htr": {"status": {"02": {"temp": 22}}}}}
         client._handle_update(incremental)
+
+        assert client._nodes_raw["htr"]["status"]["02"]["temp"] == 22
+        assert client._nodes["nodes"]["htr"]["status"] == {
+            "01": {"temp": 20},
+            "02": {"temp": 22},
+        }
 
         await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary
- add a shared helper to process websocket node payloads and reuse it in dev_data and update handlers
- extend websocket client tests to validate both overwrite and merge paths for the new helper

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d94cb338ec832989e5410c4229fa8f