### PR TITLE
Refine TermoWeb coordinator helpers and tests

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+
+from custom_components.termoweb import coordinator as coord_module
+
+
+def test_device_display_name_helper() -> None:
+    """Helpers should trim names and fall back to the device id."""
+
+    assert coord_module._device_display_name({"name": " Device "}, "dev") == "Device"
+    assert coord_module._device_display_name({"name": ""}, "dev") == "Device dev"
+    assert coord_module._device_display_name({}, "dev") == "Device dev"
+    assert coord_module._device_display_name({"name": 1234}, "dev") == "1234"
+
+    proxy_device: MappingProxyType[str, str] = MappingProxyType({"name": " Proxy "})
+    assert coord_module._device_display_name(proxy_device, "dev") == "Proxy"
+
+
+def test_ensure_heater_section_helper() -> None:
+    """The helper must reuse existing sections or insert defaults."""
+
+    nodes_by_type: dict[str, dict[str, Any]] = {
+        "htr": {"addrs": ["1"], "settings": {"1": {}}}
+    }
+    existing = coord_module._ensure_heater_section(nodes_by_type, lambda: {})
+    assert existing is nodes_by_type["htr"]
+
+    proxy_nodes = MappingProxyType({"addrs": ("2",), "settings": {"2": {}}})
+    nodes_by_type = {"htr": proxy_nodes}  # type: ignore[assignment]
+    converted = coord_module._ensure_heater_section(nodes_by_type, lambda: {})
+    assert converted == {"addrs": ["2"], "settings": {"2": {}}}
+    assert nodes_by_type["htr"] == converted
+
+    nodes_by_type = {}
+    created = coord_module._ensure_heater_section(
+        nodes_by_type,
+        lambda: MappingProxyType(
+            {"addrs": ("A",), "settings": {"A": {"mode": "auto"}}}
+        ),
+    )
+    assert created == {"addrs": ["A"], "settings": {"A": {"mode": "auto"}}}
+    assert nodes_by_type["htr"] == created

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -29,40 +29,6 @@ EnergyStateCoordinator = coord_module.EnergyStateCoordinator
 StateCoordinator = coord_module.StateCoordinator
 
 
-def test_device_display_name_helper() -> None:
-    """Helpers should trim names and fall back to device id."""
-
-    assert coord_module._device_display_name({"name": " Device "}, "dev") == "Device"
-    assert coord_module._device_display_name({"name": ""}, "dev") == "Device dev"
-    assert coord_module._device_display_name({}, "dev") == "Device dev"
-    assert coord_module._device_display_name({"name": 1234}, "dev") == "1234"
-
-
-def test_ensure_heater_section_helper() -> None:
-    """The helper must reuse existing sections or insert defaults."""
-
-    nodes_by_type: dict[str, dict[str, Any]] = {
-        "htr": {"addrs": ["1"], "settings": {"1": {}}}
-    }
-    existing = coord_module._ensure_heater_section(nodes_by_type, lambda: {})
-    assert existing is nodes_by_type["htr"]
-
-    nodes_by_type = {}
-    created = coord_module._ensure_heater_section(
-        nodes_by_type, lambda: {"addrs": ["A"], "settings": {}}
-    )
-    assert created == {"addrs": ["A"], "settings": {}}
-    assert nodes_by_type["htr"] == {"addrs": ["A"], "settings": {}}
-
-    nodes_by_type = {"htr": []}  # type: ignore[assignment]
-    replaced = coord_module._ensure_heater_section(
-        nodes_by_type,
-        lambda: {"addrs": ["B"], "settings": {"B": {"mode": "auto"}}},
-    )
-    assert replaced == {"addrs": ["B"], "settings": {"B": {"mode": "auto"}}}
-    assert nodes_by_type["htr"] == replaced
-
-
 def test_ensure_inventory_rebuilds_and_refreshes_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -440,7 +406,6 @@ def test_merge_address_payload_upgrades_string_lookup() -> None:
     coord._merge_address_payload({"htr": ["1", "2"]})
 
     assert coord._addr_lookup == {"1": {"htr"}, "2": {"htr"}}
-
 
 
 def test_refresh_heater_updates_existing_and_new_data() -> None:


### PR DESCRIPTION
## Summary
- harden the coordinator helpers that trim device names and guarantee an `htr` section while normalising iterable address payloads
- ensure the state and energy coordinators rely on the shared helpers instead of inlined logic
- add a dedicated coordinator test module that exercises the helpers and drop the duplicated coverage from the energy coordinator suite

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68d94e31d09083298dd79d4a49504181