### PR TITLE
Fix legacy websocket resolution without blocking imports

### DIFF
--- a/custom_components/termoweb/backend/termoweb.py
+++ b/custom_components/termoweb/backend/termoweb.py
@@ -1,10 +1,11 @@
 """TermoWeb backend implementation."""
 from __future__ import annotations
 
-from importlib import import_module
+import sys
 from typing import Any
 
-from ..ws_client import WebSocketClient
+from custom_components.termoweb.ws_client import WebSocketClient
+
 from .base import Backend, WsClientProto
 
 
@@ -14,10 +15,16 @@ class TermoWebBackend(Backend):
     def _resolve_ws_client_cls(self) -> type[Any]:
         """Return the websocket client class compatible with this backend."""
 
-        module = import_module("custom_components.termoweb.__init__")
-        ws_cls = getattr(module, "WebSocket09Client", None)
-        if isinstance(ws_cls, type):
-            return ws_cls
+        for module_name in (
+            "custom_components.termoweb.__init__",
+            "custom_components.termoweb",
+        ):
+            module = sys.modules.get(module_name)
+            if not module:
+                continue
+            ws_cls = getattr(module, "WebSocket09Client", None)
+            if isinstance(ws_cls, type):
+                return ws_cls
         return WebSocketClient
 
     def create_ws_client(

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -19,10 +19,11 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .api import RESTClient
 from .const import API_BASE, DOMAIN, WS_NAMESPACE, signal_ws_data, signal_ws_status
 from .heater import prepare_heater_platform_data
-from .nodes import NODE_CLASS_BY_TYPE, build_node_inventory
+from .nodes import NODE_CLASS_BY_TYPE
 from .utils import (
     HEATER_NODE_TYPES,
     addresses_by_node_type,
+    build_node_inventory,  # noqa: F401 - re-exported for tests
     ensure_node_inventory,
     normalize_heater_addresses,
 )

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -134,14 +134,16 @@ def test_termoweb_backend_resolve_ws_client_cls_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     backend = TermoWebBackend(brand="termoweb", client=DummyHttpClient())
-    modules = {
-        "custom_components.termoweb.__init__": SimpleNamespace(WebSocket09Client=None)
-    }
-
-    def fake_import(name: str) -> Any:
-        return modules[name]
-
-    monkeypatch.setattr(termoweb_backend, "import_module", fake_import)
+    monkeypatch.setitem(
+        termoweb_backend.sys.modules,
+        "custom_components.termoweb",
+        SimpleNamespace(WebSocket09Client=None),
+    )
+    monkeypatch.setitem(
+        termoweb_backend.sys.modules,
+        "custom_components.termoweb.__init__",
+        SimpleNamespace(WebSocket09Client=None),
+    )
 
     resolved = backend._resolve_ws_client_cls()
     assert resolved is WebSocketClient
@@ -168,11 +170,11 @@ def test_termoweb_backend_legacy_ws_class(monkeypatch: pytest.MonkeyPatch) -> No
             self.coordinator = coordinator
             self.kwargs = kwargs
 
-    modules = {
-        "custom_components.termoweb.__init__": SimpleNamespace(WebSocket09Client=LegacyWS)
-    }
-
-    monkeypatch.setattr(termoweb_backend, "import_module", modules.__getitem__)
+    monkeypatch.setitem(
+        termoweb_backend.sys.modules,
+        "custom_components.termoweb",
+        SimpleNamespace(WebSocket09Client=LegacyWS),
+    )
 
     loop = asyncio.new_event_loop()
     try:


### PR DESCRIPTION
## Summary
- resolve the TermoWeb websocket client using already-loaded modules to avoid blocking imports during setup
- expose `build_node_inventory` from the websocket client module for tests that depend on the helper
- update backend factory tests to patch `sys.modules` entries instead of import hooks

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d954ab8b648329839596c97f767a01