### PR TITLE
Refactor node normalization helpers

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -25,9 +25,7 @@ async def async_get_integration_version(hass: HomeAssistant) -> str:
     return integration.version or "unknown"
 
 
-def build_heater_energy_unique_id(
-    dev_id: Any, node_type: Any, addr: Any
-) -> str:
+def build_heater_energy_unique_id(dev_id: Any, node_type: Any, addr: Any) -> str:
     """Return the canonical unique ID for a heater energy sensor."""
 
     dev = normalize_node_addr(dev_id)
@@ -121,6 +119,42 @@ def build_node_inventory(raw_nodes: Any) -> list["Node"]:  # noqa: UP037
     return _build_node_inventory(raw_nodes)
 
 
+def _normalize_node_identifier(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+    lowercase: bool,
+) -> str:
+    """Return ``value`` as a normalised node identifier string."""
+
+    raw = value
+    if use_default_when_falsey and not raw:
+        raw = default
+
+    try:
+        normalized = str(raw).strip()
+    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+        normalized = ""
+    else:
+        if lowercase:
+            normalized = normalized.lower()
+
+    if normalized:
+        return normalized
+
+    if default and not use_default_when_falsey:
+        try:
+            normalized_default = str(default).strip()
+        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+            return ""
+        if lowercase:
+            normalized_default = normalized_default.lower()
+        return normalized_default
+
+    return ""
+
+
 def normalize_node_type(
     value: Any,
     *,
@@ -129,25 +163,12 @@ def normalize_node_type(
 ) -> str:
     """Return ``value`` as a normalised node type string."""
 
-    raw = value
-    if use_default_when_falsey and not raw:
-        raw = default
-
-    try:
-        normalized = str(raw).strip().lower()
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-        normalized = ""
-
-    if normalized:
-        return normalized
-
-    if default and not use_default_when_falsey:
-        try:
-            return str(default).strip().lower()
-        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-            return ""
-
-    return ""
+    return _normalize_node_identifier(
+        value,
+        default=default,
+        use_default_when_falsey=use_default_when_falsey,
+        lowercase=True,
+    )
 
 
 def normalize_node_addr(
@@ -158,25 +179,12 @@ def normalize_node_addr(
 ) -> str:
     """Return ``value`` as a normalised node address string."""
 
-    raw = value
-    if use_default_when_falsey and not raw:
-        raw = default
-
-    try:
-        normalized = str(raw).strip()
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-        normalized = ""
-
-    if normalized:
-        return normalized
-
-    if default and not use_default_when_falsey:
-        try:
-            return str(default).strip()
-        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-            return ""
-
-    return ""
+    return _normalize_node_identifier(
+        value,
+        default=default,
+        use_default_when_falsey=use_default_when_falsey,
+        lowercase=False,
+    )
 
 
 def _entry_gateway_record(
@@ -252,7 +260,9 @@ def addresses_by_node_type(
 
     known: set[str] | None = None
     if known_types is not None:
-        known = {normalize_node_type(node_type) for node_type in known_types if node_type}
+        known = {
+            normalize_node_type(node_type) for node_type in known_types if node_type
+        }
 
     result: dict[str, list[str]] = {}
     seen: dict[str, set[str]] = {}


### PR DESCRIPTION
## Summary
- add a shared helper to normalize node identifiers with optional lowercasing
- rewrite normalize_node_type and normalize_node_addr to reuse the helper

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d95b660c2083299210716908eded5a