### PR TITLE
Remove redundant build_node_inventory wrapper

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -111,16 +111,6 @@ def ensure_node_inventory(
         record["node_inventory"] = []
 
     return []
-
-
-def build_node_inventory(raw_nodes: Any) -> list["Node"]:  # noqa: UP037
-    """Return canonical node inventory using the shared builder."""
-
-    from .nodes import build_node_inventory as _build_node_inventory  # noqa: PLC0415
-
-    return _build_node_inventory(raw_nodes)
-
-
 def normalize_node_type(
     value: Any,
     *,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,6 @@ from custom_components.termoweb.utils import (
     HEATER_NODE_TYPES,
     _entry_gateway_record,
     addresses_by_node_type,
-    build_node_inventory as utils_build_node_inventory,
     build_gateway_device_info,
     build_heater_energy_unique_id,
     ensure_node_inventory,
@@ -102,16 +101,6 @@ def test_ensure_node_inventory_sets_empty_cache_when_missing() -> None:
 
     assert result == []
     assert record["node_inventory"] == []
-
-
-def test_utils_build_node_inventory_wrapper() -> None:
-    payload = {"nodes": [{"type": "htr", "addr": "Z1"}]}
-
-    nodes = utils_build_node_inventory(payload)
-
-    assert [node.addr for node in nodes] == ["Z1"]
-
-
 def test_addresses_by_node_type_skips_invalid_entries() -> None:
     nodes = [
         types.SimpleNamespace(type=" ", addr="skip"),

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -14,6 +14,7 @@ from conftest import _install_stubs
 
 _install_stubs()
 
+import custom_components.termoweb.nodes as nodes
 import custom_components.termoweb.utils as utils
 import custom_components.termoweb.ws_client as ws_core
 
@@ -2449,7 +2450,7 @@ def test_dispatch_nodes_reuses_cached_inventory(
     def explode_build(raw_nodes: Any) -> list[Any]:  # pragma: no cover - defensive
         raise AssertionError("build_node_inventory should not be called")
 
-    monkeypatch.setattr(utils, "build_node_inventory", explode_build)
+    monkeypatch.setattr(nodes, "build_node_inventory", explode_build)
 
     payload = {"nodes": [{"addr": "01", "type": "htr"}]}
 


### PR DESCRIPTION
## Summary
- remove the build_node_inventory wrapper from utils
- update tests to import build_node_inventory from the nodes module directly
- adjust websocket client tests to monkeypatch the nodes builder

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d95b5039b083298ba145d954b85afa