### PR TITLE
Refactor node normalization helper

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -110,7 +110,7 @@ def ensure_node_inventory(
 
     return []
 
-def normalize_node_type(
+def _normalize_node_identifier(
     value: Any,
     *,
     default: str = "",


### PR DESCRIPTION
## Summary
- rename the shared node normalization helper to a private `_normalize_node_identifier`
- update `normalize_node_type` and `normalize_node_addr` to call the shared helper

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d96a6607dc8329a533fcd22106359c