### PR TITLE
Refactor node helpers into nodes module

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -36,20 +36,20 @@ from .energy import (
     OPTION_ENERGY_HISTORY_IMPORTED as ENERGY_OPTION_ENERGY_HISTORY_IMPORTED,
     OPTION_ENERGY_HISTORY_PROGRESS as ENERGY_OPTION_ENERGY_HISTORY_PROGRESS,
     OPTION_MAX_HISTORY_RETRIEVED as ENERGY_OPTION_MAX_HISTORY_RETRIEVED,
-    default_samples_rate_limit_state,
-    reset_samples_rate_limit_state,
+    async_import_energy_history as _async_import_energy_history_impl,
     async_register_import_energy_history_service,
     async_schedule_initial_energy_import,
-    async_import_energy_history as _async_import_energy_history_impl,
+    default_samples_rate_limit_state,
+    reset_samples_rate_limit_state,
 )
-from .nodes import build_node_inventory
-from .utils import (
+from .nodes import (
     HEATER_NODE_TYPES as _HEATER_NODE_TYPES,
-    async_get_integration_version as _async_get_integration_version,
     build_heater_address_map as _build_heater_address_map,
+    build_node_inventory,
     ensure_node_inventory as _ensure_node_inventory,
     normalize_heater_addresses as _normalize_heater_addresses,
 )
+from .utils import async_get_integration_version as _async_get_integration_version
 
 HEATER_NODE_TYPES = _HEATER_NODE_TYPES
 

--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -18,8 +18,7 @@ from .const import (
     TOKEN_PATH,
     USER_AGENT,
 )
-from .nodes import Node, NodeDescriptor
-from .utils import normalize_node_addr, normalize_node_type
+from .nodes import Node, NodeDescriptor, normalize_node_addr, normalize_node_type
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 import logging
-from typing import Any, Callable
-import time
+from typing import Any
 
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -25,8 +24,8 @@ from .heater import (
     log_skipped_nodes,
     prepare_heater_platform_data,
 )
-from .nodes import HeaterNode
-from .utils import float_or_none, normalize_node_type
+from .nodes import HeaterNode, normalize_node_type
+from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -15,14 +15,15 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import BackendAuthError, BackendRateLimitError, RESTClient
 from .const import HTR_ENERGY_UPDATE_INTERVAL, MIN_POLL_INTERVAL
-from .nodes import Node, build_node_inventory
-from .utils import (
+from .nodes import (
+    Node,
     build_heater_address_map,
-    float_or_none,
+    build_node_inventory,
     normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
 )
+from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import entity_registry as er
 
 from .api import RESTClient
 from .const import DOMAIN
-from .utils import (
+from .nodes import (
     build_heater_address_map,
     build_heater_energy_unique_id,
     ensure_node_inventory,

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -14,10 +14,11 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_data
-from .nodes import Node, build_node_inventory
-from .utils import (
+from .nodes import (
     HEATER_NODE_TYPES,
+    Node,
     build_heater_address_map,
+    build_node_inventory,
     ensure_node_inventory,
     normalize_node_addr,
     normalize_node_type,

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -1,14 +1,85 @@
-"""Node model abstractions for TermoWeb devices."""
+"""Node model abstractions and helpers for TermoWeb devices."""
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 import logging
-from typing import Any
+from typing import Any, cast
 
-from .utils import normalize_node_addr, normalize_node_type
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_node_identifier(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+    lowercase: bool,
+) -> str:
+    """Return ``value`` as a normalised node identifier string."""
+
+    raw = value
+    if use_default_when_falsey and not raw:
+        raw = default
+
+    try:
+        normalized = str(raw).strip()
+    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+        normalized = ""
+    else:
+        if lowercase:
+            normalized = normalized.lower()
+
+    if normalized:
+        return normalized
+
+    if default and not use_default_when_falsey:
+        try:
+            normalized_default = str(default).strip()
+        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+            return ""
+        if lowercase:
+            normalized_default = normalized_default.lower()
+        return normalized_default
+
+    return ""
+
+
+def normalize_node_type(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+) -> str:
+    """Return ``value`` as a normalised node type string."""
+
+    return _normalize_node_identifier(
+        value,
+        default=default,
+        use_default_when_falsey=use_default_when_falsey,
+        lowercase=True,
+    )
+
+
+def normalize_node_addr(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+) -> str:
+    """Return ``value`` as a normalised node address string."""
+
+    return _normalize_node_identifier(
+        value,
+        default=default,
+        use_default_when_falsey=use_default_when_falsey,
+        lowercase=False,
+    )
+
+
+HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
 
 
 class Node:
@@ -225,3 +296,215 @@ def build_node_inventory(raw_nodes: Any) -> list[Node]:
         inventory.append(node)
 
     return inventory
+
+
+def ensure_node_inventory(
+    record: Mapping[str, Any], *, nodes: Any | None = None
+) -> list[Node]:
+    """Return cached node inventory, rebuilding and caching when missing."""
+
+    cacheable = isinstance(record, MutableMapping)
+    cached = record.get("node_inventory")
+    if isinstance(cached, list) and cached:
+        cached_nodes: list[Node] = []
+        for node in cached:
+            if not hasattr(node, "as_dict"):
+                continue
+            node_type = normalize_node_type(getattr(node, "type", ""))
+            addr = normalize_node_addr(getattr(node, "addr", ""))
+            if not node_type or not addr:
+                continue
+            cached_nodes.append(cast(Node, node))
+        if cached_nodes:
+            if cacheable and len(cached_nodes) != len(cached):
+                record["node_inventory"] = list(cached_nodes)
+            return list(cached_nodes)
+
+    payloads: list[Any] = []
+    if nodes is not None:
+        payloads.append(nodes)
+
+    record_nodes = record.get("nodes")
+    if record_nodes is not None and (not payloads or record_nodes is not payloads[0]):
+        payloads.append(record_nodes)
+
+    last_index = len(payloads) - 1
+    for index, raw_nodes in enumerate(payloads):
+        try:
+            inventory = build_node_inventory(raw_nodes)
+        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+            inventory = []
+
+        if cacheable and (inventory or index == last_index):
+            record["node_inventory"] = list(inventory)
+
+        if inventory:
+            return list(inventory)
+
+    if isinstance(cached, list):
+        if cacheable and "node_inventory" not in record:
+            record["node_inventory"] = []
+        return []
+
+    if cacheable and "node_inventory" not in record:
+        record["node_inventory"] = []
+
+    return []
+
+
+def build_heater_energy_unique_id(dev_id: Any, node_type: Any, addr: Any) -> str:
+    """Return the canonical unique ID for a heater energy sensor."""
+
+    dev = normalize_node_addr(dev_id)
+    node = normalize_node_type(node_type)
+    address = normalize_node_addr(addr)
+    if not dev or not node or not address:
+        raise ValueError("dev_id, node_type and addr must be provided")
+    return f"{DOMAIN}:{dev}:{node}:{address}:energy"
+
+
+def parse_heater_energy_unique_id(unique_id: str) -> tuple[str, str, str] | None:
+    """Parse a heater energy sensor unique ID into its components."""
+
+    if not isinstance(unique_id, str):
+        return None
+    stripped = unique_id.strip()
+    if not stripped or not stripped.startswith(f"{DOMAIN}:"):
+        return None
+    try:
+        domain, dev, node, address, metric = stripped.split(":", 4)
+    except ValueError:
+        return None
+    if domain != DOMAIN or metric != "energy":
+        return None
+    if not dev or not node or not address:
+        return None
+    return dev, node, address
+
+
+def addresses_by_node_type(
+    nodes: Iterable[Node],
+    *,
+    known_types: Iterable[str] | None = None,
+) -> tuple[dict[str, list[str]], set[str]]:
+    """Return mapping of node type to address list, tracking unknown types."""
+
+    known: set[str] | None = None
+    if known_types is not None:
+        known = {normalize_node_type(node_type) for node_type in known_types if node_type}
+
+    result: dict[str, list[str]] = {}
+    seen: dict[str, set[str]] = {}
+    unknown: set[str] = set()
+
+    for node in nodes:
+        node_type = normalize_node_type(getattr(node, "type", ""))
+        if not node_type:
+            continue
+        addr = normalize_node_addr(getattr(node, "addr", ""))
+        if not addr:
+            continue
+        type_seen = seen.setdefault(node_type, set())
+        if addr in type_seen:
+            continue
+        type_seen.add(addr)
+        result.setdefault(node_type, []).append(addr)
+        if known is not None and node_type not in known:
+            unknown.add(node_type)
+
+    return result, unknown
+
+
+def build_heater_address_map(
+    nodes: Iterable[Any],
+    *,
+    heater_types: Iterable[str] | None = None,
+) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+    """Return mapping of heater node types to addresses and reverse lookup."""
+
+    allowed_types: set[str]
+    if heater_types is None:
+        allowed_types = set(HEATER_NODE_TYPES)
+    else:
+        allowed_types = {
+            normalize_node_type(node_type, use_default_when_falsey=True)
+            for node_type in heater_types
+            if normalize_node_type(node_type, use_default_when_falsey=True)
+        }  # pragma: no cover - exercised indirectly in integration
+
+    if not allowed_types:
+        return {}, {}  # pragma: no cover - defensive
+
+    by_type_raw, _ = addresses_by_node_type(
+        nodes,
+        known_types=allowed_types,
+    )  # pragma: no cover - exercised via higher level integration tests
+
+    by_type: dict[str, list[str]] = {
+        node_type: list(addresses)
+        for node_type, addresses in by_type_raw.items()
+        if node_type in allowed_types and addresses
+    }
+
+    reverse: dict[str, set[str]] = {}
+    for node_type, addresses in by_type.items():
+        for address in addresses:
+            reverse.setdefault(address, set()).add(node_type)
+
+    return by_type, reverse
+
+
+def normalize_heater_addresses(
+    addrs: Iterable[Any] | Mapping[Any, Iterable[Any]] | None,
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    """Return canonical heater addresses and compatibility aliases."""
+
+    cleaned_map: dict[str, list[str]] = {}
+    compat_aliases: dict[str, str] = {}
+
+    if addrs is None:
+        sources: Iterable[tuple[Any, Iterable[Any] | Any]] = []
+    elif isinstance(addrs, Mapping):
+        sources = addrs.items()
+    else:
+        sources = [("htr", addrs)]
+
+    for raw_type, values in sources:
+        node_type = normalize_node_type(
+            raw_type,
+            use_default_when_falsey=True,
+        )
+        if not node_type:
+            continue
+
+        alias_target: str | None = None
+        if node_type in {"heater", "heaters", "htr"}:
+            alias_target = "htr"
+        if alias_target is not None and node_type != alias_target:
+            compat_aliases[node_type] = alias_target
+            node_type = alias_target
+
+        if node_type not in HEATER_NODE_TYPES:
+            continue
+
+        if isinstance(values, str) or not isinstance(values, Iterable):
+            candidates = [values]
+        else:
+            candidates = list(values)
+
+        bucket = cleaned_map.setdefault(node_type, [])
+        seen: set[str] = set(bucket)
+        for candidate in candidates:
+            addr = normalize_node_addr(
+                candidate,
+                use_default_when_falsey=True,
+            )
+            if not addr or addr in seen:
+                continue
+            seen.add(addr)
+            bucket.append(addr)
+
+    cleaned_map.setdefault("htr", [])
+    compat_aliases["htr"] = "htr"
+
+    return cleaned_map, compat_aliases

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -25,12 +25,8 @@ from .heater import (
     log_skipped_nodes,
     prepare_heater_platform_data,
 )
-from .utils import (
-    HEATER_NODE_TYPES,
-    build_gateway_device_info,
-    build_heater_energy_unique_id,
-    float_or_none,
-)
+from .nodes import HEATER_NODE_TYPES, build_heater_energy_unique_id
+from .utils import build_gateway_device_info, float_or_none
 
 _WH_TO_KWH = 1 / 1000.0
 

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, MutableMapping
+from collections.abc import Mapping
 import math
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
@@ -12,170 +12,12 @@ from homeassistant.loader import async_get_integration
 
 from .const import DOMAIN
 
-if TYPE_CHECKING:
-    from .nodes import Node
-
-HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
-
 
 async def async_get_integration_version(hass: HomeAssistant) -> str:
     """Return the installed integration version string."""
 
     integration = await async_get_integration(hass, DOMAIN)
     return integration.version or "unknown"
-
-
-def build_heater_energy_unique_id(dev_id: Any, node_type: Any, addr: Any) -> str:
-    """Return the canonical unique ID for a heater energy sensor."""
-
-    dev = normalize_node_addr(dev_id)
-    node = normalize_node_type(node_type)
-    address = normalize_node_addr(addr)
-    if not dev or not node or not address:
-        raise ValueError("dev_id, node_type and addr must be provided")
-    return f"{DOMAIN}:{dev}:{node}:{address}:energy"
-
-
-def parse_heater_energy_unique_id(unique_id: str) -> tuple[str, str, str] | None:
-    """Parse a heater energy sensor unique ID into its components."""
-
-    if not isinstance(unique_id, str):
-        return None
-    stripped = unique_id.strip()
-    if not stripped or not stripped.startswith(f"{DOMAIN}:"):
-        return None
-    try:
-        domain, dev, node, address, metric = stripped.split(":", 4)
-    except ValueError:
-        return None
-    if domain != DOMAIN or metric != "energy":
-        return None
-    if not dev or not node or not address:
-        return None
-    return dev, node, address
-
-
-def ensure_node_inventory(
-    record: Mapping[str, Any], *, nodes: Any | None = None
-) -> list["Node"]:  # noqa: UP037
-    """Return cached node inventory, rebuilding and caching when missing."""
-
-    cacheable = isinstance(record, MutableMapping)
-    cached = record.get("node_inventory")
-    if isinstance(cached, list) and cached:
-        cached_nodes: list["Node"] = []  # noqa: UP037
-        for node in cached:
-            if not hasattr(node, "as_dict"):
-                continue
-            node_type = normalize_node_type(getattr(node, "type", ""))
-            addr = normalize_node_addr(getattr(node, "addr", ""))
-            if not node_type or not addr:
-                continue
-            cached_nodes.append(cast("Node", node))
-        if cached_nodes:
-            if cacheable and len(cached_nodes) != len(cached):
-                record["node_inventory"] = list(cached_nodes)
-            return list(cached_nodes)
-
-    payloads: list[Any] = []
-    if nodes is not None:
-        payloads.append(nodes)
-
-    record_nodes = record.get("nodes")
-    if record_nodes is not None and (not payloads or record_nodes is not payloads[0]):
-        payloads.append(record_nodes)
-
-    last_index = len(payloads) - 1
-    for index, raw_nodes in enumerate(payloads):
-        try:
-            from .nodes import build_node_inventory as build_inventory  # noqa: PLC0415
-
-            inventory = build_inventory(raw_nodes)
-        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-            inventory = []
-
-        if cacheable and (inventory or index == last_index):
-            record["node_inventory"] = list(inventory)
-
-        if inventory:
-            return list(inventory)
-
-    if isinstance(cached, list):
-        if cacheable and "node_inventory" not in record:
-            record["node_inventory"] = []
-        return []
-
-    if cacheable and "node_inventory" not in record:
-        record["node_inventory"] = []
-
-    return []
-
-def _normalize_node_identifier(
-    value: Any,
-    *,
-    default: str = "",
-    use_default_when_falsey: bool = False,
-    lowercase: bool,
-) -> str:
-    """Return ``value`` as a normalised node identifier string."""
-
-    raw = value
-    if use_default_when_falsey and not raw:
-        raw = default
-
-    try:
-        normalized = str(raw).strip()
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-        normalized = ""
-    else:
-        if lowercase:
-            normalized = normalized.lower()
-
-    if normalized:
-        return normalized
-
-    if default and not use_default_when_falsey:
-        try:
-            normalized_default = str(default).strip()
-        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-            return ""
-        if lowercase:
-            normalized_default = normalized_default.lower()
-        return normalized_default
-
-    return ""
-
-
-def normalize_node_type(
-    value: Any,
-    *,
-    default: str = "",
-    use_default_when_falsey: bool = False,
-) -> str:
-    """Return ``value`` as a normalised node type string."""
-
-    return _normalize_node_identifier(
-        value,
-        default=default,
-        use_default_when_falsey=use_default_when_falsey,
-        lowercase=True,
-    )
-
-
-def normalize_node_addr(
-    value: Any,
-    *,
-    default: str = "",
-    use_default_when_falsey: bool = False,
-) -> str:
-    """Return ``value`` as a normalised node address string."""
-
-    return _normalize_node_identifier(
-        value,
-        default=default,
-        use_default_when_falsey=use_default_when_falsey,
-        lowercase=False,
-    )
 
 
 def _entry_gateway_record(
@@ -242,86 +84,13 @@ def build_gateway_device_info(
     return info
 
 
-def addresses_by_node_type(
-    nodes: Iterable["Node"],  # noqa: UP037
-    *,
-    known_types: Iterable[str] | None = None,
-) -> tuple[dict[str, list[str]], set[str]]:
-    """Return mapping of node type to address list, tracking unknown types."""
-
-    known: set[str] | None = None
-    if known_types is not None:
-        known = {
-            normalize_node_type(node_type) for node_type in known_types if node_type
-        }
-
-    result: dict[str, list[str]] = {}
-    seen: dict[str, set[str]] = {}
-    unknown: set[str] = set()
-
-    for node in nodes:
-        node_type = normalize_node_type(getattr(node, "type", ""))
-        if not node_type:
-            continue
-        addr = normalize_node_addr(getattr(node, "addr", ""))
-        if not addr:
-            continue
-        type_seen = seen.setdefault(node_type, set())
-        if addr in type_seen:
-            continue
-        type_seen.add(addr)
-        result.setdefault(node_type, []).append(addr)
-        if known is not None and node_type not in known:
-            unknown.add(node_type)
-
-    return result, unknown
-
-
-def build_heater_address_map(
-    nodes: Iterable[Any],
-    *,
-    heater_types: Iterable[str] | None = None,
-) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
-    """Return mapping of heater node types to addresses and reverse lookup."""
-
-    allowed_types: set[str]
-    if heater_types is None:
-        allowed_types = set(HEATER_NODE_TYPES)
-    else:
-        allowed_types = {
-            normalize_node_type(node_type, use_default_when_falsey=True)
-            for node_type in heater_types
-            if normalize_node_type(node_type, use_default_when_falsey=True)
-        }  # pragma: no cover - exercised indirectly in integration
-
-    if not allowed_types:
-        return {}, {}  # pragma: no cover - defensive
-
-    by_type_raw, _ = addresses_by_node_type(
-        nodes,
-        known_types=allowed_types,
-    )  # pragma: no cover - exercised via higher level integration tests
-
-    by_type: dict[str, list[str]] = {
-        node_type: list(addresses)
-        for node_type, addresses in by_type_raw.items()
-        if node_type in allowed_types and addresses
-    }
-
-    reverse: dict[str, set[str]] = {}
-    for node_type, addresses in by_type.items():
-        for address in addresses:
-            reverse.setdefault(address, set()).add(node_type)
-
-    return by_type, reverse
-
-
 def float_or_none(value: Any) -> float | None:
     """Return value as ``float`` if possible, else ``None``.
 
     Converts integers, floats, and numeric strings to ``float`` while safely
     handling ``None`` and non-numeric inputs.
     """
+
     try:
         if value is None:
             return None
@@ -335,59 +104,3 @@ def float_or_none(value: Any) -> float | None:
         return num if math.isfinite(num) else None
     except Exception:  # noqa: BLE001
         return None
-
-
-def normalize_heater_addresses(
-    addrs: Iterable[Any] | Mapping[Any, Iterable[Any]] | None,
-) -> tuple[dict[str, list[str]], dict[str, str]]:
-    """Return canonical heater addresses and compatibility aliases."""
-
-    cleaned_map: dict[str, list[str]] = {}
-    compat_aliases: dict[str, str] = {}
-
-    if addrs is None:
-        sources: Iterable[tuple[Any, Iterable[Any] | Any]] = []
-    elif isinstance(addrs, Mapping):
-        sources = addrs.items()
-    else:
-        sources = [("htr", addrs)]
-
-    for raw_type, values in sources:
-        node_type = normalize_node_type(
-            raw_type,
-            use_default_when_falsey=True,
-        )
-        if not node_type:
-            continue
-
-        alias_target: str | None = None
-        if node_type in {"heater", "heaters", "htr"}:
-            alias_target = "htr"
-        if alias_target is not None and node_type != alias_target:
-            compat_aliases[node_type] = alias_target
-            node_type = alias_target
-
-        if node_type not in HEATER_NODE_TYPES:
-            continue
-
-        if isinstance(values, str) or not isinstance(values, Iterable):
-            candidates = [values]
-        else:
-            candidates = list(values)
-
-        bucket = cleaned_map.setdefault(node_type, [])
-        seen: set[str] = set(bucket)
-        for candidate in candidates:
-            addr = normalize_node_addr(
-                candidate,
-                use_default_when_falsey=True,
-            )
-            if not addr or addr in seen:
-                continue
-            seen.add(addr)
-            bucket.append(addr)
-
-    cleaned_map.setdefault("htr", [])
-    compat_aliases["htr"] = "htr"
-
-    return cleaned_map, compat_aliases

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -19,10 +19,11 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .api import RESTClient
 from .const import API_BASE, DOMAIN, WS_NAMESPACE, signal_ws_data, signal_ws_status
 from .heater import prepare_heater_platform_data
-from .nodes import NODE_CLASS_BY_TYPE, build_node_inventory as _build_node_inventory
-from .utils import (
+from .nodes import (
     HEATER_NODE_TYPES,
+    NODE_CLASS_BY_TYPE,
     addresses_by_node_type,
+    build_node_inventory as _build_node_inventory,
     ensure_node_inventory,
     normalize_heater_addresses,
 )

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -340,7 +340,7 @@ custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.native_val
     Return the summed energy usage across all heaters.
 custom_components/termoweb/sensor.py :: InstallationTotalEnergySensor.extra_state_attributes
     Return identifiers describing the aggregated energy value.
-custom_components/termoweb/utils.py :: addresses_by_node_type
+custom_components/termoweb/nodes.py :: addresses_by_node_type
     Return mapping of node type to address list, tracking unknown types.
 custom_components/termoweb/utils.py :: float_or_none
     Return value as ``float`` if possible, else ``None``.

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -20,7 +20,7 @@ from custom_components.termoweb.const import (
     HTR_ENERGY_UPDATE_INTERVAL,
     signal_ws_data,
 )
-from custom_components.termoweb.utils import normalize_heater_addresses
+from custom_components.termoweb.nodes import normalize_heater_addresses
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.update_coordinator import UpdateFailed

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -12,8 +12,11 @@ from conftest import _install_stubs, make_ws_payload
 _install_stubs()
 
 from custom_components.termoweb import heater as heater_module
-from custom_components.termoweb.nodes import HeaterNode, build_node_inventory
-from custom_components.termoweb.utils import build_heater_address_map
+from custom_components.termoweb.nodes import (
+    HeaterNode,
+    build_heater_address_map,
+    build_node_inventory,
+)
 from homeassistant.core import HomeAssistant
 
 HeaterNodeBase = heater_module.HeaterNodeBase

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -17,11 +17,11 @@ from aiohttp import ClientError
 from custom_components.termoweb import coordinator as coordinator_module
 from custom_components.termoweb import sensor as sensor_module
 from custom_components.termoweb import const as const_module
-from custom_components.termoweb.nodes import build_node_inventory
-from custom_components.termoweb.utils import (
-    build_gateway_device_info,
+from custom_components.termoweb.nodes import (
     build_heater_energy_unique_id,
+    build_node_inventory,
 )
+from custom_components.termoweb.utils import build_gateway_device_info
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from custom_components.termoweb import utils as utils_module
+from custom_components.termoweb import nodes as nodes_module
 
 from conftest import _install_stubs
 
@@ -681,9 +681,9 @@ def test_async_import_energy_history_skips_invalid_samples(
             }
         }
 
-        uid_c = utils_module.build_heater_energy_unique_id("dev", "htr", "C")
+        uid_c = nodes_module.build_heater_energy_unique_id("dev", "htr", "C")
         ent_reg.add("sensor.dev_C_energy", "sensor", const.DOMAIN, uid_c, "C energy")
-        uid_d = utils_module.build_heater_energy_unique_id("dev", "htr", "D")
+        uid_d = nodes_module.build_heater_energy_unique_id("dev", "htr", "D")
         ent_reg.add("sensor.dev_D_energy", "sensor", const.DOMAIN, uid_d, "D energy")
 
         store = Mock()
@@ -750,7 +750,7 @@ def test_import_energy_history(monkeypatch: pytest.MonkeyPatch) -> None:
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 4 * 86_400
@@ -845,7 +845,7 @@ def test_import_energy_history_with_existing_stats(
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 4 * 86_400
@@ -937,7 +937,7 @@ def test_import_energy_history_clears_overlap(monkeypatch: pytest.MonkeyPatch) -
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 4 * 86_400
@@ -1033,7 +1033,7 @@ def test_import_energy_history_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 2 * 86_400
@@ -1108,7 +1108,7 @@ def test_import_history_uses_last_stats_and_clears_overlap(
             "config_entry": entry,
         }
 
-        uid = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 5 * 86_400
@@ -1207,7 +1207,7 @@ def test_import_history_uses_sync_recorder_helpers(
             "config_entry": entry,
         }
 
-        uid = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 5 * 86_400
@@ -1303,8 +1303,8 @@ def test_import_energy_history_reset_and_subset(
             "node_inventory": _inventory_for(mod, ["A", "B"]),
             "config_entry": entry,
         }
-        uidA = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uidB = utils_module.build_heater_energy_unique_id("dev", "htr", "B")
+        uidA = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uidB = nodes_module.build_heater_energy_unique_id("dev", "htr", "B")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uidA, "A energy")
         ent_reg.add("sensor.dev_B_energy", "sensor", const.DOMAIN, uidB, "B energy")
 
@@ -1402,8 +1402,8 @@ def test_import_energy_history_reset_all_progress(
             "config_entry": entry,
         }
 
-        uid_a = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uid_b = utils_module.build_heater_energy_unique_id("dev", "htr", "B")
+        uid_a = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid_b = nodes_module.build_heater_energy_unique_id("dev", "htr", "B")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -1547,7 +1547,7 @@ def test_import_energy_history_requested_map_filters(
             )
 
         monkeypatch.setattr(
-            utils_module, "addresses_by_node_type", fake_addresses_by_node_type
+            nodes_module, "addresses_by_node_type", fake_addresses_by_node_type
         )
 
         original_normalize = mod.normalize_heater_addresses
@@ -1558,8 +1558,8 @@ def test_import_energy_history_requested_map_filters(
 
         monkeypatch.setattr(mod, "normalize_heater_addresses", fake_normalize)
 
-        uid_a = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uid_b_legacy = utils_module.build_heater_energy_unique_id("dev", "htr", "B")
+        uid_a = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid_b_legacy = nodes_module.build_heater_energy_unique_id("dev", "htr", "B")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -1725,7 +1725,7 @@ def test_import_energy_history_resets_requested_progress(
             return ({"pmo": ["X"]}, set())
 
         monkeypatch.setattr(
-            utils_module, "addresses_by_node_type", fake_addresses_by_node_type
+            nodes_module, "addresses_by_node_type", fake_addresses_by_node_type
         )
 
         fake_now = 5 * 86_400
@@ -1982,8 +1982,8 @@ def test_service_dispatches_import_tasks(monkeypatch: pytest.MonkeyPatch) -> Non
         rec = hass.data[const.DOMAIN][entry.entry_id]
         rec["node_inventory"] = _inventory_for(mod, {"htr": ["A"], "acm": ["B"]})
 
-        uid_a = utils_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uid_b = utils_module.build_heater_energy_unique_id("dev", "acm", "B")
+        uid_a = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid_b = nodes_module.build_heater_energy_unique_id("dev", "acm", "B")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -2141,7 +2141,7 @@ def test_service_filters_invalid_entities(monkeypatch: pytest.MonkeyPatch) -> No
             "sensor.no_entry",
             "sensor",
             const.DOMAIN,
-            utils_module.build_heater_energy_unique_id("dev", "htr", "D"),
+            nodes_module.build_heater_energy_unique_id("dev", "htr", "D"),
             "Missing entry",
             config_entry_id="missing",
         )
@@ -2149,7 +2149,7 @@ def test_service_filters_invalid_entities(monkeypatch: pytest.MonkeyPatch) -> No
             "sensor.no_config",
             "sensor",
             const.DOMAIN,
-            utils_module.build_heater_energy_unique_id("dev", "htr", "C"),
+            nodes_module.build_heater_energy_unique_id("dev", "htr", "C"),
             "No config",
         )
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as entity_registry_mod
 
-from custom_components.termoweb.utils import (
+from custom_components.termoweb.nodes import (
     build_heater_address_map,
     build_heater_energy_unique_id,
 )

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -13,8 +13,9 @@ from custom_components.termoweb.nodes import (
     PowerMonitorNode,
     ThermostatNode,
     build_node_inventory,
+    normalize_node_addr,
+    normalize_node_type,
 )
-from custom_components.termoweb.utils import normalize_node_addr, normalize_node_type
 
 
 def test_heater_node_normalises_inputs() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,22 +5,23 @@ from typing import Any
 
 import pytest
 
-from custom_components.termoweb import utils as utils_module
+from custom_components.termoweb import nodes as nodes_module
 from custom_components.termoweb.const import DOMAIN
-from custom_components.termoweb.nodes import build_node_inventory
-
-from custom_components.termoweb.utils import (
+from custom_components.termoweb.nodes import (
     HEATER_NODE_TYPES,
-    _entry_gateway_record,
     addresses_by_node_type,
-    build_gateway_device_info,
     build_heater_energy_unique_id,
+    build_node_inventory,
     ensure_node_inventory,
-    float_or_none,
     normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
     parse_heater_energy_unique_id,
+)
+from custom_components.termoweb.utils import (
+    _entry_gateway_record,
+    build_gateway_device_info,
+    float_or_none,
 )
 
 
@@ -233,8 +234,8 @@ def test_build_heater_energy_unique_id_round_trip(
 ) -> None:
     calls: list[tuple[str, object, dict[str, Any]]] = []
 
-    original_normalize_type = utils_module.normalize_node_type
-    original_normalize_addr = utils_module.normalize_node_addr
+    original_normalize_type = nodes_module.normalize_node_type
+    original_normalize_addr = nodes_module.normalize_node_addr
 
     def _record_type(value, **kwargs):
         calls.append(("type", value, kwargs))
@@ -244,8 +245,8 @@ def test_build_heater_energy_unique_id_round_trip(
         calls.append(("addr", value, kwargs))
         return original_normalize_addr(value, **kwargs)
 
-    monkeypatch.setattr(utils_module, "normalize_node_type", _record_type)
-    monkeypatch.setattr(utils_module, "normalize_node_addr", _record_addr)
+    monkeypatch.setattr(nodes_module, "normalize_node_type", _record_type)
+    monkeypatch.setattr(nodes_module, "normalize_node_addr", _record_addr)
 
     unique_id = build_heater_energy_unique_id(" dev ", " ACM ", " 01 ")
 


### PR DESCRIPTION
## Summary
- centralize node normalization and heater helper functions inside `nodes.py`
- streamline `utils.py` to only gateway and numeric utilities while updating imports across the integration
- refresh tests and documentation references to use the new node helper locations

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d96b2c16bc8329b46bffeb2fcaf069