### PR TITLE
Fix pytest coroutine detection deprecation warning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import datetime as dt
 import enum
 import time
@@ -42,7 +43,7 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
         return None
 
     testfunction = pyfuncitem.obj
-    if not asyncio.iscoroutinefunction(testfunction):
+    if not inspect.iscoroutinefunction(testfunction):
         return None
 
     marker = pyfuncitem.get_closest_marker("asyncio")


### PR DESCRIPTION
## Summary
- replace the deprecated `asyncio.iscoroutinefunction` check in the pytest hook with `inspect.iscoroutinefunction` to silence the DeprecationWarning during the test suite

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check tests/conftest.py

------
https://chatgpt.com/codex/tasks/task_e_68da3cd220e483299a0538280f9d3784