### PR TITLE
Handle generic Ducaheat node settings

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -572,3 +572,8 @@ class RESTClient:
             _redact_bearer(repr(payload)),
         )
 
+    def normalise_ws_nodes(self, nodes: dict[str, Any]) -> dict[str, Any]:
+        """Return websocket node payloads unchanged by default."""
+
+        return nodes
+

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -905,6 +905,14 @@ class WebSocketClient:
         if nodes is None:
             _LOGGER.debug("WS %s: %s without nodes", self.dev_id, event)
             return
+        normaliser = getattr(self._client, "normalise_ws_nodes", None)
+        if callable(normaliser):
+            try:
+                nodes = normaliser(nodes)  # type: ignore[arg-type]
+            except Exception:  # pragma: no cover - defensive logging only
+                _LOGGER.debug(
+                    "WS %s: normalise_ws_nodes failed; using raw payload", self.dev_id
+                )
         if _LOGGER.isEnabledFor(logging.DEBUG):
             changed = self._collect_update_addresses(nodes)
             if merge:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1238,9 +1238,9 @@ def test_ducaheat_get_node_settings_normalises_payload(
         assert data["stemp"] == "21.0"
         assert data["mtemp"] == "20.5"
         assert data["units"] == "C"
-        assert data["boost_active"] is True
-        assert data["boost_time"] == 45
-        assert data["boost_temp"] == "23.0"
+        assert "boost_active" not in data
+        assert "boost_time" not in data
+        assert "boost_temp" not in data
         assert len(data["prog"]) == 168
         assert data["ptemp"] == ["7.0", "18.0", "21.0"]
         assert data["raw"]["status"]["mode"] == "Manual"
@@ -1265,7 +1265,8 @@ def test_ducaheat_get_node_settings_acm_merges_capabilities(
                         "capabilities": {
                             "boost": {"min": 10},
                             "charge": {"modes": ["eco"]},
-                        }
+                        },
+                        "extra_options": {"boost_temp": "25.0", "boost_time": 30},
                     },
                     "capabilities": {"charge": {"levels": [1, 2, 3]}},
                 },
@@ -1288,10 +1289,101 @@ def test_ducaheat_get_node_settings_acm_merges_capabilities(
         data = await client.get_node_settings("dev", ("acm", "2"))
 
         assert data["mode"] == "auto"
+        assert data["boost_temp"] == "25.0"
+        assert data["boost_time"] == 30
         assert data["capabilities"] == {
             "boost": {"max": 90, "min": 10},
             "charge": {"modes": ["eco"], "levels": [1, 2, 3]},
         }
+        assert session.request_calls[0][1] == (
+            "https://api.termoweb.fake/api/v2/devs/dev/acm/2"
+        )
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_get_node_settings_acm_handles_half_hour_prog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        half_hour_prog = {
+            str(idx): pattern
+            for idx, pattern in enumerate(
+                [
+                    [0, 2] * 24,
+                    [0, 0] * 24,
+                    [2, 2] * 24,
+                    [0, 1] * 24,
+                    [1, 2] * 24,
+                    [0, 2, 1, 0] * 12,
+                    [0] * 48,
+                ]
+            )
+        }
+
+        session = FakeSession()
+        session.queue_request(
+            MockResponse(
+                200,
+                {
+                    "status": {
+                        "sync_status": "ok",
+                        "mode": "off",
+                        "heating": False,
+                        "units": "C",
+                        "stemp": "21.0",
+                        "mtemp": 24.4,
+                    },
+                    "setup": {
+                        "sync_status": "ok",
+                        "operational_mode": 1,
+                        "control_mode": 5,
+                        "units": "C",
+                        "offset": "0.0",
+                        "priority": "medium",
+                        "away_offset": "2.0",
+                        "window_mode_enabled": False,
+                        "prog_resolution": 1,
+                        "charging_conf": {
+                            "slot_1": {"start": 0, "end": 1430},
+                            "slot_2": {"start": 0, "end": 0},
+                            "active_days": [1, 1, 1, 1, 1, 1, 1],
+                        },
+                        "min_stemp": "5.0",
+                        "max_stemp": "30.0",
+                    },
+                    "prog": {"sync_status": "ok", "prog": half_hour_prog},
+                },
+                headers={"Content-Type": "application/json"},
+            )
+        )
+
+        client = DucaheatRESTClient(
+            session,
+            "user",
+            "pass",
+            api_base="https://api.termoweb.fake",
+        )
+
+        async def fake_headers() -> dict[str, str]:
+            return {"Authorization": "Bearer token"}
+
+        monkeypatch.setattr(client, "_authed_headers", fake_headers)
+
+        data = await client.get_node_settings("dev", ("acm", "2"))
+
+        assert data["mode"] == "off"
+        assert data["stemp"] == "21.0"
+        assert data["mtemp"] == "24.4"
+        assert data["units"] == "C"
+        assert len(data["prog"]) == 168
+        assert data["prog"][:24] == [2] * 24
+        assert data["prog"][24:48] == [0] * 24
+        assert data["prog"][72:96] == [1] * 24
+        assert data["prog"][96:120] == [2] * 24
+        assert session.request_calls[0][1] == (
+            "https://api.termoweb.fake/api/v2/devs/dev/acm/2"
+        )
 
     asyncio.run(_run())
 
@@ -1533,10 +1625,31 @@ def test_ducaheat_normalise_settings_fallbacks() -> None:
     result = client._normalise_settings(payload)
     assert result["stemp"] == "20.5"
     assert result["mtemp"] == "19.0"
-    assert result["boost_temp"] == "23.0"
-    assert result["boost_time"] == 30
+    assert "boost_temp" not in result
+    assert "boost_time" not in result
     assert result["ptemp"] == ["5.0", "", "18.0"]
     assert result["name"] == "Heater"
+
+
+def test_ducaheat_normalise_settings_acm_status_boost() -> None:
+    client = DucaheatRESTClient(
+        FakeSession(),
+        "user",
+        "pass",
+        api_base="https://api.termoweb.fake",
+    )
+    payload = {
+        "status": {
+            "boost_temp": "24",
+            "boost_time": 15,
+            "boost_active": True,
+        }
+    }
+
+    result = client._normalise_settings(payload, node_type="acm")
+    assert result["boost_temp"] == "24.0"
+    assert result["boost_time"] == 15
+    assert result["boost_active"] is True
 
 
 def test_ducaheat_normalise_prog_with_varied_inputs() -> None:
@@ -1575,6 +1688,15 @@ def test_ducaheat_normalise_prog_invalid_inputs() -> None:
 
     bad_day = {"days": {"mon": ["x"]}}
     assert client._normalise_prog(bad_day) is None
+    assert (
+        client._normalise_prog({"days": {"mon": {"slots": None}}}) is None
+    )
+    assert (
+        client._normalise_prog({"days": {"mon": {"slots": 123}}}) is None
+    )
+    assert (
+        client._normalise_prog({"days": {"mon": {"values": "abc"}}}) is None
+    )
 
 
 def test_ducaheat_normalise_prog_temps_variations() -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -204,6 +204,44 @@ def test_apply_nodes_payload_logs_without_changes(
     client._merge_nodes.assert_called_once()
 
 
+def test_apply_nodes_payload_uses_normaliser(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client normalisers should transform websocket payloads when available."""
+
+    module = _load_ws_client()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self._session = None
+
+        def normalise_ws_nodes(self, nodes: dict[str, Any]) -> dict[str, Any]:
+            self.calls.append(nodes)
+            return {"htr": {"settings": {"01": {"prog": [0] * 168}}}}
+
+    hass = types.SimpleNamespace(
+        loop=types.SimpleNamespace(create_task=lambda coro, name=None: None)
+    )
+    api_client = FakeClient()
+    client = module.WebSocket09Client(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=api_client,
+        coordinator=types.SimpleNamespace(),
+    )
+
+    client._merge_nodes = MagicMock()
+    client._build_nodes_snapshot = MagicMock(return_value={"nodes": {}})
+    client._dispatch_nodes = MagicMock()
+    client._mark_event = MagicMock()
+
+    payload = {"nodes": {"htr": {"settings": {"01": {"prog": {"prog": {"0": [0] * 48}}}}}}}
+    client._apply_nodes_payload(payload, merge=False, event="snapshot")
+
+    assert api_client.calls == [payload["nodes"]]
+    client._merge_nodes.assert_not_called()
+
+
 def test_collect_update_addresses_ignores_non_mappings() -> None:
     """Collector should ignore non-dict sections while gathering addresses."""
 


### PR DESCRIPTION
## Summary
- adjust the Ducaheat REST client to request node settings from `/{node_type}/{addr}`, logging non-heater payloads and returning raw data for other node types
- normalise accumulator and heater payloads while limiting boost metadata to accumulators
- extend tests to cover generic node retrieval, accumulator boost handling, and heater responses without boost data alongside existing programme cases

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68da45ee00f48329a09bef1d92c82541