### PR TITLE
Fix Engine.IO websocket endpoint path

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -732,7 +732,7 @@ class WebSocketClient:
         base = self._socket_base()
         t_ms = int(time.time() * 1000)
         url = (
-            f"{base}/socket.io?EIO=3&transport=polling&token={token}&dev_id={self.dev_id}&t={t_ms}"
+            f"{base}/socket_io?EIO=3&transport=polling&token={token}&dev_id={self.dev_id}&t={t_ms}"
         )
         try:
             async with asyncio.timeout(15):
@@ -803,7 +803,7 @@ class WebSocketClient:
         token = await self._get_token()
         base = self._upgrade_scheme(self._socket_base())
         url = (
-            f"{base}/socket.io?EIO=3&transport=websocket&sid={sid}&token={token}&dev_id={self.dev_id}"
+            f"{base}/socket_io?EIO=3&transport=websocket&sid={sid}&token={token}&dev_id={self.dev_id}"
         )
         self._engineio_ws = await self._session.ws_connect(
             url,

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -551,7 +551,7 @@ def test_engineio_handshake_parsing_and_errors() -> None:
         handshake_url = session.get_calls[0]["url"]
         prefix = (
             "https://api-tevolve.termoweb.net/api/v2/"
-            "socket.io?EIO=3&transport=polling&token=token&dev_id=dev&t="
+            "socket_io?EIO=3&transport=polling&token=token&dev_id=dev&t="
         )
         assert handshake_url.startswith(prefix)
         assert handshake_url[len(prefix) :].isdigit()
@@ -633,7 +633,7 @@ def test_engineio_connect_and_send() -> None:
         call = session.ws_connect_calls[0]
         assert call["url"] == (
             "wss://api-tevolve.termoweb.net/api/v2/"
-            "socket.io?EIO=3&transport=websocket&sid=sid-123&token=abc&dev_id=dev"
+            "socket_io?EIO=3&transport=websocket&sid=sid-123&token=abc&dev_id=dev"
         )
         assert call["kwargs"]["protocols"] == ("websocket",)
         assert client._engineio_ws.sent[0] == f"40{module.WS_NAMESPACE}"


### PR DESCRIPTION
## Summary
- update the Engine.IO v2 polling and websocket upgrade URLs to use the socket_io suffix
- align websocket client tests with the new Engine.IO endpoint path

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68da851ff6fc83299c2d5df6bde4b8c6