### PR TITLE
Remove unused websocket endpoint helper

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -1773,15 +1773,6 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
         path = parsed.path.rstrip("/")
         return urlunsplit((scheme, netloc, path or "", "", ""))
 
-    def _socket_endpoint(self) -> str:
-        """Return the websocket endpoint path."""
-
-        return "api/v2/socket_io"
-
-
-
-
-
 class DucaheatWSClient(WebSocketClient):
     """Verbose websocket client variant with payload debug logging."""
 


### PR DESCRIPTION
## Summary
- remove the unused `_socket_endpoint` helper from the websocket client implementation
- rely on existing engine.io path builder and ensure no dangling references remain

## Testing
- ruff check custom_components/termoweb/ws_client.py tests/test_ws_client.py
- pytest tests/test_ws_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dc10b414588329ba46ca0739bba7a3