### PR TITLE
Consolidate heater helper imports into nodes module

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.loader import async_get_integration
 
 from .const import DOMAIN
-from .nodes import extract_heater_addrs as _extract_heater_addrs
 
 
 async def async_get_integration_version(hass: HomeAssistant) -> str:
@@ -105,6 +104,3 @@ def float_or_none(value: Any) -> float | None:
         return num if math.isfinite(num) else None
     except Exception:  # noqa: BLE001
         return None
-
-
-extract_heater_addrs = _extract_heater_addrs

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from custom_components.termoweb.nodes import (
     build_heater_energy_unique_id,
     build_node_inventory,
     ensure_node_inventory,
+    extract_heater_addrs,
     normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
@@ -21,7 +22,6 @@ from custom_components.termoweb.nodes import (
 from custom_components.termoweb.utils import (
     _entry_gateway_record,
     build_gateway_device_info,
-    extract_heater_addrs,
     float_or_none,
 )
 


### PR DESCRIPTION
## Summary
- remove the legacy extract_heater_addrs re-export from utils so heater helpers only live in nodes.py
- update utils tests to import extract_heater_addrs from the canonical nodes module

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dbf78f9abc832980b5acb3b35b0e2f