### PR TITLE
Remove unused extract_heater_addrs helper

### DIFF
--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -298,32 +298,6 @@ def build_node_inventory(raw_nodes: Any) -> list[Node]:
     return inventory
 
 
-def extract_heater_addrs(nodes_payload: Mapping[str, Any] | None) -> list[str]:
-    """Return heater node addresses extracted from ``nodes_payload``."""
-
-    if not isinstance(nodes_payload, Mapping):
-        return []
-
-    inventory = build_node_inventory(nodes_payload)
-    deduped: list[str] = []
-    seen: set[str] = set()
-
-    for node in inventory:
-        node_type = normalize_node_type(getattr(node, "type", ""))
-        if node_type not in HEATER_NODE_TYPES:
-            continue
-        addr = normalize_node_addr(getattr(node, "addr", ""))
-        if not addr:
-            continue
-        key = addr.casefold()
-        if key in seen:
-            continue
-        deduped.append(addr)
-        seen.add(key)
-
-    return deduped
-
-
 def ensure_node_inventory(
     record: Mapping[str, Any], *, nodes: Any | None = None
 ) -> list[Node]:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -198,26 +198,6 @@ def test_node_init_uses_normalization_helpers() -> None:
     assert node.name == "Normalised"
 
 
-def test_extract_heater_addrs_ignores_blank_addresses(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    payload: dict[str, object] = {"nodes": []}
-
-    fake_nodes = [
-        SimpleNamespace(type="htr", addr="A"),
-        SimpleNamespace(type="htr", addr="  "),
-        SimpleNamespace(type="acm", addr="B"),
-    ]
-
-    def fake_build(raw: object) -> list[SimpleNamespace]:
-        assert raw is payload
-        return list(fake_nodes)
-
-    monkeypatch.setattr(nodes_module, "build_node_inventory", fake_build)
-
-    assert nodes_module.extract_heater_addrs(payload) == ["A", "B"]
-
-
 def test_ensure_node_inventory_sets_empty_cache() -> None:
     record: dict[str, object] = {}
     result = nodes_module.ensure_node_inventory(record)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,6 @@ from custom_components.termoweb.nodes import (
     build_heater_energy_unique_id,
     build_node_inventory,
     ensure_node_inventory,
-    extract_heater_addrs,
     normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
@@ -291,23 +290,3 @@ def test_build_heater_energy_unique_id_requires_components(
 )
 def test_parse_heater_energy_unique_id_invalid(value) -> None:
     assert parse_heater_energy_unique_id(value) is None
-
-
-def test_extract_heater_addrs_filters_duplicates_and_types() -> None:
-    payload = {
-        "nodes": [
-            {"type": "htr", "addr": " A "},
-            {"type": "acm", "addr": "B"},
-            {"type": "pmo", "addr": "p1"},
-            {"type": "htr", "addr": "a"},
-            {"type": "thm", "addr": "t"},
-            {"type": "htr", "addr": "  "},
-        ]
-    }
-
-    assert extract_heater_addrs(payload) == ["A", "B"]
-
-
-@pytest.mark.parametrize("payload", [None, [], "invalid", {"nodes": "bad"}])
-def test_extract_heater_addrs_handles_invalid_payload(payload: Any) -> None:
-    assert extract_heater_addrs(payload) == []


### PR DESCRIPTION
## Summary
- remove the deprecated `extract_heater_addrs` helper from the node utilities
- delete the unit tests that only exercised the removed helper and clean up related imports

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dc211bf6a08329a9cc117cc3dadd30