### PR TITLE
Use dispatcher helper for gateway connectivity sensor

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -9,12 +9,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_status
 from .coordinator import StateCoordinator
+from .heater import DispatcherSubscriptionHelper
 from .utils import build_gateway_device_info
 
 
@@ -44,15 +44,21 @@ class GatewayOnlineBinarySensor(
         self._dev_id = str(dev_id)
         self._attr_name = "TermoWeb Gateway Online"
         self._attr_unique_id = f"{self._dev_id}_online"
-        self._unsub_ws = None
+        self._ws_subscription = DispatcherSubscriptionHelper(self)
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to websocket status updates when added to hass."""
         await super().async_added_to_hass()
-        self._unsub_ws = async_dispatcher_connect(
-            self.hass, signal_ws_status(self._entry_id), self._on_ws_status
-        )
-        self.async_on_remove(lambda: self._unsub_ws() if self._unsub_ws else None)
+        if self.hass is None:
+            return
+
+        signal = signal_ws_status(self._entry_id)
+        self._ws_subscription.subscribe(self.hass, signal, self._on_ws_status)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from websocket updates before removal."""
+        self._ws_subscription.unsubscribe()
+        await super().async_will_remove_from_hass()
 
     def _ws_state(self) -> dict[str, Any]:
         """Return the latest websocket status payload for this device."""


### PR DESCRIPTION
## Summary
- switch the gateway connectivity binary sensor to DispatcherSubscriptionHelper-managed websocket subscriptions
- add lifecycle cleanup and unit tests validating the helper wiring

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dc2114e7ec83299de767464b3ba90b