### PR TITLE
Log raw handshake lease values

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -158,10 +158,13 @@ class WebSocketClient:
     # ------------------------------------------------------------------
     # Public control
     # ------------------------------------------------------------------
-    def _wrap_background_task(self, target: Any, *args: Any, **kwargs: Any) -> asyncio.Task:
+    def _wrap_background_task(
+        self, target: Any, *args: Any, **kwargs: Any
+    ) -> asyncio.Task:
         """Schedule socket.io background tasks on the HA loop."""
         coro = target(*args, **kwargs)
         if not asyncio.iscoroutine(coro):
+
             async def _runner() -> Any:
                 return coro
 
@@ -254,7 +257,9 @@ class WebSocketClient:
                 delay = self._backoff_seq[
                     min(self._backoff_idx, len(self._backoff_seq) - 1)
                 ]
-                self._backoff_idx = min(self._backoff_idx + 1, len(self._backoff_seq) - 1)
+                self._backoff_idx = min(
+                    self._backoff_idx + 1, len(self._backoff_seq) - 1
+                )
                 await asyncio.sleep(delay * random.uniform(0.8, 1.2))
         finally:
             self._update_status("stopped")
@@ -309,7 +314,10 @@ class WebSocketClient:
                 await self._sio.disconnect()
             except Exception:  # noqa: BLE001
                 _LOGGER.debug(
-                    "WS %s: disconnect due to %s failed", self.dev_id, reason, exc_info=True
+                    "WS %s: disconnect due to %s failed",
+                    self.dev_id,
+                    reason,
+                    exc_info=True,
                 )
         self._disconnected.set()
 
@@ -642,7 +650,11 @@ class WebSocketClient:
                 return None
         else:
             return None
-        if "ms" in key or "milli" in key or (raw > 86400 and "hour" not in key and "day" not in key):
+        if (
+            "ms" in key
+            or "milli" in key
+            or (raw > 86400 and "hour" not in key and "day" not in key)
+        ):
             raw /= 1000.0
         return raw
 
@@ -657,21 +669,27 @@ class WebSocketClient:
                 lease_scalars: list[str] = []
                 lease_tokens = ("ttl", "timeout", "lease", "expire")
 
-                def _format_scalar(value: Any) -> str | None:
-                    if isinstance(value, bool):
+                def _summarise_value(value: Any) -> str | None:
+                    if isinstance(value, (Mapping, list, tuple)):
                         return None
-                    if isinstance(value, (int, float)):
-                        return format(value, "g")
-                    if isinstance(value, str):
-                        candidate = value.strip()
-                        if not candidate:
-                            return None
-                        try:
-                            float(candidate)
-                        except ValueError:
-                            return None
-                        return candidate
-                    return None
+                    raw: str
+                    if isinstance(value, bytes):
+                        raw = value.decode("utf-8", "replace")
+                    elif isinstance(value, str):
+                        raw = value
+                    elif isinstance(value, (bool, int, float)):
+                        raw = str(value)
+                    elif value is None:
+                        raw = "None"
+                    else:
+                        raw = repr(value)
+                    if not raw:
+                        return raw
+                    safe = raw.replace("\n", "\\n")
+                    max_len = 120
+                    if len(safe) > max_len:
+                        safe = f"{safe[: max_len - 1]}…"
+                    return safe
 
                 def _collect_scalars(node: Any, path: str) -> None:
                     if isinstance(node, Mapping):
@@ -680,7 +698,7 @@ class WebSocketClient:
                             key_lower = key_str.lower()
                             next_path = f"{path}.{key_str}" if path else key_str
                             if any(token in key_lower for token in lease_tokens):
-                                formatted = _format_scalar(value)
+                                formatted = _summarise_value(value)
                                 if formatted is not None:
                                     lease_scalars.append(f"{next_path}={formatted}")
                             if isinstance(value, (Mapping, list, tuple)):
@@ -691,9 +709,7 @@ class WebSocketClient:
 
                 _collect_scalars(data, "")
                 summary = ", ".join(lease_scalars) if lease_scalars else "none"
-                _LOGGER.debug(
-                    "WS %s: handshake lease hints: %s", self.dev_id, summary
-                )
+                _LOGGER.debug("WS %s: handshake lease hints: %s", self.dev_id, summary)
             ttl_info = self._extract_subscription_ttl(data)
             ttl: float
             source: str
@@ -742,9 +758,7 @@ class WebSocketClient:
                     _LOGGER.debug(
                         "WS %s: update event for %s",
                         self.dev_id,
-                        ", ".join(
-                            f"{node_type}/{addr}" for node_type, addr in changed
-                        ),
+                        ", ".join(f"{node_type}/{addr}" for node_type, addr in changed),
                     )
                 else:
                     _LOGGER.debug(
@@ -782,9 +796,7 @@ class WebSocketClient:
             self._forward_sample_updates(sample_updates)
         self._mark_event(paths=None, count_event=True)
 
-    def _forward_sample_updates(
-        self, updates: Mapping[str, Mapping[str, Any]]
-    ) -> None:
+    def _forward_sample_updates(self, updates: Mapping[str, Mapping[str, Any]]) -> None:
         """Relay websocket heater sample updates to the energy coordinator."""
 
         record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
@@ -868,7 +880,8 @@ class WebSocketClient:
 
         if not is_snapshot:  # pragma: no cover - legacy branch
             nodes_by_type = {
-                node_type: {"addrs": list(addrs)} for node_type, addrs in addr_map.items()
+                node_type: {"addrs": list(addrs)}
+                for node_type, addrs in addr_map.items()
             }
             snapshot["nodes_by_type"] = nodes_by_type
             if "htr" in nodes_by_type:
@@ -893,7 +906,8 @@ class WebSocketClient:
             "nodes_by_type": deepcopy(snapshot.get("nodes_by_type", {})),
         }
         payload_copy.setdefault(
-            "addr_map", {node_type: list(addrs) for node_type, addrs in addr_map.items()}
+            "addr_map",
+            {node_type: list(addrs) for node_type, addrs in addr_map.items()},
         )
         if unknown_types:
             payload_copy.setdefault("unknown_types", sorted(unknown_types))
@@ -966,9 +980,7 @@ class WebSocketClient:
                 for node_type, addrs in normalized_map.items():
                     if not addrs and node_type != "htr":
                         continue
-                    bucket = self._ensure_type_bucket(
-                        dev_map, nodes_by_type, node_type
-                    )
+                    bucket = self._ensure_type_bucket(dev_map, nodes_by_type, node_type)
                     if addrs:
                         bucket["addrs"] = list(addrs)
                 updated = dict(coordinator_data)
@@ -1650,7 +1662,9 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
         addr_pairs.update(f"{node_type}/{addr}" for node_type, addr in sample_addrs)
         if addr_pairs:
             _LOGGER.debug(
-                "WS %s: legacy update for %s", self.dev_id, ", ".join(sorted(addr_pairs))
+                "WS %s: legacy update for %s",
+                self.dev_id,
+                ", ".join(sorted(addr_pairs)),
             )
         elif updated_nodes:
             _LOGGER.debug("WS %s: legacy nodes refresh", self.dev_id)
@@ -1680,7 +1694,10 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
             )
             self._legacy_subscription_configured = True
             return
-        if self._subscription_refresh_task is None and self._subscription_refresh_due is None:
+        if (
+            self._subscription_refresh_task is None
+            and self._subscription_refresh_due is None
+        ):
             self._apply_subscription_ttl(
                 ttl=_DEFAULT_SUBSCRIPTION_TTL,
                 source="default",
@@ -1836,6 +1853,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
         netloc = parsed.netloc or parsed.path
         path = parsed.path.rstrip("/")
         return urlunsplit((scheme, netloc, path or "", "", ""))
+
 
 class DucaheatWSClient(WebSocketClient):
     """Verbose websocket client variant with payload debug logging."""

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -38,9 +38,7 @@ def patch_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
                 http=None,
             )
 
-        def on(
-            self, event: str, *, handler: Any, namespace: str | None = None
-        ) -> None:
+        def on(self, event: str, *, handler: Any, namespace: str | None = None) -> None:
             self.events[(event, namespace)] = handler
 
         async def connect(self, *args: Any, **kwargs: Any) -> None:
@@ -71,6 +69,7 @@ def _make_client(
     """Helper to instantiate a websocket client with test doubles."""
 
     if hass_loop is None:
+
         class _DummyTask:
             def __init__(self, coro: Any) -> None:
                 self._coro = coro
@@ -104,6 +103,7 @@ def _make_client(
 
             def __await__(self):  # type: ignore[no-untyped-def]
                 if self._cancelled or self._completed:
+
                     async def _noop() -> None:
                         return None
 
@@ -146,6 +146,7 @@ def _make_ducaheat_client(
     """Return a Ducaheat websocket client configured for tests."""
 
     if hass_loop is None:
+
         def _create_task(coro: Any, **_: Any) -> Any:
             closer = getattr(coro, "close", None)
             if callable(closer):
@@ -210,7 +211,9 @@ async def test_error_handlers_log_payloads(
 
     caplog.clear()
     await ns_disconnect("transport closed")
-    assert f"namespace disconnect ({module.WS_NAMESPACE}): transport closed" in caplog.text
+    assert (
+        f"namespace disconnect ({module.WS_NAMESPACE}): transport closed" in caplog.text
+    )
 
 
 def test_ws_state_bucket_initialises_missing_data(
@@ -246,6 +249,7 @@ def _make_legacy_client(
     """Return a TermoWeb legacy websocket client with patched dependencies."""
 
     if hass_loop is None:
+
         def _create_task(coro: Any, **_: Any) -> Any:
             closer = getattr(coro, "close", None)
             if callable(closer):
@@ -273,7 +277,9 @@ def _make_legacy_client(
     return client
 
 
-def test_http_wrapping_handles_missing_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_http_wrapping_handles_missing_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensure http assignments tolerate attribute errors and reuse existing sessions."""
 
     class AltAsyncClient:
@@ -299,9 +305,7 @@ def test_http_wrapping_handles_missing_attributes(monkeypatch: pytest.MonkeyPatc
                 raise AttributeError("http not writable")
             object.__setattr__(self, name, value)
 
-        def on(
-            self, event: str, *, handler: Any, namespace: str | None = None
-        ) -> None:
+        def on(self, event: str, *, handler: Any, namespace: str | None = None) -> None:
             self.events[(event, namespace)] = handler
 
         async def connect(self, *args: Any, **kwargs: Any) -> None:
@@ -332,15 +336,11 @@ async def test_ws_url_and_engineio_target(monkeypatch: pytest.MonkeyPatch) -> No
 
     ws_url = await client.ws_url()
     assert (
-        ws_url
-        == "https://api.example.com/api/v2/socket_io?token=token&dev_id=device"
+        ws_url == "https://api.example.com/api/v2/socket_io?token=token&dev_id=device"
     )
 
     base, path = await client._build_engineio_target()
-    assert (
-        base
-        == "https://api.example.com/api/v2/socket_io?token=token&dev_id=device"
-    )
+    assert base == "https://api.example.com/api/v2/socket_io?token=token&dev_id=device"
     assert path == "api/v2/socket_io"
 
 
@@ -359,7 +359,9 @@ async def test_wrap_background_task_runs_coroutine(
     assert captured == ["ok"]
 
 
-def test_wrap_background_task_with_sync_function(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_wrap_background_task_with_sync_function(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     loop = asyncio.new_event_loop()
     client = _make_client(monkeypatch, hass_loop=loop)
     task = client._wrap_background_task(lambda: "value")
@@ -471,7 +473,9 @@ def test_legacy_event_configures_subscription(monkeypatch: pytest.MonkeyPatch) -
     assert created
 
 
-def test_legacy_event_updates_ttl_after_default(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_legacy_event_updates_ttl_after_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensure default TTL is used until a payload provides an explicit value."""
 
     client = _make_legacy_client(monkeypatch)
@@ -489,7 +493,9 @@ def test_legacy_event_updates_ttl_after_default(monkeypatch: pytest.MonkeyPatch)
     client._loop.create_task = capture_task  # type: ignore[assignment]
 
     monkeypatch.setattr(module.time, "time", lambda: 200.0)
-    client._handle_event({"name": "data", "args": [[{"path": "/mgr/session", "body": {}}]]})
+    client._handle_event(
+        {"name": "data", "args": [[{"path": "/mgr/session", "body": {}}]]}
+    )
     assert client._subscription_ttl == pytest.approx(module._DEFAULT_SUBSCRIPTION_TTL)
     assert client._legacy_subscription_configured is False
     assert len(tasks) == 1
@@ -508,7 +514,9 @@ def test_legacy_event_updates_ttl_after_default(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
-async def test_legacy_refresh_subscription_success(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_legacy_refresh_subscription_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Check the legacy lease renewal updates bookkeeping on success."""
 
     client = _make_legacy_client(monkeypatch, hass_loop=asyncio.get_event_loop())
@@ -526,7 +534,9 @@ async def test_legacy_refresh_subscription_success(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
-async def test_legacy_refresh_subscription_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_legacy_refresh_subscription_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensure legacy lease renewal failures schedule a restart."""
 
     client = _make_legacy_client(monkeypatch, hass_loop=asyncio.get_event_loop())
@@ -639,7 +649,9 @@ async def test_ws_url_adds_suffix_when_missing(monkeypatch: pytest.MonkeyPatch) 
 
 
 @pytest.mark.asyncio
-async def test_apply_nodes_payload_updates_state(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_apply_nodes_payload_updates_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     hass_loop = asyncio.get_event_loop()
     client = _make_client(monkeypatch, hass_loop=hass_loop)
     client._coordinator.data = {"device": {"nodes_by_type": {}}}
@@ -750,7 +762,9 @@ def test_ducaheat_summarise_addresses_handles_empty(
 
 
 @pytest.mark.asyncio
-async def test_runner_handles_error_and_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_runner_handles_error_and_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
     statuses: list[str] = []
     monkeypatch.setattr(client, "_update_status", statuses.append)
@@ -830,7 +844,9 @@ async def test_idle_monitor_triggers_restart(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
-async def test_idle_monitor_exits_when_disconnected(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_idle_monitor_exits_when_disconnected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
     client._sio.connected = False
     client._disconnected.set()
@@ -859,7 +875,9 @@ async def test_idle_monitor_handles_transient_disconnect(
 
 
 @pytest.mark.asyncio
-async def test_idle_monitor_skips_when_no_last_event(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_idle_monitor_skips_when_no_last_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
     client._sio.connected = True
     client._last_event_at = None
@@ -873,7 +891,9 @@ async def test_idle_monitor_skips_when_no_last_event(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
-async def test_idle_monitor_retries_failed_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_idle_monitor_retries_failed_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Retry idle refreshes when the previous renewal failed."""
 
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
@@ -948,7 +968,9 @@ def test_start_and_stop_cancel_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
     loop.close()
 
 
-def test_restart_subscription_refresh_replaces_task(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_restart_subscription_refresh_replaces_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensure restarting the lease task cancels the previous instance."""
 
     client = _make_client(monkeypatch)
@@ -997,7 +1019,9 @@ def test_restart_subscription_refresh_replaces_task(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
-async def test_cancel_subscription_refresh_waits(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_cancel_subscription_refresh_waits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Cancel the refresh task and await its termination."""
 
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
@@ -1104,6 +1128,7 @@ async def test_subscription_refresh_loop_propagates_cancel(
     with pytest.raises(asyncio.CancelledError):
         await client._subscription_refresh_loop()
 
+
 @pytest.mark.asyncio
 async def test_refresh_subscription_requires_connection(
     monkeypatch: pytest.MonkeyPatch,
@@ -1143,7 +1168,9 @@ async def test_refresh_subscription_updates_metadata(
     monkeypatch.setattr(module._LOGGER, "isEnabledFor", lambda level: True)
 
     info_calls: list[tuple[Any, ...]] = []
-    monkeypatch.setattr(module._LOGGER, "info", lambda *args, **kwargs: info_calls.append(args))
+    monkeypatch.setattr(
+        module._LOGGER, "info", lambda *args, **kwargs: info_calls.append(args)
+    )
 
     await client._refresh_subscription(reason="unit")
 
@@ -1151,11 +1178,10 @@ async def test_refresh_subscription_updates_metadata(
     assert subscribe_mock.await_count == 1
     assert client._subscription_refresh_failed is False
     assert client._subscription_refresh_last_success == pytest.approx(1000.0)
-    assert client._subscription_refresh_due == pytest.approx(1000.0 + client._subscription_ttl)
-    assert any(
-        "unit" in " ".join(str(part) for part in call)
-        for call in info_calls
+    assert client._subscription_refresh_due == pytest.approx(
+        1000.0 + client._subscription_ttl
     )
+    assert any("unit" in " ".join(str(part) for part in call) for call in info_calls)
 
 
 def test_apply_subscription_ttl_updates_state(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1164,10 +1190,14 @@ def test_apply_subscription_ttl_updates_state(monkeypatch: pytest.MonkeyPatch) -
     client = _make_client(monkeypatch)
 
     restarts: list[str] = []
-    monkeypatch.setattr(client, "_restart_subscription_refresh", lambda: restarts.append("restart"))
+    monkeypatch.setattr(
+        client, "_restart_subscription_refresh", lambda: restarts.append("restart")
+    )
 
     info_calls: list[tuple[Any, ...]] = []
-    monkeypatch.setattr(module._LOGGER, "info", lambda *args, **kwargs: info_calls.append(args))
+    monkeypatch.setattr(
+        module._LOGGER, "info", lambda *args, **kwargs: info_calls.append(args)
+    )
 
     client._apply_subscription_ttl(
         ttl=30,
@@ -1219,10 +1249,14 @@ def test_coerce_seconds_variants() -> None:
     assert module.WebSocketClient._coerce_seconds("90", "ttl") == 90.0
     assert module.WebSocketClient._coerce_seconds("oops", "ttl") is None
     assert module.WebSocketClient._coerce_seconds(90000, "leaseMs") == 90.0
-    assert module.WebSocketClient._coerce_seconds(172800, "lease") == pytest.approx(172.8)
+    assert module.WebSocketClient._coerce_seconds(172800, "lease") == pytest.approx(
+        172.8
+    )
 
 
-def test_forward_sample_updates_handles_missing_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_forward_sample_updates_handles_missing_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Gracefully handle missing coordinator records for sample forwarding."""
 
     client = _make_client(monkeypatch)
@@ -1253,13 +1287,29 @@ def test_dispatch_nodes_records_unknown_types(monkeypatch: pytest.MonkeyPatch) -
     """Include unknown node types in the dispatched payload copy."""
 
     client = _make_client(monkeypatch)
-    record = {"nodes": {"nodes": [{"type": "foo", "addr": "1"}, {"type": "htr", "addr": "A"}]}}
+    record = {
+        "nodes": {"nodes": [{"type": "foo", "addr": "1"}, {"type": "htr", "addr": "A"}]}
+    }
     client.hass.data[module.DOMAIN] = {"entry": record}
     client._dispatcher_mock.reset_mock()
 
     snapshot = {
-        "nodes": {"htr": {"settings": {"A": {}}, "addrs": ["A"], "advanced": {}, "samples": {}}},
-        "nodes_by_type": {"htr": {"addrs": ["A"], "settings": {"A": {}}, "advanced": {}, "samples": {}}},
+        "nodes": {
+            "htr": {
+                "settings": {"A": {}},
+                "addrs": ["A"],
+                "advanced": {},
+                "samples": {},
+            }
+        },
+        "nodes_by_type": {
+            "htr": {
+                "addrs": ["A"],
+                "settings": {"A": {}},
+                "advanced": {},
+                "samples": {},
+            }
+        },
     }
 
     addr_map = client._dispatch_nodes(snapshot)
@@ -1267,6 +1317,7 @@ def test_dispatch_nodes_records_unknown_types(monkeypatch: pytest.MonkeyPatch) -
     payload = client._dispatcher_mock.call_args[0][2]
     assert payload["unknown_types"] == ["foo"]
     assert addr_map["htr"] == ["A"]
+
 
 @pytest.mark.asyncio
 async def test_connect_once_invokes_socket(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1284,7 +1335,9 @@ async def test_connect_once_invokes_socket(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
-async def test_connect_once_respects_stop_event(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_connect_once_respects_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
     client._stop_event = asyncio.Event()
     client._stop_event.set()
@@ -1294,7 +1347,9 @@ async def test_connect_once_respects_stop_event(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_events_handles_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_wait_for_events_handles_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
     client._stop_event = asyncio.Event()
     client._disconnected = asyncio.Event()
@@ -1326,7 +1381,9 @@ def test_api_base_default(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_force_refresh_token_resets_access(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_force_refresh_token_resets_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
     rest = client._client
     rest._access_token = "abc"  # type: ignore[attr-defined]
@@ -1335,7 +1392,9 @@ async def test_force_refresh_token_resets_access(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_build_engineio_target_handles_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_build_engineio_target_handles_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     rest = DummyREST(base="http://")
     client = _make_client(monkeypatch, rest=rest, hass_loop=asyncio.get_event_loop())
     with pytest.raises(RuntimeError):
@@ -1398,7 +1457,9 @@ def test_collect_update_addresses_extracts(monkeypatch: pytest.MonkeyPatch) -> N
     assert addresses == [("aux", "3"), ("htr", "1")]
 
 
-def test_collect_update_addresses_skips_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_collect_update_addresses_skips_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch)
     nodes = {"htr": [1, 2], 10: {"settings": {"1": {}}}}
     assert client._collect_update_addresses(nodes) == []
@@ -1426,7 +1487,9 @@ def test_apply_heater_addresses_updates_energy(monkeypatch: pytest.MonkeyPatch) 
         energy_coordinator.updated = mapping
 
     energy_coordinator.update_addresses = update_addresses  # type: ignore[attr-defined]
-    client.hass.data[module.DOMAIN]["entry"] = {"energy_coordinator": energy_coordinator}
+    client.hass.data[module.DOMAIN]["entry"] = {
+        "energy_coordinator": energy_coordinator
+    }
     initial_data = {"device": {"nodes_by_type": {}}}
     client._coordinator.data = initial_data
     result = client._apply_heater_addresses({"htr": [1, 2]})
@@ -1537,6 +1600,12 @@ def test_handle_handshake_logs_lease_scalars(
     monkeypatch.setattr(module.time, "time", lambda: 300.0)
     caplog.set_level(logging.DEBUG, logger=module._LOGGER.name)
 
+    class LeaseSentinel:
+        def __repr__(self) -> str:
+            return "LeaseSentinel"
+
+    long_value = "x" * 130
+
     payload = {
         "lease": {
             "ttl": 450,
@@ -1545,6 +1614,12 @@ def test_handle_handshake_logs_lease_scalars(
             "leaseFlag": True,
             "leaseLabel": "   ",
             "leaseCode": "invalid",
+            "leaseBytes": b"raw-bytes",
+            "leaseNone": None,
+            "leaseObject": LeaseSentinel(),
+            "leaseMultiline": "line1\nline2",
+            "leaseLong": long_value,
+            "leaseEmpty": "",
         },
         "meta": {"timeout": 120},
         "segments": [
@@ -1565,10 +1640,46 @@ def test_handle_handshake_logs_lease_scalars(
     message = log_messages[-1]
     assert "lease.ttl=450" in message
     assert "lease.leaseMs=450000" in message
+    assert "lease.leaseFlag=True" in message
+    assert "lease.leaseLabel=   " in message
+    assert "lease.leaseCode=invalid" in message
+    assert "lease.leaseBytes=raw-bytes" in message
+    assert "lease.leaseNone=None" in message
+    assert "lease.leaseObject=LeaseSentinel" in message
+    assert "lease.leaseMultiline=line1\\nline2" in message
+    assert f"lease.leaseLong={'x' * 119}…" in message
+    assert "lease.leaseEmpty=" in message
     assert "meta.timeout=120" in message
     assert "segments[0].leaseTtl=42" in message
     assert "segments[1].timeout=75" in message
     assert "secret-should-not-log" not in message
+
+
+def test_handle_handshake_logs_raw_lease_strings(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Confirm lease strings are logged without coercion."""
+
+    client = _make_client(monkeypatch)
+    refresh_loop = AsyncMock()
+    monkeypatch.setattr(client, "_subscription_refresh_loop", refresh_loop)
+    monkeypatch.setattr(module.time, "time", lambda: 400.0)
+    caplog.set_level(logging.DEBUG, logger=module._LOGGER.name)
+
+    payload = {"lease": {"ttl": "300", "leaseCode": "PT5M"}}
+
+    client._handle_handshake(payload)
+
+    log_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+        and "handshake lease hints" in record.getMessage()
+    ]
+    assert log_messages, "expected handshake lease hint log entry"
+    message = log_messages[-1]
+    assert "lease.ttl=300" in message
+    assert "lease.leaseCode=PT5M" in message
 
 
 def test_handle_handshake_uses_default_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1637,7 +1748,9 @@ async def test_subscription_refresh_loop_schedules_and_refreshes(
     client._closing = False
 
 
-def test_apply_heater_addresses_inventory_and_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_heater_addresses_inventory_and_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch)
     client.hass.data[module.DOMAIN]["entry"] = {}
     client._coordinator.data = {"device": {"nodes_by_type": {}}}
@@ -1646,7 +1759,9 @@ def test_apply_heater_addresses_inventory_and_empty(monkeypatch: pytest.MonkeyPa
     assert result == {"htr": []}
 
 
-def test_apply_heater_addresses_skips_empty_non_heater(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_heater_addresses_skips_empty_non_heater(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = _make_client(monkeypatch)
     client.hass.data[module.DOMAIN]["entry"] = {}
     client._coordinator.data = {"device": {"nodes_by_type": {}}}
@@ -1723,7 +1838,9 @@ def test_cancel_idle_restart_with_pending(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_ducaheat_client_extended_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_ducaheat_client_extended_logging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client = module.DucaheatWSClient(
         SimpleNamespace(loop=asyncio.get_event_loop(), data={}),
         entry_id="entry",
@@ -1825,7 +1942,9 @@ def test_heater_sample_subscription_targets(monkeypatch: pytest.MonkeyPatch) -> 
     client = _make_client(monkeypatch)
     entry = client.hass.data[module.DOMAIN]["entry"]
 
-    def fake_collect(record: Mapping[str, Any], *, coordinator: Any | None = None) -> Any:
+    def fake_collect(
+        record: Mapping[str, Any], *, coordinator: Any | None = None
+    ) -> Any:
         assert record is entry
         assert coordinator is client._coordinator
         return (
@@ -1866,6 +1985,7 @@ async def test_sample_subscription_handles_fallback_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _make_client(monkeypatch, hass_loop=asyncio.get_event_loop())
+
     def fake_collect(record: Any, *, coordinator: Any | None = None) -> Any:
         assert coordinator is client._coordinator
         try:
@@ -1952,5 +2072,3 @@ async def test_ducaheat_debug_logging(
     await client._on_dev_data({"nodes": {}})
     await client._on_update({"nodes": {}})
     assert caplog.text.count("ducaheat") >= 4
-
-


### PR DESCRIPTION
## Summary
- log raw handshake lease-related values with truncation so debugging always shows the original payloads
- extend websocket client handshake tests to cover numeric and non-numeric lease hints in the debug output

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dc32ce75308329830edd4d4f6eb05b