### PR TITLE
Add installation snapshot caching helpers

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -43,6 +43,7 @@ from .energy import (
     default_samples_rate_limit_state,
     reset_samples_rate_limit_state,
 )
+from .installation import InstallationSnapshot
 from .nodes import (
     HEATER_NODE_TYPES as _HEATER_NODE_TYPES,
     build_heater_address_map as _build_heater_address_map,
@@ -168,6 +169,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ).strip()
     nodes = await client.get_nodes(dev_id)
     node_inventory = build_node_inventory(nodes)
+    snapshot = InstallationSnapshot(
+        dev_id=dev_id,
+        raw_nodes=nodes,
+        node_inventory=node_inventory,
+    )
 
     if node_inventory:
         type_counts = Counter(node.type for node in node_inventory)
@@ -193,8 +199,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "client": backend.client,
         "coordinator": coordinator,
         "dev_id": dev_id,
-        "nodes": nodes,
-        "node_inventory": node_inventory,
+        "snapshot": snapshot,
+        "node_inventory": list(snapshot.inventory),
         "config_entry": entry,
         "base_poll_interval": max(base_interval, MIN_POLL_INTERVAL),
         "stretched": False,

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -1,0 +1,224 @@
+"""Helpers describing a TermoWeb installation snapshot."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from .nodes import (
+    Node,
+    build_heater_address_map,
+    build_node_inventory,
+    heater_sample_subscription_targets,
+    normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
+)
+
+
+class InstallationSnapshot:
+    """Cache metadata derived from node inventory for reuse."""
+
+    __slots__ = (
+        "_compat_aliases",
+        "_dev_id",
+        "_explicit_name_pairs",
+        "_heater_address_map",
+        "_heater_address_reverse",
+        "_inventory",
+        "_name_map_cache",
+        "_name_map_factories",
+        "_nodes_by_type",
+        "_raw_nodes",
+        "_sample_address_map",
+        "_sample_targets",
+    )
+
+    def __init__(
+        self,
+        *,
+        dev_id: str,
+        raw_nodes: Any,
+        node_inventory: Iterable[Node] | None = None,
+    ) -> None:
+        """Initialise the snapshot with backend payload metadata."""
+
+        self._dev_id = str(dev_id)
+        self._raw_nodes = raw_nodes
+        self._inventory = list(node_inventory) if node_inventory is not None else None
+        self._nodes_by_type: dict[str, list[Node]] | None = None
+        self._explicit_name_pairs: set[tuple[str, str]] | None = None
+        self._heater_address_map: dict[str, list[str]] | None = None
+        self._heater_address_reverse: dict[str, set[str]] | None = None
+        self._sample_address_map: dict[str, list[str]] | None = None
+        self._compat_aliases: dict[str, str] | None = None
+        self._sample_targets: list[tuple[str, str]] | None = None
+        self._name_map_cache: dict[int, dict[Any, Any]] = {}
+        self._name_map_factories: dict[int, Callable[[str], str]] = {}
+
+    @property
+    def dev_id(self) -> str:
+        """Return the backend device identifier for the snapshot."""
+
+        return self._dev_id
+
+    @property
+    def raw_nodes(self) -> Any:
+        """Return the raw nodes payload associated with the snapshot."""
+
+        return self._raw_nodes
+
+    def update_nodes(
+        self, raw_nodes: Any, *, node_inventory: Iterable[Node] | None = None
+    ) -> None:
+        """Update cached payload data and invalidate derived caches."""
+
+        self._raw_nodes = raw_nodes
+        self._inventory = list(node_inventory) if node_inventory is not None else None
+        self._invalidate_caches()
+
+    def _invalidate_caches(self) -> None:
+        """Reset derived cache state so it can be lazily recomputed."""
+
+        self._nodes_by_type = None
+        self._explicit_name_pairs = None
+        self._heater_address_map = None
+        self._heater_address_reverse = None
+        self._sample_address_map = None
+        self._compat_aliases = None
+        self._sample_targets = None
+        self._name_map_cache.clear()
+        self._name_map_factories.clear()
+
+    def _ensure_inventory(self) -> list[Node]:
+        """Return the cached node inventory, rebuilding if required."""
+
+        if self._inventory is None:
+            self._inventory = build_node_inventory(self._raw_nodes)
+        return self._inventory
+
+    @property
+    def inventory(self) -> list[Node]:
+        """Expose the normalised node inventory for the installation."""
+
+        return self._ensure_inventory()
+
+    def _ensure_nodes_by_type(self) -> None:
+        """Populate caches describing heater nodes by type."""
+
+        if self._nodes_by_type is not None:
+            return
+
+        nodes_by_type: dict[str, list[Node]] = defaultdict(list)
+        explicit_names: set[tuple[str, str]] = set()
+        for node in self._ensure_inventory():
+            node_type = normalize_node_type(getattr(node, "type", ""))
+            if not node_type:
+                continue
+            nodes_by_type[node_type].append(node)
+            addr = normalize_node_addr(getattr(node, "addr", ""))
+            if addr and getattr(node, "name", "").strip():
+                explicit_names.add((node_type, addr))
+
+        self._nodes_by_type = {k: list(v) for k, v in nodes_by_type.items()}
+        self._explicit_name_pairs = explicit_names
+
+    @property
+    def nodes_by_type(self) -> dict[str, list[Node]]:
+        """Return a mapping of node type to ``Node`` instances."""
+
+        self._ensure_nodes_by_type()
+        return dict(self._nodes_by_type or {})
+
+    @property
+    def explicit_heater_names(self) -> set[tuple[str, str]]:
+        """Return node type/address pairs with explicit names."""
+
+        self._ensure_nodes_by_type()
+        return set(self._explicit_name_pairs or set())
+
+    def _ensure_address_maps(self) -> None:
+        """Populate cached heater address maps from the inventory."""
+
+        if self._heater_address_map is not None:
+            return
+
+        forward, reverse = build_heater_address_map(self._ensure_inventory())
+        self._heater_address_map = {k: list(v) for k, v in forward.items()}
+        self._heater_address_reverse = {
+            addr: set(node_types) for addr, node_types in reverse.items()
+        }
+
+    @property
+    def heater_address_map(self) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+        """Return forward and reverse heater address maps."""
+
+        self._ensure_address_maps()
+        forward = {k: list(v) for k, v in (self._heater_address_map or {}).items()}
+        reverse = {
+            addr: set(types)
+            for addr, types in (self._heater_address_reverse or {}).items()
+        }
+        return forward, reverse
+
+    def _ensure_sample_addresses(self) -> None:
+        """Calculate canonical heater sample address data."""
+
+        if self._sample_address_map is not None:
+            return
+
+        forward, _ = self.heater_address_map
+        normalized_map, compat = normalize_heater_addresses(forward)
+        self._sample_address_map = {
+            node_type: list(addrs) for node_type, addrs in normalized_map.items()
+        }
+        self._compat_aliases = dict(compat)
+
+    @property
+    def heater_sample_address_map(self) -> tuple[dict[str, list[str]], dict[str, str]]:
+        """Return normalised heater addresses suitable for samples."""
+
+        self._ensure_sample_addresses()
+        return (
+            {k: list(v) for k, v in (self._sample_address_map or {}).items()},
+            dict(self._compat_aliases or {}),
+        )
+
+    @property
+    def heater_sample_targets(self) -> list[tuple[str, str]]:
+        """Return ordered ``(node_type, addr)`` sample subscription targets."""
+
+        if self._sample_targets is None:
+            normalized_map, _ = self.heater_sample_address_map
+            self._sample_targets = heater_sample_subscription_targets(normalized_map)
+        return list(self._sample_targets)
+
+    def heater_name_map(
+        self, default_factory: Callable[[str], str]
+    ) -> dict[Any, Any]:
+        """Return cached heater name mapping for ``default_factory``."""
+
+        key = id(default_factory)
+        cached = self._name_map_cache.get(key)
+        if cached is not None and self._name_map_factories.get(key) is default_factory:
+            return cached
+
+        from .heater import (  # noqa: PLC0415
+            build_heater_name_map as _build_heater_name_map,
+        )
+
+        mapping = _build_heater_name_map(self._ensure_inventory(), default_factory)
+        self._name_map_cache[key] = mapping
+        self._name_map_factories[key] = default_factory
+        return mapping
+
+
+def ensure_snapshot(record: Any) -> InstallationSnapshot | None:
+    """Return the installation snapshot stored in ``record`` when present."""
+
+    if isinstance(record, dict):
+        snapshot = record.get("snapshot")
+        if isinstance(snapshot, InstallationSnapshot):
+            return snapshot
+    return None

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -24,6 +24,7 @@ import socketio
 
 from .api import RESTClient
 from .const import API_BASE, DOMAIN, WS_NAMESPACE, signal_ws_data, signal_ws_status
+from .installation import InstallationSnapshot, ensure_snapshot
 from .nodes import (
     NODE_CLASS_BY_TYPE,
     addresses_by_node_type,
@@ -848,13 +849,20 @@ class WebSocketClient:
             snapshot = {"nodes": deepcopy(raw_nodes), "nodes_by_type": {}}
 
         record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
-        record_map: Mapping[str, Any]
-        if isinstance(record, Mapping):
-            record_map = record
+        snapshot_obj = ensure_snapshot(record)
+        if isinstance(snapshot_obj, InstallationSnapshot):
+            snapshot_obj.update_nodes(raw_nodes)
+            inventory = snapshot_obj.inventory
+            if isinstance(record, dict):
+                record["node_inventory"] = list(inventory)
         else:
-            record_map = {}  # pragma: no cover - defensive default
+            record_map: Mapping[str, Any]
+            if isinstance(record, Mapping):
+                record_map = record
+            else:
+                record_map = {}  # pragma: no cover - defensive default
 
-        inventory = ensure_node_inventory(record_map, nodes=raw_nodes)
+            inventory = ensure_node_inventory(record_map, nodes=raw_nodes)
 
         addr_map, unknown_types = addresses_by_node_type(
             inventory, known_types=NODE_CLASS_BY_TYPE
@@ -880,7 +888,7 @@ class WebSocketClient:
         if hasattr(self._coordinator, "update_nodes"):
             self._coordinator.update_nodes(raw_nodes, inventory)
 
-        if isinstance(record, dict):
+        if isinstance(record, dict) and snapshot_obj is None:
             record["nodes"] = raw_nodes
             record["node_inventory"] = inventory
 
@@ -951,10 +959,24 @@ class WebSocketClient:
 
         normalized_map, _compat_aliases = normalize_heater_addresses(addr_map)
         record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
-        if isinstance(record, dict):
+        snapshot_obj = ensure_snapshot(record)
+        if isinstance(snapshot_obj, InstallationSnapshot) and inventory is not None:
+            snapshot_obj.update_nodes(snapshot_obj.raw_nodes, node_inventory=inventory)
+            if isinstance(record, dict):
+                record["node_inventory"] = list(snapshot_obj.inventory)
+
+        if isinstance(record, dict) and snapshot_obj is None:
             if inventory is not None:
                 record["node_inventory"] = inventory
             energy_coordinator = record.get("energy_coordinator")
+            if hasattr(energy_coordinator, "update_addresses"):
+                energy_coordinator.update_addresses(normalized_map)
+        else:
+            energy_coordinator = (
+                record.get("energy_coordinator")
+                if isinstance(record, Mapping)
+                else None
+            )
             if hasattr(energy_coordinator, "update_addresses"):
                 energy_coordinator.update_addresses(normalized_map)
 


### PR DESCRIPTION
## Summary
- add an InstallationSnapshot helper that caches node inventory, address maps, and sample targets for reuse【F:custom_components/termoweb/installation.py†L1-L224】
- create and store the snapshot during setup, and update energy import logic to respect snapshot overrides while keeping node_inventory in sync【F:custom_components/termoweb/__init__.py†L166-L213】【F:custom_components/termoweb/energy.py†L914-L939】
- refactor heater, node, and websocket helpers to consume snapshot accessors and extend tests to ensure cached data is reused【F:custom_components/termoweb/heater.py†L280-L327】【F:custom_components/termoweb/nodes.py†L540-L597】【F:custom_components/termoweb/ws_client.py†L834-L1014】【F:tests/test_heater_base.py†L34-L220】【F:tests/test_nodes.py†L263-L292】

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68dc33e526e08329be48e3e685d3b64e