### PR TITLE
Allow configuring websocket namespace

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -519,6 +519,7 @@ class DucaheatBackend(Backend):
             api_client=self.client,
             coordinator=coordinator,
             protocol="engineio2",
+            namespace="/",
         )
 
 

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -64,6 +64,7 @@ def test_ducaheat_backend_creates_ws_client() -> None:
     assert ws_client.dev_id == "dev"
     assert ws_client.entry_id == "entry"
     assert ws_client._protocol_hint == "engineio2"
+    assert ws_client._namespace == "/"
 
 
 def test_dummy_client_get_node_settings_accepts_acm() -> None:


### PR DESCRIPTION
## Summary
- allow the shared websocket client to accept a configurable namespace and update handlers to use it
- construct the Ducaheat websocket client with the root namespace while keeping TermoWeb behaviour unchanged
- extend websocket tests to cover the namespace override and root namespace event handling

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dd877996108329bbbf585950c95eb0