### PR TITLE
Ensure snapshot paths are covered

### DIFF
--- a/tests/test_installation_snapshot.py
+++ b/tests/test_installation_snapshot.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+from types import SimpleNamespace
+
+from custom_components.termoweb.installation import InstallationSnapshot, ensure_snapshot
+from custom_components.termoweb.nodes import (
+    build_node_inventory,
+    heater_sample_subscription_targets,
+)
+
+
+def _make_snapshot(
+    nodes: list[dict[str, Any]],
+    *,
+    dev_id: str = "dev",
+    include_inventory: bool = True,
+) -> InstallationSnapshot:
+    """Return an installation snapshot preloaded with ``nodes`` payload."""
+
+    payload = {"nodes": nodes}
+    inventory = build_node_inventory(payload)
+    if include_inventory:
+        return InstallationSnapshot(dev_id=dev_id, raw_nodes=payload, node_inventory=inventory)
+    return InstallationSnapshot(dev_id=dev_id, raw_nodes=payload)
+
+
+def test_snapshot_properties_and_inventory_cache() -> None:
+    """Properties should expose cached metadata and computed inventory."""
+
+    nodes = [{"type": "HTR", "addr": "1", "name": "Heater"}]
+    snapshot = _make_snapshot(nodes)
+
+    assert snapshot.dev_id == "dev"
+    assert snapshot.raw_nodes == {"nodes": nodes}
+    assert [node.addr for node in snapshot.inventory] == ["1"]
+
+
+def test_snapshot_sample_targets_and_name_map_caching() -> None:
+    """Sample targets and name maps should reuse cached computations."""
+
+    nodes = [
+        {"type": "htr", "addr": "1", "name": ""},
+        {"type": "acm", "addr": "2", "name": None},
+    ]
+    snapshot = _make_snapshot(nodes, include_inventory=False)
+
+    targets_first = snapshot.heater_sample_targets
+    targets_second = snapshot.heater_sample_targets
+    expected_targets = heater_sample_subscription_targets(
+        snapshot.heater_sample_address_map[0]
+    )
+
+    assert targets_first == expected_targets
+    assert targets_second == expected_targets
+
+    def _factory(name: str) -> str:
+        return f"prefixed {name}"
+
+    first_map = snapshot.heater_name_map(_factory)
+    second_map = snapshot.heater_name_map(_factory)
+
+    assert first_map is second_map
+    assert "htr" in first_map
+    assert isinstance(first_map["htr"], dict)
+
+
+def test_snapshot_nodes_by_type_skips_unknown() -> None:
+    """Nodes without valid types should be ignored in type maps."""
+
+    snapshot = InstallationSnapshot(
+        dev_id="dev",
+        raw_nodes={"nodes": []},
+        node_inventory=[
+            SimpleNamespace(type="", addr="1", name=""),
+            SimpleNamespace(type="htr", addr="2", name=""),
+        ],
+    )
+    record = {"snapshot": snapshot}
+
+    assert ensure_snapshot(record) is snapshot
+
+    mapping = snapshot.nodes_by_type
+
+    assert "htr" in mapping
+    assert all(node.addr == "2" for node in mapping["htr"])

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 import pytest
 
 import custom_components.termoweb.ws_client as module
+from custom_components.termoweb.installation import InstallationSnapshot
 
 
 class DummyREST:
@@ -195,6 +196,63 @@ def test_ducaheat_client_uses_root_namespace(monkeypatch: pytest.MonkeyPatch) ->
     assert client._namespace == "/"
     assert ("dev_data", "/") in client._sio.events
     assert ("disconnect", "/") in client._sio.events
+
+
+def test_translate_path_update_parses_segments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Translate Ducaheat style path payloads into node updates."""
+
+    client = _make_ducaheat_client(monkeypatch)
+
+    assert client._translate_path_update(None) is None
+    assert client._translate_path_update({"nodes": {}}) is None
+
+    sample_payload = {
+        "path": "/devs/dev/htr/001/samples",
+        "body": {"energy": 1},
+    }
+    translated = client._translate_path_update(sample_payload)
+    assert translated == {"htr": {"samples": {"001": {"energy": 1}}}}
+
+    nested_payload = {
+        "path": "/htr/001/setup/limits/max",
+        "body": {"value": 10},
+    }
+    translated_nested = client._translate_path_update(nested_payload)
+    assert translated_nested == {
+        "001": {"settings": {"setup": {"limits": {"max": {"value": 10}}}}}
+    }
+
+
+def test_translate_path_update_edge_cases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Handle malformed path payloads in the translator."""
+
+    client = _make_ducaheat_client(monkeypatch)
+
+    assert client._translate_path_update({"path": "", "body": {}}) is None
+    assert client._translate_path_update({"path": "/foo", "body": {}}) is None
+    assert (
+        client._translate_path_update({"path": "/devs/dev/ /001/status", "body": {}})
+        is None
+    )
+    assert (
+        client._translate_path_update({"path": "/devs/dev/unknown/001", "body": {}})
+        is None
+    )
+    assert (
+        client._translate_path_update({"path": "/devs/dev/htr/001", "body": {}})
+        is None
+    )
+    assert (
+        client._translate_path_update({"path": "/devs/dev/htr/ /status", "body": {}})
+        is None
+    )
+
+    assert client._resolve_update_section(None) == (None, None)
+    assert client._resolve_update_section("advanced_setup") == (
+        "advanced",
+        "advanced_setup",
+    )
+    assert client._resolve_update_section("setup") == ("settings", "setup")
 
 
 def test_handshake_error_records_context() -> None:
@@ -1385,6 +1443,61 @@ def test_dispatch_nodes_handles_raw_payload(monkeypatch: pytest.MonkeyPatch) -> 
     assert "nodes" in record
     assert isinstance(client._coordinator.data, dict)
     assert updates and isinstance(updates[0], dict)
+
+
+def test_dispatch_nodes_updates_snapshot_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Snapshot records should be updated when new nodes payloads arrive."""
+
+    client = _make_client(monkeypatch)
+    base_nodes = {"nodes": [{"type": "htr", "addr": "1", "name": "Heater"}]}
+    snapshot = InstallationSnapshot(dev_id="device", raw_nodes=base_nodes)
+    energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
+    record = {"snapshot": snapshot, "energy_coordinator": energy_coordinator}
+    client.hass.data = {module.DOMAIN: {client.entry_id: record}}
+    client._coordinator.update_nodes = MagicMock()
+    client._coordinator.data = {client.dev_id: {}}
+
+    payload = {
+        "nodes": base_nodes,
+        "nodes_by_type": {"htr": {"addrs": ["1"], "settings": {"1": {}}, "advanced": {}, "samples": {}}},
+    }
+
+    addr_map = client._dispatch_nodes(payload)
+
+    assert addr_map["htr"] == ["1"]
+    assert "node_inventory" in record
+    assert energy_coordinator.update_addresses.call_count == 1
+    client._coordinator.update_nodes.assert_called_once()
+
+
+def test_heater_sample_subscription_targets_with_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Derive heater sample subscriptions from snapshot-backed records."""
+
+    client = _make_client(monkeypatch)
+    nodes_payload = {"nodes": [{"type": "htr", "addr": "1"}, {"type": "acm", "addr": "2"}]}
+    snapshot = InstallationSnapshot(dev_id="device", raw_nodes=nodes_payload)
+    energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
+    record = {"snapshot": snapshot, "energy_coordinator": energy_coordinator}
+    client.hass.data = {module.DOMAIN: {client.entry_id: record}}
+    client._coordinator.data = {client.dev_id: {}}
+
+    inventory = list(snapshot.inventory)
+
+    def fake_collect(record_data, *, coordinator=None):
+        return inventory, {"htr": ["1"], "acm": ["2"]}, {"htr": "htr"}
+
+    monkeypatch.setattr(module, "collect_heater_sample_addresses", fake_collect)
+
+    targets = client._heater_sample_subscription_targets()
+
+    assert targets
+    assert record["node_inventory"]
+    energy_coordinator.update_addresses.assert_called_once()
+    coordinator_data = client._coordinator.data[client.dev_id]
+    assert "nodes_by_type" in coordinator_data
+    assert coordinator_data["nodes_by_type"]["htr"]["addrs"]
 
 
 def test_schedule_and_cancel_idle_restart(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add installation snapshot tests to exercise cached inventory, address maps, and name maps
- reload snapshot classes in node tests so the snapshot address path is exercised under module reloads
- cover websocket translator edge cases and snapshot-driven update flows, and ensure the energy history service reuses snapshot inventories

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dd91887cec8329b84a98c6289faee5