### PR TITLE
Remove duplicate backend entry in hass data

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -204,7 +204,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "config_entry": entry,
         "base_poll_interval": max(base_interval, MIN_POLL_INTERVAL),
         "stretched": False,
-        "backend": backend,
         "ws_tasks": {},  # dev_id -> asyncio.Task
         "ws_clients": {},  # dev_id -> WS clients
         "ws_state": {},  # dev_id -> status attrs


### PR DESCRIPTION
## Summary
- remove the duplicate `"backend"` entry when storing TermoWeb integration state

## Testing
- `ruff check .` *(fails: existing lint violations in the repository)*
- `pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68de42856cb083298e27559c5caf9446