### PR TITLE
Update TermoWeb config flow branding text

### DIFF
--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Tevolve heaters",
-        "description": "Choose your heater brand and enter your account credentials.",
+        "title": "Connect to TermoWeb family heaters",
+        "description": "Choose your TermoWeb or Ducaheat brand and enter your account credentials.",
         "data": {
           "brand": "Brand",
           "username": "Email",

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -2,19 +2,19 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Tevolve heaters",
-        "description": "Version: {version}\n\nChoose your heater brand and enter your account credentials",
+        "title": "Connect to TermoWeb family heaters",
+        "description": "Version: {version}\n\nChoose your TermoWeb or Ducaheat brand and enter your account credentials.",
         "data": {
           "brand": "Brand",
           "username": "Email",
           "password": "Password",
-          "poll_interval": "Polling interval (seconds)"
+          "poll_interval": "Base poll interval (seconds)"
         }
       }
     },
     "error": {
       "invalid_auth": "Invalid username or password (or client key).",
-      "cannot_connect": "Cannot connect to Termoweb — network/DNS/SSL error.",
+      "cannot_connect": "Cannot connect to TermoWeb — network/DNS/SSL error.",
       "rate_limited": "Temporarily rate-limited by API. Try again later.",
       "unknown": "Unknown error"
     }
@@ -22,10 +22,10 @@
   "options": {
     "step": {
       "edit": {
-        "title": "Termoweb Options",
+        "title": "TermoWeb Options",
         "description": "Version: {version}",
         "data": {
-          "poll_interval": "Polling interval (seconds)"
+          "poll_interval": "Base poll interval (seconds)"
         }
       }
     }


### PR DESCRIPTION
## Summary
- update the config flow strings to reference the TermoWeb family instead of Tevolve
- align the English translations with the new branding and consistent poll interval labels

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68de456046988329990a8efb7e09ad9e