### PR TITLE
Improve TermoWeb card installer source detection

### DIFF
--- a/custom_components/termoweb/assets/install_termoweb_card.sh
+++ b/custom_components/termoweb/assets/install_termoweb_card.sh
@@ -11,17 +11,33 @@ CARD_NAME="termoweb_schedule_card.js"
 DEST_DIR="${CONFIG_DIR}/www/termoweb"
 DEST="${DEST_DIR}/${CARD_NAME}"
 
-SRC="${CONFIG_DIR}/custom_components/termoweb/www/${CARD_NAME}"
+SOURCES=(
+  "${CONFIG_DIR}/custom_components/termoweb/assets/${CARD_NAME}"
+  "${CONFIG_DIR}/custom_components/termoweb/www/${CARD_NAME}"
+  "${CONFIG_DIR}/custom_components/termoweb/${CARD_NAME}"
+)
 
 echo "[*] Using config dir: ${CONFIG_DIR}"
 mkdir -p "${DEST_DIR}"
 
-if [ -f "${SRC}" ]; then
-  cp -f "${SRC}" "${DEST}"
-  echo "[+] Copied ${SRC} -> ${DEST}"
+FOUND_SRC=""
+for CANDIDATE in "${SOURCES[@]}"; do
+  if [ -f "${CANDIDATE}" ]; then
+    FOUND_SRC="${CANDIDATE}"
+    break
+  fi
+done
+
+if [ -n "${FOUND_SRC}" ]; then
+  echo "[+] Found ${CARD_NAME} at ${FOUND_SRC}"
+  cp -f "${FOUND_SRC}" "${DEST}"
+  echo "[+] Copied ${FOUND_SRC} -> ${DEST}"
   echo "[i] Now add a Lovelace resource in the UI:"
   echo "    URL: /local/termoweb/${CARD_NAME}"
   echo "    Type: JavaScript Module"
 else
-  echo "[!] Could not find ${CARD_NAME} in ${SRC}"
+  echo "[!] Could not find ${CARD_NAME} in any known location. Checked:"
+  for CANDIDATE in "${SOURCES[@]}"; do
+    echo "    - ${CANDIDATE}"
+  done
 fi


### PR DESCRIPTION
## Summary
- update the TermoWeb card install script to prioritize the bundled assets copy before legacy www locations
- add logging that reports which source path was used or that no card file was found

## Testing
- bash custom_components/termoweb/assets/install_termoweb_card.sh /tmp/ha_config
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68de454e37c48329ac1fb7002d3c8d0a