### PR TITLE
Align Ducaheat websocket client connect parameters

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -1908,7 +1908,15 @@ class DucaheatWSClient(WebSocketClient):
 
         self._disconnected.clear()
         self._backoff_idx = 0
-        await self._sio.connect(url, transports=["websocket"])
+        engineio_path = "socket.io"
+        await self._sio.connect(
+            url,
+            transports=["websocket"],
+            namespaces=[self._namespace],
+            socketio_path=engineio_path,
+            wait=True,
+            wait_timeout=15,
+        )
         self._log_connect_response()
 
     def _redact_value(self, value: str) -> str:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1741,6 +1741,10 @@ async def test_ducaheat_connect_matches_reference(monkeypatch: pytest.MonkeyPatc
     connect_mock.assert_awaited_once_with(
         "https://api-tevolve.termoweb.net/api/v2/socket_io?token=abc&dev_id=device",
         transports=["websocket"],
+        namespaces=["/"],
+        socketio_path="socket.io",
+        wait=True,
+        wait_timeout=15,
     )
 
 


### PR DESCRIPTION
## Summary
- update the Ducaheat websocket client to pass the same connect options as the base implementation
- refresh the websocket client unit test to assert the expanded connect signature

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68df8c9d73b883298d3a145a26a8bc76