### PR TITLE
Use API namespace for Ducaheat websocket

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -1834,7 +1834,7 @@ class DucaheatWSClient(WebSocketClient):
         session: aiohttp.ClientSession | None = None,
         handshake_fail_threshold: int = 5,
         protocol: str | None = None,
-        namespace: str = "/",
+        namespace: str = WS_NAMESPACE,
     ) -> None:
         """Initialise the websocket client with extended debug logging."""
 


### PR DESCRIPTION
## Summary
- update the Ducaheat websocket client to use the API v2 namespace by default
- align websocket client tests with the API namespace while keeping explicit coverage for the legacy root namespace

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dfb6985d008329b10ac53dc13efa4d