### PR TITLE
Fix Ducaheat websocket namespace

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 from ..api import RESTClient
-from ..const import BRAND_DUCAHEAT
+from ..const import BRAND_DUCAHEAT, WS_NAMESPACE
 from ..nodes import NodeDescriptor
 from ..ws_client import DucaheatWSClient
 from .base import Backend, WsClientProto
@@ -519,7 +519,7 @@ class DucaheatBackend(Backend):
             api_client=self.client,
             coordinator=coordinator,
             protocol="engineio2",
-            namespace="/",
+            namespace=WS_NAMESPACE,
         )
 
 

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from custom_components.termoweb.api import RESTClient
 from custom_components.termoweb.backend.ducaheat import DucaheatBackend, DucaheatRESTClient
+from custom_components.termoweb.const import WS_NAMESPACE
 from custom_components.termoweb.ws_client import DucaheatWSClient, WebSocketClient
 
 
@@ -64,7 +65,7 @@ def test_ducaheat_backend_creates_ws_client() -> None:
     assert ws_client.dev_id == "dev"
     assert ws_client.entry_id == "entry"
     assert ws_client._protocol_hint == "engineio2"
-    assert ws_client._namespace == "/"
+    assert ws_client._namespace == WS_NAMESPACE
 
 
 def test_dummy_client_get_node_settings_accepts_acm() -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -15,7 +15,7 @@ from custom_components.termoweb.backend import (  # noqa: E402
     TermoWebBackend,
     create_backend,
 )
-from custom_components.termoweb.const import BRAND_DUCAHEAT  # noqa: E402
+from custom_components.termoweb.const import BRAND_DUCAHEAT, WS_NAMESPACE  # noqa: E402
 from custom_components.termoweb.ws_client import (  # noqa: E402
     DucaheatWSClient,
     TermoWebWSClient,
@@ -75,6 +75,7 @@ def test_backend_factory_returns_expected_clients() -> None:
         assert isinstance(ws_client, WebSocketClient)
         assert isinstance(ws_client, DucaheatWSClient)
         assert ws_client._protocol_hint == "engineio2"
+        assert ws_client._namespace == WS_NAMESPACE
         loop.run_until_complete(ws_client.stop())
     finally:
         loop.close()


### PR DESCRIPTION
## Summary
- update the Ducaheat backend to create websocket clients with the API v2 namespace
- extend backend tests to assert the websocket namespace selection

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dfc076de0083299ad6495737ac4bcd