### PR TITLE
Handle namespace connect events separately

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -121,6 +121,9 @@ class WebSocketClient:
         self._sio.on("error", handler=self._on_error)
         self._sio.on("reconnect_failed", handler=self._on_reconnect_failed)
         self._sio.on(
+            "connect", namespace=self._namespace, handler=self._on_namespace_connect
+        )
+        self._sio.on(
             "disconnect",
             namespace=self._namespace,
             handler=self._on_namespace_disconnect,
@@ -368,6 +371,10 @@ class WebSocketClient:
         if self._idle_monitor_task is None or self._idle_monitor_task.done():
             self._idle_monitor_task = self._loop.create_task(self._idle_monitor())
         self._register_debug_catch_all()
+
+    async def _on_namespace_connect(self) -> None:
+        """Join the namespace and request the initial snapshot."""
+
         try:
             if self._namespace != "/":
                 await self._sio.emit("join", namespace=self._namespace)


### PR DESCRIPTION
## Summary
- register a namespace-specific connect handler so the socket client only joins once the namespace handshake completes
- move the join/dev_data emission logic into a dedicated `_on_namespace_connect` helper
- update websocket client tests to validate the new handler sequencing and ensure the root connect hook no longer emits

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e039df5bfc83298c4136dd8b2d3b22