### PR TITLE
Align Ducaheat websocket path documentation and tests

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -1936,6 +1936,12 @@ class DucaheatWSClient(WebSocketClient):
         url = f"{base_url}/socket.io?{query}"
         return url, "socket.io"
 
+    async def ws_url(self) -> str:
+        """Return the websocket URL for diagnostics."""
+
+        url, _ = await self._build_engineio_target()
+        return url
+
     def _redact_value(self, value: str) -> str:
         """Return a redacted representation of sensitive values."""
 

--- a/docs/ducaheat_api.md
+++ b/docs/ducaheat_api.md
@@ -170,7 +170,8 @@ connectivity drops.
 
 ## WebSocket (Socket.IO)
 
-**Path:** `/api/v2/socket_io?token=<access_token>` (handshake may be redirected to a session identifier URL fragment).
+**Path:** `/socket.io?token=<access_token>&dev_id=<dev_id>` (handshake may be redirected to a session identifier URL fragment).
+**Namespace:** `/` (default).
 
 The app listens for at least these events:
 - `dev_handshake` — initial device list / permissions (not observed in this capture but present in prior reverse engineering).

--- a/docs/ducaheat_openapi.yaml
+++ b/docs/ducaheat_openapi.yaml
@@ -10,7 +10,7 @@ info:
     Key differences vs TermoWeb:
       - No consolidated `/settings` resource for heaters.
       - Writes are segmented: `/status`, `/mode`, `/prog`, `/prog_temps`, `/setup`, `/lock`, `/select`.
-      - Socket path differs: `/api/v2/socket_io?token=...`.
+      - Socket path differs: `/socket.io?token=...&dev_id=...`.
 
     Base host: https://api-tevolve.termoweb.net
 servers:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -15,7 +15,7 @@ from custom_components.termoweb.backend import (  # noqa: E402
     TermoWebBackend,
     create_backend,
 )
-from custom_components.termoweb.const import BRAND_DUCAHEAT, WS_NAMESPACE  # noqa: E402
+from custom_components.termoweb.const import BRAND_DUCAHEAT  # noqa: E402
 from custom_components.termoweb.ws_client import (  # noqa: E402
     DucaheatWSClient,
     TermoWebWSClient,
@@ -75,7 +75,7 @@ def test_backend_factory_returns_expected_clients() -> None:
         assert isinstance(ws_client, WebSocketClient)
         assert isinstance(ws_client, DucaheatWSClient)
         assert ws_client._protocol_hint == "engineio2"
-        assert ws_client._namespace == WS_NAMESPACE
+        assert ws_client._namespace == "/"
         loop.run_until_complete(ws_client.stop())
     finally:
         loop.close()


### PR DESCRIPTION
## Summary
- document the Ducaheat Socket.IO endpoint as `/socket.io` with the default `/` namespace
- adjust websocket client helpers and tests to expect the updated path and headers
- ensure the backend factory test accepts the `/` namespace for Ducaheat

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e2388296dc83299692476cdc7d32ee