### PR TITLE
Fix Ducaheat path translation

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -636,19 +636,30 @@ class WebSocketClient:
 
         if devs_idx >= 0:
             relevant = segments[devs_idx + 1 :]
+            node_type_idx = 1
+            addr_idx = 2
+            section_idx = 3
+            if len(relevant) <= addr_idx:
+                return None
         else:
             relevant = segments
+            node_type_idx = 0
+            addr_idx = 1
+            section_idx = 2
+            if len(relevant) <= addr_idx:
+                return None
 
-        if len(relevant) < 3:
-            return None
-
-        node_type = normalize_node_type(relevant[1])
-        addr = normalize_node_addr(relevant[2])
+        node_type = normalize_node_type(relevant[node_type_idx])
+        addr = normalize_node_addr(relevant[addr_idx])
         if not node_type or not addr:
             return None
 
-        section = relevant[3] if len(relevant) >= 4 else None
-        remainder = relevant[4:] if len(relevant) >= 5 else []
+        section = relevant[section_idx] if len(relevant) > section_idx else None
+        remainder = (
+            relevant[section_idx + 1 :]
+            if len(relevant) > section_idx + 1
+            else []
+        )
 
         target_section, nested_key = self._resolve_update_section(section)
         if target_section is None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -222,8 +222,19 @@ def test_translate_path_update_parses_segments(monkeypatch: pytest.MonkeyPatch) 
     }
     translated_nested = client._translate_path_update(nested_payload)
     assert translated_nested == {
-        "001": {"settings": {"setup": {"limits": {"max": {"value": 10}}}}}
+        "htr": {
+            "settings": {
+                "001": {"setup": {"limits": {"max": {"value": 10}}}}
+            }
+        }
     }
+
+    status_payload = {
+        "path": "/acm/2/status",
+        "body": {"state": "ok"},
+    }
+    translated_status = client._translate_path_update(status_payload)
+    assert translated_status == {"acm": {"status": {"2": {"state": "ok"}}}}
 
 
 def test_translate_path_update_edge_cases(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- update the websocket path translator to detect both /devs/... and direct node paths while preserving normalised node metadata keys
- adjust websocket client tests to cover the corrected path handling and add a direct status payload scenario

## Testing
- pytest tests/test_ws_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e238728f2883299b19336930a31086