### PR TITLE
Fix Socket.IO connection path

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -244,11 +244,9 @@ class WebSocketClient:
 
     async def ws_url(self) -> str:
         """Return the websocket URL using the API client's token helper."""
-        token = await self._get_token()
-        base = self._api_base().rstrip("/")
-        if not base.endswith("/api/v2"):
-            base = f"{base}/api/v2"
-        return f"{base}/socket_io?token={token}&dev_id={self.dev_id}"
+
+        url, _ = await self._build_engineio_target()
+        return url
 
     async def debug_probe(self) -> None:
         """Emit a dev_data probe for debugging purposes."""
@@ -369,14 +367,9 @@ class WebSocketClient:
         netloc = parsed.netloc or parsed.path
         if not netloc:
             raise RuntimeError("invalid API base")
-        path = parsed.path.rstrip("/")
-        if not path.endswith("/api/v2"):
-            path = f"{path}/api/v2" if path else "/api/v2"
-        socket_path = f"{path}/socket_io"
-        engineio_path = socket_path.strip("/")
         query = urlencode({"token": token, "dev_id": self.dev_id})
-        url = urlunsplit((scheme, netloc, socket_path, query, ""))
-        return url, engineio_path
+        url = urlunsplit((scheme, netloc, "/socket.io", query, ""))
+        return url, "socket.io"
 
     # ------------------------------------------------------------------
     # Socket.IO event handlers


### PR DESCRIPTION
## Summary
- build the Engine.IO URL for TermoWeb sockets at the host-level /socket.io endpoint
- reuse the Engine.IO builder for diagnostics so both URLs stay aligned

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e2433e6a048329b8838637072ee587