### PR TITLE
Reduce websocket lease refresh idle window

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -166,7 +166,7 @@ class WebSocketClient:
         self._nodes: dict[str, Any] = {}
         self._nodes_raw: dict[str, Any] = {}
 
-        self._payload_idle_window: float = 3600.0
+        self._payload_idle_window: float = 240.0
         self._idle_restart_task: asyncio.Task | None = None
         self._idle_restart_pending = False
         self._idle_monitor_task: asyncio.Task | None = None
@@ -1182,7 +1182,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
         self._nodes: dict[str, Any] = {}
         self._nodes_raw: dict[str, Any] = {}
 
-        self._payload_idle_window: float = 3600.0
+        self._payload_idle_window: float = 240.0
         self._idle_restart_task: asyncio.Task | None = None
         self._idle_restart_pending = False
         self._idle_monitor_task: asyncio.Task | None = None


### PR DESCRIPTION
## Summary
- lower the websocket payload idle window to 240 seconds so legacy and modern clients refresh their leases sooner

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e2456faa148329ae6b2990a51f215e