### PR TITLE
Add RTC keep-alive polling for TermoWeb websocket

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -322,6 +322,21 @@ class RESTClient:
         )
         return data
 
+    async def get_rtc_time(self, dev_id: str) -> dict[str, Any]:
+        """Return RTC metadata for a device's manager endpoint."""
+
+        headers = await self._authed_headers()
+        path = f"/api/v2/devs/{dev_id}/mgr/rtc/time"
+        data = await self._request("GET", path, headers=headers)
+        if isinstance(data, dict):
+            return data
+        _LOGGER.debug(
+            "Unexpected RTC time payload for dev %s (%s); returning empty dict",
+            dev_id,
+            type(data).__name__,
+        )
+        return {}
+
     def _ensure_temperature(self, value: Any) -> str:
         """Normalise a numeric temperature to a string with one decimal."""
 


### PR DESCRIPTION
## Summary
- add RESTClient.get_rtc_time to fetch manager RTC metadata
- poll the RTC endpoint from the TermoWeb websocket client every 30 seconds to keep sessions alive
- add unit tests covering the REST call and keep-alive loop behaviour

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e24588aaa0832982f8e0ae6f1eb767