### PR TITLE
fix(ducaheat): align namespace and sanitize websocket logs

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 from ..api import RESTClient
-from ..const import BRAND_DUCAHEAT
+from ..const import BRAND_DUCAHEAT, WS_NAMESPACE
 from ..nodes import NodeDescriptor
 from ..ws_client import DucaheatWSClient
 from .base import Backend, WsClientProto
@@ -518,8 +518,7 @@ class DucaheatBackend(Backend):
             dev_id=dev_id,
             api_client=self.client,
             coordinator=coordinator,
-            protocol="engineio2",
-            namespace="/",
+            namespace=WS_NAMESPACE,
         )
 
 

--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -1358,7 +1358,9 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
                     self._hs_fail_count = 0
                     self._hs_fail_start = 0.0
                 _LOGGER.debug(
-                    "WS: handshake error url=%s body=%r", err.url, err.body_snippet
+                    "WS: handshake error url=%s body=%r",
+                    self._sanitise_url(err.url),
+                    err.body_snippet,
                 )
             except Exception as err:  # noqa: BLE001
                 _LOGGER.info(
@@ -1432,7 +1434,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
             f"{self._socket_base()}/socket.io/1/websocket/{sid}"
             f"?token={token}&dev_id={self.dev_id}"
         )
-        _LOGGER.info("WS: connecting to %s", ws_url)
+        _LOGGER.info("WS: connecting to %s", self._sanitise_url(ws_url))
         self._ws = await self._session.ws_connect(
             ws_url,
             timeout=aiohttp.ClientTimeout(total=15),
@@ -2013,6 +2015,20 @@ class DucaheatWSClient(WebSocketClient):
             return f"{trimmed[:2]}***{trimmed[-2:]}"
         return f"{trimmed[:4]}...{trimmed[-4:]}"
 
+    def _mask_identifier(self, value: str) -> str:
+        """Return a partially masked identifier for log output."""
+
+        trimmed = value.strip()
+        if not trimmed:
+            return ""
+        if len(trimmed) <= 4:
+            return "***"
+        if len(trimmed) <= 8:
+            return f"{trimmed[:2]}...{trimmed[-2:]}"
+        prefix = trimmed[:6]
+        suffix = trimmed[-4:]
+        return f"{prefix}...{suffix}"
+
     def _sanitise_headers(self, headers: Mapping[str, Any]) -> dict[str, Any]:
         """Redact sensitive header values for logging."""
 
@@ -2039,7 +2055,12 @@ class DucaheatWSClient(WebSocketClient):
 
         sanitised: dict[str, str] = {}
         for key, value in params.items():
-            sanitised[key] = self._redact_value(value) if key == "token" else value
+            if key == "token":
+                sanitised[key] = self._redact_value(str(value))
+            elif key == "dev_id":
+                sanitised[key] = self._mask_identifier(str(value))
+            else:
+                sanitised[key] = value
         return sanitised
 
     def _sanitise_url(self, url: str) -> str:
@@ -2051,7 +2072,14 @@ class DucaheatWSClient(WebSocketClient):
             return url
         query_items = parse_qsl(parsed.query, keep_blank_values=True)
         sanitised_pairs = [
-            (key, self._redact_value(value) if key == "token" else value)
+            (
+                key,
+                self._redact_value(value)
+                if key == "token"
+                else self._mask_identifier(value)
+                if key == "dev_id"
+                else value,
+            )
             for key, value in query_items
         ]
         sanitised_query = urlencode(sanitised_pairs, doseq=True)

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from custom_components.termoweb.api import RESTClient
 from custom_components.termoweb.backend.ducaheat import DucaheatBackend, DucaheatRESTClient
+from custom_components.termoweb.const import WS_NAMESPACE
 from custom_components.termoweb.ws_client import DucaheatWSClient, WebSocketClient
 
 
@@ -63,8 +64,8 @@ def test_ducaheat_backend_creates_ws_client() -> None:
     assert isinstance(ws_client, DucaheatWSClient)
     assert ws_client.dev_id == "dev"
     assert ws_client.entry_id == "entry"
-    assert ws_client._protocol_hint == "engineio2"
-    assert ws_client._namespace == "/"
+    assert ws_client._protocol_hint is None
+    assert ws_client._namespace == WS_NAMESPACE
 
 
 def test_dummy_client_get_node_settings_accepts_acm() -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -15,7 +15,7 @@ from custom_components.termoweb.backend import (  # noqa: E402
     TermoWebBackend,
     create_backend,
 )
-from custom_components.termoweb.const import BRAND_DUCAHEAT  # noqa: E402
+from custom_components.termoweb.const import BRAND_DUCAHEAT, WS_NAMESPACE  # noqa: E402
 from custom_components.termoweb.ws_client import (  # noqa: E402
     DucaheatWSClient,
     TermoWebWSClient,
@@ -74,8 +74,8 @@ def test_backend_factory_returns_expected_clients() -> None:
         )
         assert isinstance(ws_client, WebSocketClient)
         assert isinstance(ws_client, DucaheatWSClient)
-        assert ws_client._protocol_hint == "engineio2"
-        assert ws_client._namespace == "/"
+        assert ws_client._protocol_hint is None
+        assert ws_client._namespace == WS_NAMESPACE
         loop.run_until_complete(ws_client.stop())
     finally:
         loop.close()

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -2216,7 +2216,7 @@ def test_ducaheat_helper_sanitisation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     params = client._sanitise_params({"token": "secret", "dev_id": "device"})
     assert params["token"] != "secret"
-    assert params["dev_id"] == "device"
+    assert params["dev_id"] == "de...ce"
 
     headers_no_token = client._sanitise_headers({"Authorization": "Bearer"})
     assert headers_no_token["Authorization"].startswith("Be")


### PR DESCRIPTION
## Summary
- point the Ducaheat backend websocket client at the `/api/v2/socket_io` namespace without forcing an Engine.IO protocol hint
- redact tokens and mask device identifiers in websocket connection logs
- refresh the backend and websocket client tests to match the new namespace and sanitisation expectations

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e24671662c8329976f23dd65b7d45c