### PR TITLE
Confirmed backend protocol for both Ducaheat and TermoWeb

### DIFF
--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -40,6 +40,24 @@ BRAND_BASIC_AUTH: Final[Mapping[str, str]] = {
     BRAND_DUCAHEAT: "NWM0OWRjZTk3NzUxMDM1MTUwNmM0MmRiOnRldm9sdmU=",
 }
 
+# UA / locale (matches app loosely; helps avoid quirky WAF rules)
+USER_AGENT: Final = "TermoWeb/2.5.1 (Android; HomeAssistant Integration)"
+DUCAHEAT_USER_AGENT: Final = "Ducaheat/1.40.1 (Android; HomeAssistant Integration)"
+
+TERMOWEB_REQUESTED_WITH: Final = "com.casple.termoweb.v2"
+DUCAHEAT_REQUESTED_WITH: Final = "net.termoweb.ducaheat.app"
+ACCEPT_LANGUAGE: Final = "en-US,en;q=0.8"
+
+BRAND_USER_AGENTS: Final[Mapping[str, str]] = {
+    BRAND_TERMOWEB: USER_AGENT,
+    BRAND_DUCAHEAT: DUCAHEAT_USER_AGENT,
+}
+
+BRAND_REQUESTED_WITH: Final[Mapping[str, str]] = {
+    BRAND_TERMOWEB: TERMOWEB_REQUESTED_WITH,
+    BRAND_DUCAHEAT: DUCAHEAT_REQUESTED_WITH,
+}
+
 
 def get_brand_api_base(brand: str) -> str:
     """Return API base URL for the selected brand."""
@@ -61,18 +79,17 @@ def get_brand_label(brand: str) -> str:
 
     return BRAND_LABELS.get(brand, BRAND_LABELS[BRAND_TERMOWEB])
 
-# Polling
-DEFAULT_POLL_INTERVAL: Final = 120  # seconds
-MIN_POLL_INTERVAL: Final = 30  # seconds
-MAX_POLL_INTERVAL: Final = 3600  # seconds
-STRETCHED_POLL_INTERVAL: Final = 2700  # seconds (45 minutes) when WS healthy ≥5m
 
-# Heater energy polling interval when relying on push updates
-HTR_ENERGY_UPDATE_INTERVAL: Final = timedelta(hours=1)
+def get_brand_user_agent(brand: str) -> str:
+    """Return the preferred User-Agent string for the brand."""
 
-# UA / locale (matches app loosely; helps avoid quirky WAF rules)
-USER_AGENT: Final = "TermoWeb/2.5.1 (Android; HomeAssistant Integration)"
-ACCEPT_LANGUAGE: Final = "en-US,en;q=0.8"
+    return BRAND_USER_AGENTS.get(brand, USER_AGENT)
+
+
+def get_brand_requested_with(brand: str) -> str | None:
+    """Return the X-Requested-With header value for the brand."""
+
+    return BRAND_REQUESTED_WITH.get(brand)
 
 # Socket.IO namespace used by the websocket client implementation
 WS_NAMESPACE: Final = "/api/v2/socket_io"
@@ -82,9 +99,21 @@ WS_NAMESPACE: Final = "/api/v2/socket_io"
 
 def signal_ws_data(entry_id: str) -> str:
     """Signal name for WS ‘data’ frames dispatched to platforms."""
+
     return f"{DOMAIN}_{entry_id}_ws_data"
 
 
 def signal_ws_status(entry_id: str) -> str:
     """Signal name for WS status/health updates."""
+
     return f"{DOMAIN}_{entry_id}_ws_status"
+
+# Polling
+DEFAULT_POLL_INTERVAL: Final = 120  # seconds
+MIN_POLL_INTERVAL: Final = 30  # seconds
+MAX_POLL_INTERVAL: Final = 3600  # seconds
+STRETCHED_POLL_INTERVAL: Final = 2700  # seconds (45 minutes) when WS healthy ≥5m
+
+# Heater energy polling interval when relying on push updates
+HTR_ENERGY_UPDATE_INTERVAL: Final = timedelta(hours=1)
+

--- a/docs/ducaheat_api.md
+++ b/docs/ducaheat_api.md
@@ -171,13 +171,15 @@ connectivity drops.
 ## WebSocket (Socket.IO)
 
 **Path:** `/socket.io?token=<access_token>&dev_id=<dev_id>` (handshake may be redirected to a session identifier URL fragment).
-**Namespace:** `/` (default).
+**Namespace:** `/api/v2/socket_io`.
 
 The app listens for at least these events:
 - `dev_handshake` — initial device list / permissions (not observed in this capture but present in prior reverse engineering).
 - `dev_data` — full gateway snapshot (see above).
 - `update` — incremental node changes. The payload contains `path` (e.g., `/acm/2/status`) and `body` matching the corresponding
   REST resource. Clients should route updates by node type and address using the `path` components.
+- App heartbeat: the backend emits `"message"` events with payload `"ping"`. Reply with `"pong"` to avoid the server pausing
+  updates after a few minutes.
 
 ---
 
@@ -210,6 +212,7 @@ curl -sS -H "Authorization: Bearer $TOK" -H "Content-Type: application/json"   -
 
 ## Notes and caveats
 
+- REST and websocket calls include `User-Agent: Ducaheat/...` plus `X-Requested-With: net.termoweb.ducaheat.app` (and `Origin: https://localhost` for Socket.IO) to match the Android hybrid app environment.
 - Treat unknown keys as forward‑compatible; the app is tolerant of additional fields.
 - Program payload (`/prog`) structure varies by model/firmware. Capture the GET shape first and write it back unchanged after edits.
 - Some deployments may accept `/htr/{addr}/boost` as a synonym for boosting, but `/status` with `{ "boost": true }` is consistently present in the app bundle.

--- a/docs/termoweb_api.md
+++ b/docs/termoweb_api.md
@@ -152,11 +152,13 @@ Observed cadence for `htr`: ~3600 s.
 GET /socket.io/1/?token=<Bearer>&dev_id=<dev_id>&t=<ms>
 → "<sid>:60:60:websocket,xhr-polling"
 ```
+- **Headers**: include `Origin: https://localhost` alongside the mobile app UA.
 
 ### WebSocket URL
 ```
 wss://control.termoweb.net/socket.io/1/websocket/<sid>?token=...&dev_id=...
 ```
+- **Headers**: reuse `Origin: https://localhost` when opening the websocket.
 
 ### Namespace & heartbeats
 - Join: `1::/api/v2/socket_io`
@@ -171,6 +173,7 @@ Observed paths in pushes: `/htr/<addr>/settings`, `/htr/<addr>/advanced_setup`, 
 ---
 
 ### Notes / gotchas
+- Mobile apps send `User-Agent: TermoWeb/...` together with `X-Requested-With: com.casple.termoweb.v2` on REST and websocket calls; mirror these headers to avoid WAF oddities.
 - Always send temperatures as strings with one decimal (e.g. `"20.0"`), otherwise some backends return `400`.
 - POST `/htr/*/settings` returns **201** `{}` and echoes via WebSocket shortly after; do a timed fallback poll if needed.
 - Schedules: 168‑element `prog` array with values `{0,1,2}` mapping to presets `[cold, night, day]` in `ptemp`.


### PR DESCRIPTION
## Summary
- seed the legacy TermoWeb websocket client with brand headers and force the https://localhost origin during the Socket.IO handshake and upgrade
- connect the Ducaheat client on the API namespace, reply to the mobile app's message ping heartbeat, and extend the websocket tests to cover the new contract
- document the required origins/heartbeats for both backends and add regression tests for the TermoWeb origin handling

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/ws_client.py tests/test_ws_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e24e2011ac832989d55fea8d8c56d5