### PR TITLE
Implement segmented ACM writes for Ducaheat

### DIFF
--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -144,7 +144,7 @@ def test_ducaheat_rest_client_normalises_acm(monkeypatch) -> None:
     asyncio.run(_run())
 
 
-def test_ducaheat_rest_set_node_settings_routes_non_htr(monkeypatch) -> None:
+def test_ducaheat_rest_set_node_settings_routes_non_special(monkeypatch) -> None:
     async def _run() -> None:
         session = SimpleNamespace()
         client = DucaheatRESTClient(session, "user", "pass")
@@ -159,7 +159,7 @@ def test_ducaheat_rest_set_node_settings_routes_non_htr(monkeypatch) -> None:
 
         result = await client.set_node_settings(
             "dev",
-            ("acm", "4"),
+            ("pmo", "4"),
             mode="auto",
             stemp=20.5,
         )
@@ -167,7 +167,7 @@ def test_ducaheat_rest_set_node_settings_routes_non_htr(monkeypatch) -> None:
         assert result == {"ok": True}
         assert captured["args"] == (
             "dev",
-            ("acm", "4"),
+            ("pmo", "4"),
             {"mode": "auto", "stemp": 20.5, "prog": None, "ptemp": None, "units": "C"},
         )
 


### PR DESCRIPTION
## Summary
- replace accumulator writes with segmented /mode, /status, /prog, and /prog_temps calls using dedicated helpers
- add DucaheatRequestError and formatting utilities to ensure correct temperature/unit payloads
- expand test coverage for accumulator writes and update backend routing tests

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e2610b11a0832985e9fcdf44299a56