### PR TITLE
Handle Home Assistant stop events cleanly

### DIFF
--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -1979,9 +1979,11 @@ def test_setup_defers_import_until_started(monkeypatch: pytest.MonkeyPatch) -> N
         assert await mod.async_setup_entry(hass, entry) is True
         import_mock.assert_not_called()
 
-        assert len(listeners) == 1
-        event, cb = listeners[0]
-        assert event == mod.EVENT_HOMEASSISTANT_STARTED
+        start_listeners = [
+            cb for event, cb in listeners if event == mod.EVENT_HOMEASSISTANT_STARTED
+        ]
+        assert len(start_listeners) == 1
+        cb = start_listeners[0]
 
         hass.async_create_task(cb(None))
         if tasks:


### PR DESCRIPTION
## Summary
- add a dedicated shutdown helper and Home Assistant stop listener so websocket tasks and clients close gracefully
- provide a fallback for EVENT_HOMEASSISTANT_STOP and tidy auxiliary helpers to avoid unnecessary dict key iteration
- extend the Home Assistant stubs and tests to cover stop handling and multiple startup listeners

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e2614d5b70832988566c424b132f4e