### PR TITLE
Document Ducaheat accumulator write semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Run tests with coverage:
 uv run pytest --cov=custom_components/termoweb --cov-report=term-missing
 ```
 
+See [`docs/developer-notes.md`](docs/developer-notes.md) for backend write semantics and other
+implementation details for contributors.
+
 ---
 
 ## Search keywords

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -1,0 +1,19 @@
+# Developer notes
+
+## Ducaheat accumulator write semantics
+
+Ducaheat accumulators (and heaters served by the same backend) do not expose a monolithic
+`/acm/.../settings` endpoint. The mobile apps persist state by issuing targeted POSTs to the
+segmented endpoints listed in [`docs/ducaheat_api.md`](./ducaheat_api.md). Use the table there as the
+source of truth when mapping Home Assistant services to cloud writes.
+
+Key observations from traffic captures:
+
+- **Temperature payloads must be strings** formatted with exactly one decimal place (e.g. `"22.0"`).
+  Sending floats or integers causes the backend to reject the request.
+- The `units` field is **always uppercase** (`"C"` or `"F"`); lowercase variants fail validation.
+- Some operations require a `select: true` POST before the substantive write and `select: false`
+  afterwards. Keep the claim short-lived to avoid stepping on app sessions.
+- Boost, lock, and similar toggles are literal booleans; do not send quoted values.
+
+These semantics apply to both heater (`htr`) and accumulator (`acm`) nodes within the Ducaheat API.


### PR DESCRIPTION
## Summary
- capture the segmented accumulator write endpoints in the Ducaheat API docs
- add developer notes describing the required payload formatting for contributors
- link the README developer section to the new documentation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2695029e083298c75b79ea7790f0b