### PR TITLE
Refactor Ducaheat tests and cover shutdown edge cases

### DIFF
--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -1182,3 +1182,22 @@ def test_async_migrate_entry_returns_true(
     entry = ConfigEntry("migrate", data={})
     stub_hass.config_entries.add(entry)
     assert asyncio.run(termoweb_init.async_migrate_entry(stub_hass, entry)) is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_entry_ignores_non_mapping(termoweb_init: Any) -> None:
+    await termoweb_init._async_shutdown_entry(object())
+
+
+@pytest.mark.asyncio
+async def test_shutdown_entry_skips_completed_record(termoweb_init: Any) -> None:
+    rec: dict[str, object] = {"_shutdown_complete": True, "ws_clients": {}}
+    await termoweb_init._async_shutdown_entry(rec)
+    assert rec["_shutdown_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_entry_handles_client_without_stop(termoweb_init: Any) -> None:
+    rec: dict[str, object] = {"ws_clients": {"dev": object()}}
+    await termoweb_init._async_shutdown_entry(rec)
+    assert rec["_shutdown_complete"] is True


### PR DESCRIPTION
## Summary
- refactor the Ducaheat REST client tests to share a fixture and run directly under pytest-asyncio
- add targeted coverage for segmented POST logging and log redaction helpers
- exercise _async_shutdown_entry defensive paths to complete integration shutdown coverage

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e26b5bd8e483298a7b8da7ef723a29