### PR TITLE
Fix Ducaheat heartbeat idle timer handling

### DIFF
--- a/custom_components/termoweb/ws_client.py
+++ b/custom_components/termoweb/ws_client.py
@@ -2374,7 +2374,10 @@ class DucaheatWSClient(WebSocketClient):
                 payload = None
         if payload != "ping":
             return
-        self._mark_event(paths=None, count_event=False)
+        now = time.time()
+        self._stats.last_event_ts = now
+        self._last_event_at = now
+        self._last_heartbeat_at = now
         try:
             await self._sio.emit("message", "pong", namespace=self._namespace)
         except Exception:  # noqa: BLE001 - best effort heartbeat ack


### PR DESCRIPTION
## Summary
- stop treating Ducaheat app-level heartbeat pings as payload events so idle restarts can trigger
- extend websocket client tests to ensure heartbeats keep the payload idle timer intact

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e26f37b0148329a97a8c70703a0fb7