### PR TITLE
Use monotonic timers for websocket and token intervals

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -97,6 +97,7 @@ def test_prune_and_register_pending_settings(monkeypatch: pytest.MonkeyPatch) ->
         return fake_time["value"]
 
     monkeypatch.setattr(coord_module.time, "time", _fake_time)
+    monkeypatch.setattr(coord_module, "time_mod", _fake_time)
 
     coordinator._pending_settings[("htr", "1")] = coord_module.PendingSetting(
         mode="auto",
@@ -132,6 +133,7 @@ def test_should_defer_pending_setting_branches(
         return fake_time["value"]
 
     monkeypatch.setattr(coord_module.time, "time", _fake_time)
+    monkeypatch.setattr(coord_module, "time_mod", _fake_time)
 
     coordinator._pending_settings[("htr", "1")] = coord_module.PendingSetting(
         mode="auto",

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -203,6 +203,7 @@ def test_power_calculation(monkeypatch: pytest.MonkeyPatch) -> None:
             return fake_time
 
         monkeypatch.setattr(coord_module.time, "time", _fake_time)
+        monkeypatch.setattr(coord_module, "time_mod", _fake_time)
 
         await coord.async_refresh()
         assert coord.data["1"]["htr"]["energy"]["A"] == pytest.approx(0.001)
@@ -905,6 +906,7 @@ def test_counter_reset(monkeypatch: pytest.MonkeyPatch) -> None:
             return fake_time
 
         monkeypatch.setattr(coord_module.time, "time", _fake_time)
+        monkeypatch.setattr(coord_module, "time_mod", _fake_time)
 
         await coord.async_refresh()
         fake_time = 1900.0
@@ -921,7 +923,7 @@ def test_energy_processing_consistent_between_poll_and_ws(
 ) -> None:
     async def _run() -> None:
         monkeypatch.setattr(coord_module.time, "time", lambda: 4000.0)
-        monkeypatch.setattr(coord_module.time, "monotonic", lambda: 4000.0)
+        monkeypatch.setattr(coord_module, "time_mod", lambda: 4000.0)
 
         poll_client = types.SimpleNamespace()
         poll_client.get_node_samples = AsyncMock(
@@ -1100,7 +1102,7 @@ def test_ws_samples_update_defers_polling(monkeypatch: pytest.MonkeyPatch) -> No
             return fake_time
 
         monkeypatch.setattr(coord_module.time, "time", _fake_time)
-        monkeypatch.setattr(coord_module.time, "monotonic", _fake_time)
+        monkeypatch.setattr(coord_module, "time_mod", _fake_time)
 
         await coord.async_refresh()
 
@@ -1152,12 +1154,12 @@ def test_should_skip_poll_conditions(monkeypatch: pytest.MonkeyPatch) -> None:
     assert coord._should_skip_poll() is False
 
     coord._ws_deadline = 10.0
-    monkeypatch.setattr(coord_module.time, "monotonic", lambda: 15.0)
+    monkeypatch.setattr(coord_module, "time_mod", lambda: 15.0)
     assert coord._should_skip_poll() is False
 
     coord.data = {"dev": {}}
     coord._ws_deadline = 20.0
-    monkeypatch.setattr(coord_module.time, "monotonic", lambda: 5.0)
+    monkeypatch.setattr(coord_module, "time_mod", lambda: 5.0)
     assert coord._should_skip_poll() is True
 
 
@@ -1177,7 +1179,7 @@ def test_async_update_data_uses_cached_samples(monkeypatch: pytest.MonkeyPatch) 
         }
         coord._ws_deadline = 100.0
 
-        monkeypatch.setattr(coord_module.time, "monotonic", lambda: 50.0)
+        monkeypatch.setattr(coord_module, "time_mod", lambda: 50.0)
 
         cached = await coord._async_update_data()
         assert cached == coord.data
@@ -1250,7 +1252,7 @@ def test_handle_ws_samples_branching(monkeypatch: pytest.MonkeyPatch) -> None:
     def _fake_time() -> float:
         return fake_now
 
-    monkeypatch.setattr(coord_module.time, "monotonic", _fake_time)
+    monkeypatch.setattr(coord_module, "time_mod", _fake_time)
     monkeypatch.setattr(coord_module.time, "time", _fake_time)
 
     updates = {


### PR DESCRIPTION
## Summary
- switch websocket clients to use `time.monotonic()` for idle checks, backoff delays, and subscription refresh bookkeeping while retaining wall-clock metadata for logging
- update the REST client and coordinator to track token expiries and pending-setting TTLs with monotonic timers
- extend websocket and coordinator tests with controllable clocks to validate monotonic backoff behaviour and fallback guards

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e2711b1a7083298e22405c08f52de3