### PR TITLE
Handle partial energy options and validate heater targets

### DIFF
--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -501,13 +501,18 @@ async def async_import_energy_history(
     start_of_today = now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
     now_ts = int(start_of_today.timestamp()) - 1
     if max_days is None:
-        max_days = int(
-            entry.options.get(OPTION_MAX_HISTORY_RETRIEVED, DEFAULT_MAX_HISTORY_DAYS)
-        )
+        raw_max_days = entry.options.get(OPTION_MAX_HISTORY_RETRIEVED)
+        try:
+            max_days = int(raw_max_days)
+        except (TypeError, ValueError):
+            max_days = DEFAULT_MAX_HISTORY_DAYS
     target = now_ts - max_days * day
-    progress: dict[str, int] = dict(
-        entry.options.get(OPTION_ENERGY_HISTORY_PROGRESS, {})
-    )
+    raw_progress = entry.options.get(OPTION_ENERGY_HISTORY_PROGRESS)
+    progress: dict[str, int]
+    if isinstance(raw_progress, Mapping):
+        progress = dict(raw_progress)
+    else:
+        progress = {}
 
     def _progress_value(node_type: str, addr: str) -> int:
         raw = progress.get(f"{node_type}:{addr}")

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 from .nodes import (
@@ -191,7 +191,21 @@ class InstallationSnapshot:
 
         if self._sample_targets is None:
             normalized_map, _ = self.heater_sample_address_map
-            self._sample_targets = heater_sample_subscription_targets(normalized_map)
+            raw_targets = heater_sample_subscription_targets(normalized_map)
+            validated: list[tuple[str, str]] = []
+            for item in raw_targets:
+                if (
+                    isinstance(item, Sequence)
+                    and not isinstance(item, (str, bytes))
+                    and len(item) == 2
+                ):
+                    node_type, addr = item
+                    if node_type is not None and addr is not None:
+                        node_str = str(node_type).strip()
+                        addr_str = str(addr).strip()
+                        if node_str and addr_str:
+                            validated.append((node_str, addr_str))
+            self._sample_targets = validated
         return list(self._sample_targets)
 
     def heater_name_map(


### PR DESCRIPTION
## Summary
- guard energy history import against missing or invalid option values
- sanitize heater sample target generation to drop malformed entries
- add tests covering partial energy options and invalid subscription targets

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e28dd7ccc48329a3ae4fd2728bfe2e