### PR TITLE
test: cover ducaheat ws normalisation

### DIFF
--- a/tests/test_ducaheat_nodes.py
+++ b/tests/test_ducaheat_nodes.py
@@ -1,0 +1,64 @@
+"""Tests for Ducaheat node normalisation helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.termoweb.backend.ducaheat import DucaheatRESTClient
+
+
+def test_ducaheat_rest_normalise_ws_nodes_mixed_settings_types() -> None:
+    """Normalisation should coerce mapping payloads while preserving scalars."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    heater_prog = {str(day): [day] * 48 for day in range(7)}
+    accumulator_prog = {str(day): [1] * 24 for day in range(7)}
+
+    payload = {
+        "htr": {
+            "settings": {
+                "01": {
+                    "prog": {"prog": heater_prog},
+                    "mode": "auto",
+                },
+                "02": ["unexpected"],
+            },
+            "status": [{"temp": 21}],
+        },
+        "acm": {
+            "settings": {
+                "03": {
+                    "prog": {"days": accumulator_prog},
+                    "mode": "charge",
+                },
+                "04": "raw",
+            },
+            "status": {"03": {"temp": 19}},
+        },
+        "pmo": ["unchanged"],
+    }
+
+    result = client.normalise_ws_nodes(payload)
+
+    heater_settings = result["htr"]["settings"]["01"]
+    assert isinstance(heater_settings, dict)
+    assert len(heater_settings["prog"]) == 168
+    # Spot check that day 1 (Monday) slots collapsed from the vendor's 48 entries.
+    assert heater_settings["prog"][24:48] == [1] * 24
+
+    accumulator_settings = result["acm"]["settings"]["03"]
+    assert isinstance(accumulator_settings, dict)
+    assert len(accumulator_settings["prog"]) == 168
+
+    # Non-mapping settings entries should pass through untouched.
+    assert result["htr"]["settings"]["02"] == ["unexpected"]
+    assert result["acm"]["settings"]["04"] == "raw"
+
+    # Non-settings sections retain their original typing.
+    assert result["htr"]["status"] == [{"temp": 21}]
+    assert result["pmo"] == ["unchanged"]
+
+    # Original payload should remain unchanged for mapping coercions.
+    assert len(payload["htr"]["settings"]["01"]["prog"]["prog"]["1"]) == 48
+    assert len(payload["acm"]["settings"]["03"]["prog"]["days"]["1"]) == 24

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1,7 +1,6 @@
 import asyncio
 from copy import deepcopy
 import logging
-import logging
 import time
 from contextlib import suppress
 from types import SimpleNamespace


### PR DESCRIPTION
## Summary
- remove the duplicate logging import from the websocket client tests
- add a Ducaheat websocket node normalisation test covering mixed setting payload types

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e28debbf008329b1841d8401b5743e