### PR TITLE
Fix Ducaheat Socket.IO handshake path

### DIFF
--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -40,6 +40,10 @@ BRAND_BASIC_AUTH: Final[Mapping[str, str]] = {
     BRAND_DUCAHEAT: "NWM0OWRjZTk3NzUxMDM1MTUwNmM0MmRiOnRldm9sdmU=",
 }
 
+BRAND_SOCKETIO_PATHS: Final[Mapping[str, str]] = {
+    BRAND_DUCAHEAT: "api/v2/socket_io",
+}
+
 # UA / locale (matches app loosely; helps avoid quirky WAF rules)
 USER_AGENT: Final = "TermoWeb/2.5.1 (Android; HomeAssistant Integration)"
 DUCAHEAT_USER_AGENT: Final = "Ducaheat/1.40.1 (Android; HomeAssistant Integration)"
@@ -90,6 +94,15 @@ def get_brand_requested_with(brand: str) -> str | None:
     """Return the X-Requested-With header value for the brand."""
 
     return BRAND_REQUESTED_WITH.get(brand)
+
+
+def get_brand_socketio_path(brand: str) -> str:
+    """Return the Socket.IO path for the selected brand."""
+
+    path = BRAND_SOCKETIO_PATHS.get(brand)
+    if path:
+        return path.lstrip("/")
+    return "socket.io"
 
 # Socket.IO namespace used by the websocket client implementation
 WS_NAMESPACE: Final = "/api/v2/socket_io"


### PR DESCRIPTION
## Summary
- add brand-specific Socket.IO path mapping and helper in the shared constants
- update the websocket client to carry the brand context, use the mapped Socket.IO path, and harden the Ducaheat handshake to the websocket-only endpoint with improved diagnostics
- refresh the websocket client test fixtures to assert the new Ducaheat connection contract and logging output

## Testing
- `ruff check custom_components/termoweb/const.py custom_components/termoweb/ws_client.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e29d62c3b883298c679b4d63364fd6