### PR TITLE
Restore TermoWeb websocket client implementation

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -80,8 +80,8 @@ _statistics_during_period_compat = (
 _get_last_statistics_compat = energy_module._get_last_statistics_compat  # noqa: SLF001
 _clear_statistics_compat = energy_module._clear_statistics_compat  # noqa: SLF001
 
-# Re-export legacy WS client for backward compatibility (tests may patch it).
-from .ws_client import TermoWebWSClient  # noqa: F401,E402
+# Re-export the websocket client for backward compatibility (tests may patch it).
+from .backend.ws_client import TermoWebWSClient  # noqa: F401,E402
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -12,7 +12,7 @@ from aiohttp import ClientResponseError
 from ..api import RESTClient
 from ..const import BRAND_DUCAHEAT, WS_NAMESPACE
 from ..nodes import NodeDescriptor
-from ..ws_client import DucaheatWSClient
+from .ducaheat_ws import DucaheatWSClient
 from .base import Backend, WsClientProto
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -1,164 +1,62 @@
 # -*- coding: utf-8 -*-
+"""Ducaheat specific websocket client."""
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
-from copy import deepcopy
-from dataclasses import dataclass
 import gzip
 import json
 import logging
 import random
 import string
-from typing import Any, Iterable, Mapping
+from typing import Any, Mapping
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import aiohttp
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .api import RESTClient
-from .const import (
+from ..api import RESTClient
+from ..const import (
     ACCEPT_LANGUAGE,
     API_BASE,
     BRAND_DUCAHEAT,
-    BRAND_TERMOWEB,
     DOMAIN,
     USER_AGENT,
-    WS_NAMESPACE,
     get_brand_api_base,
     get_brand_requested_with,
     get_brand_user_agent,
-    signal_ws_data,
-    signal_ws_status,
 )
-from .installation import InstallationSnapshot, ensure_snapshot
-from .nodes import (
-    NODE_CLASS_BY_TYPE,
-    addresses_by_node_type,
-    ensure_node_inventory,
+from ..nodes import (
     collect_heater_sample_addresses,
     heater_sample_subscription_targets,
     normalize_heater_addresses,
-    normalize_node_addr,
-    normalize_node_type,
+)
+from .ws_client import (
+    DUCAHEAT_NAMESPACE,
+    HandshakeError,
+    WSStats,
+    _WSCommon,
+    _WsLeaseMixin,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-DUCAHEAT_NAMESPACE = "/api/v2/socket_io"
 
-
-@dataclass
-class WSStats:
-    frames_total: int = 0
-    events_total: int = 0
-    last_event_ts: float = 0.0
-
-
-class HandshakeError(RuntimeError):
-    def __init__(self, status: int, url: str, detail: str) -> None:
-        super().__init__(f"handshake failed: status={status}, detail={detail}")
-        self.status = status
-        self.url = url
-
-
-class _WsLeaseMixin:
-    def __init__(self) -> None:
-        self._payload_idle_window: float = 240.0
-        self._subscription_refresh_lock = asyncio.Lock()
-        self._subscription_refresh_failed = False
-        self._backoff_idx = 0
-        self._backoff = (5, 10, 30, 120, 300)
-
-    def _reset_backoff(self) -> None:
-        self._backoff_idx = 0
-
-    def _next_backoff(self) -> float:
-        idx = min(self._backoff_idx, len(self._backoff) - 1)
-        self._backoff_idx = min(self._backoff_idx + 1, len(self._backoff) - 1)
-        return self._backoff[idx]
-
-
-class WebSocketClient(_WsLeaseMixin):
-    """Delegates to the correct manual client; no python-socketio here."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        *,
-        entry_id: str,
-        dev_id: str,
-        api_client: RESTClient,
-        coordinator: Any,
-        session: aiohttp.ClientSession | None = None,
-        protocol: str | None = None,
-        namespace: str = WS_NAMESPACE,
-    ) -> None:
-        _WsLeaseMixin.__init__(self)
-        self.hass = hass
-        self.entry_id = entry_id
-        self.dev_id = dev_id
-        self._client = api_client
-        self._coordinator = coordinator
-        self._session = session or getattr(api_client, "_session", None)
-        self._protocol_hint = protocol
-        self._namespace = namespace or WS_NAMESPACE
-        self._loop = getattr(hass, "loop", None) or asyncio.get_event_loop()
-        self._delegate: Any | None = None
-        self._brand = BRAND_DUCAHEAT if getattr(api_client, "_is_ducaheat", False) else BRAND_TERMOWEB
-
-    def start(self) -> asyncio.Task:
-        if self._delegate is not None:
-            return self._delegate.start()
-        if self._brand == BRAND_DUCAHEAT:
-            self._delegate = DucaheatWSClient(
-                self.hass,
-                entry_id=self.entry_id,
-                dev_id=self.dev_id,
-                api_client=self._client,
-                coordinator=self._coordinator,
-                session=self._session,
-                namespace=DUCAHEAT_NAMESPACE,
-            )
-        else:
-            self._delegate = TermoWebWSClient(
-                self.hass,
-                entry_id=self.entry_id,
-                dev_id=self.dev_id,
-                api_client=self._client,
-                coordinator=self._coordinator,
-                session=self._session,
-                namespace=self._namespace,
-            )
-        return self._delegate.start()
-
-    async def stop(self) -> None:
-        if self._delegate is not None:
-            await self._delegate.stop()
-
-    def is_running(self) -> bool:
-        return bool(self._delegate and self._delegate.is_running())
-
-    async def ws_url(self) -> str:
-        if self._delegate and hasattr(self._delegate, "ws_url"):
-            return await self._delegate.ws_url()
-        return ""
-
-
-# ---------- helpers ----------
 def _rand_t() -> str:
-    # vendor uses 'P'+alnum; 7 chars is enough
+    """Return a pseudo-random token string for polling requests."""
+
     return "P" + "".join(random.choice(string.ascii_letters + string.digits) for _ in range(7))
 
 
 def _encode_polling_packet(pkt: str) -> bytes:
+    """Encode Engine.IO polling payloads."""
+
     data = pkt.encode("utf-8")
     return f"{len(data)}:".encode("ascii") + data
 
 
 def _decode_polling_packets(body: bytes) -> list[str]:
-    """Engine.IO v3 binary polling: [0x00|0x01] <digit-bytes '0'..'9' until 0xFF> 0xFF <payload> ..."""
+    """Decode Engine.IO v3 binary polling frames."""
+
     buf = body
     if len(buf) >= 2 and buf[:2] == b"\x1f\x8b":
         try:
@@ -170,10 +68,13 @@ def _decode_polling_packets(body: bytes) -> list[str]:
     while i < n:
         if i + 4 > n:
             break
-        _typ = buf[i]; i += 1
-        length = 0; had_digit = False
+        _typ = buf[i]
+        i += 1
+        length = 0
+        had_digit = False
         while i < n and buf[i] != 0xFF:
-            d = buf[i]; i += 1
+            d = buf[i]
+            i += 1
             if d > 9:
                 return out
             had_digit = True
@@ -184,7 +85,8 @@ def _decode_polling_packets(body: bytes) -> list[str]:
         end = i + length
         if end > n:
             return out
-        payload = buf[i:end]; i = end
+        payload = buf[i:end]
+        i = end
         try:
             pkt = payload.decode("utf-8", errors="ignore")
         except Exception:
@@ -195,7 +97,8 @@ def _decode_polling_packets(body: bytes) -> list[str]:
 
 
 def _brand_headers(user_agent: str, requested_with: str) -> dict[str, str]:
-    # For polling requests (WS uses ws_connect defaults)
+    """Construct brand-specific headers for polling."""
+
     return {
         "User-Agent": user_agent or USER_AGENT,
         "Accept-Language": ACCEPT_LANGUAGE,
@@ -210,81 +113,20 @@ def _brand_headers(user_agent: str, requested_with: str) -> dict[str, str]:
     }
 
 
-class _WSCommon:
-    def _ws_state_bucket(self) -> dict[str, Any]:
-        domain_bucket = self.hass.data.setdefault(DOMAIN, {})
-        entry_bucket = domain_bucket.setdefault(self.entry_id, {})
-        ws_state = entry_bucket.setdefault("ws_state", {})
-        return ws_state.setdefault(self.dev_id, {})
-
-    def _update_status(self, status: str) -> None:
-        async_dispatcher_send(self.hass, signal_ws_status(self.entry_id), {"dev_id": self.dev_id, "status": status})
-
-    def _dispatch_nodes(self, payload: dict[str, Any]) -> None:
-        raw_nodes = payload.get("nodes") if "nodes" in payload else payload
-        record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
-        snapshot_obj = ensure_snapshot(record)
-        if isinstance(snapshot_obj, InstallationSnapshot):
-            snapshot_obj.update_nodes(raw_nodes)
-            inventory = snapshot_obj.inventory
-            if isinstance(record, dict):
-                record["node_inventory"] = list(inventory)
-        else:
-            record_map: Mapping[str, Any] = record if isinstance(record, Mapping) else {}
-            inventory = ensure_node_inventory(record_map, nodes=raw_nodes)
-        addr_map, _ = addresses_by_node_type(inventory, known_types=NODE_CLASS_BY_TYPE)
-        if hasattr(self._coordinator, "update_nodes"):
-            self._coordinator.update_nodes(raw_nodes, inventory)
-        payload_copy = {
-            "dev_id": self.dev_id,
-            "node_type": None,
-            "nodes": deepcopy(raw_nodes),
-            "addr_map": {t: list(a) for t, a in addr_map.items()},
-        }
-        async_dispatcher_send(self.hass, signal_ws_data(self.entry_id), payload_copy)
-
-
-# ---------- TermoWeb stub (unused for Ducaheat) ----------
-class TermoWebWSClient(_WsLeaseMixin, _WSCommon):
-    def __init__(self, hass: HomeAssistant, *, entry_id: str, dev_id: str, api_client: RESTClient,
-                 coordinator: Any, session: aiohttp.ClientSession | None = None, namespace: str | None = None) -> None:
-        _WsLeaseMixin.__init__(self)
-        self.hass = hass
-        self.entry_id = entry_id
-        self.dev_id = dev_id
-        self._client = api_client
-        self._coordinator = coordinator
-        self._session = session or getattr(api_client, "_session", None)
-        self._loop = getattr(hass, "loop", None) or asyncio.get_event_loop()
-        self._namespace = namespace or WS_NAMESPACE
-        self._task: asyncio.Task | None = None
-
-    def start(self) -> asyncio.Task:
-        if self._task and not self._task.done():
-            return self._task
-        self._task = self._loop.create_task(self._stub(), name=f"{DOMAIN}-ws-{self.dev_id}")
-        return self._task
-
-    async def _stub(self) -> None:
-        _LOGGER.info("TermoWebWSClient: legacy path not modified in this file")
-
-    async def stop(self) -> None:
-        if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
-
-    def is_running(self) -> bool:
-        return bool(self._task and not self._task.done())
-
-
-# ---------- Ducaheat EIO3 exact client ----------
 class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
-    def __init__(self, hass: HomeAssistant, *, entry_id: str, dev_id: str, api_client: RESTClient, coordinator: Any,
-                 session: aiohttp.ClientSession | None = None, namespace: str | None = None) -> None:
+    """Engine.IO v3 websocket client for the Ducaheat backend."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry_id: str,
+        dev_id: str,
+        api_client: RESTClient,
+        coordinator: Any,
+        session: aiohttp.ClientSession | None = None,
+        namespace: str | None = None,
+    ) -> None:
         _WsLeaseMixin.__init__(self)
         self.hass = hass
         self.entry_id = entry_id
@@ -308,7 +150,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
     def start(self) -> asyncio.Task:
         if self._task and not self._task.done():
             return self._task
-        self._task = self._loop.create_task(self._runner(), name=f"{DOMAIN}-ws-{self.dev_id}")
+        self._task = self._loop.create_task(self._runner(), name=f"termoweb-ws-{self.dev_id}")
         return self._task
 
     async def stop(self) -> None:
@@ -334,7 +176,13 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
 
     async def ws_url(self) -> str:
         token = await self._get_token()
-        params = {"token": token, "dev_id": self.dev_id, "EIO": "3", "transport": "polling", "t": _rand_t()}
+        params = {
+            "token": token,
+            "dev_id": self.dev_id,
+            "EIO": "3",
+            "transport": "polling",
+            "t": _rand_t(),
+        }
         return urlunsplit(urlsplit(self._base_host())._replace(path=self._path(), query=urlencode(params)))
 
     async def _runner(self) -> None:
@@ -346,8 +194,8 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                     await self._read_loop_ws()
                 except asyncio.CancelledError:
                     break
-                except Exception as e:
-                    _LOGGER.debug("WS (ducaheat): error %s", e, exc_info=True)
+                except Exception as exc:  # pragma: no cover - defensive
+                    _LOGGER.debug("WS (ducaheat): error %s", exc, exc_info=True)
                     await asyncio.sleep(self._next_backoff())
                 finally:
                     await self._disconnect("loop")
@@ -359,73 +207,117 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         token = await self._get_token()
         headers = _brand_headers(self._ua, self._xrw)
 
-        # 1) Polling OPEN (GET)
-        open_params = {"token": token, "dev_id": self.dev_id, "EIO": "3", "transport": "polling", "t": _rand_t()}
+        open_params = {
+            "token": token,
+            "dev_id": self.dev_id,
+            "EIO": "3",
+            "transport": "polling",
+            "t": _rand_t(),
+        }
         open_url = urlunsplit(urlsplit(self._base_host())._replace(path=self._path(), query=urlencode(open_params)))
         _LOGGER.debug("WS (ducaheat): OPEN GET %s", open_url.replace(token, "…"))
         async with asyncio.timeout(15):
             async with self._session.get(open_url, headers=headers) as resp:
                 body = await resp.read()
-                _LOGGER.debug("WS (ducaheat): OPEN GET -> %s bytes (status=%s)", len(body), resp.status)
+                _LOGGER.debug(
+                    "WS (ducaheat): OPEN GET -> %s bytes (status=%s)",
+                    len(body),
+                    resp.status,
+                )
                 if resp.status != 200:
                     raise HandshakeError(resp.status, open_url, "open GET")
         packets = _decode_polling_packets(body)
-        open_pkt = next((p for p in packets if p and p[0] == "0"), None)
+        open_pkt = next((pkt for pkt in packets if pkt and pkt[0] == "0"), None)
         if not open_pkt:
             _LOGGER.debug("WS (ducaheat): open raw first 120 bytes: %r", body[:120])
             raise HandshakeError(590, open_url, "missing OPEN (0)")
         info = json.loads(open_pkt[1:])
         sid = info.get("sid")
-        _LOGGER.info("WS (ducaheat): OPEN decoded sid=%s pingInterval=%s pingTimeout=%s",
-                     sid, info.get("pingInterval"), info.get("pingTimeout"))
+        _LOGGER.info(
+            "WS (ducaheat): OPEN decoded sid=%s pingInterval=%s pingTimeout=%s",
+            sid,
+            info.get("pingInterval"),
+            info.get("pingTimeout"),
+        )
         if not isinstance(sid, str) or not sid:
             raise HandshakeError(592, open_url, "missing sid")
 
-        # 2) Polling POST SIO open "40/ns"
-        post_params = {"token": token, "dev_id": self.dev_id, "EIO": "3", "transport": "polling", "t": _rand_t(), "sid": sid}
+        post_params = {
+            "token": token,
+            "dev_id": self.dev_id,
+            "EIO": "3",
+            "transport": "polling",
+            "t": _rand_t(),
+            "sid": sid,
+        }
         post_url = urlunsplit(urlsplit(self._base_host())._replace(path=self._path(), query=urlencode(post_params)))
         payload = _encode_polling_packet(f"40{self._namespace}")
         _LOGGER.debug("WS (ducaheat): POST 40/ns %s", post_url.replace(token, "…"))
         async with asyncio.timeout(15):
-            async with self._session.post(post_url, headers={**headers, "Content-Type": "text/plain;charset=UTF-8"},
-                                          data=payload) as resp:
+            async with self._session.post(
+                post_url,
+                headers={**headers, "Content-Type": "text/plain;charset=UTF-8"},
+                data=payload,
+            ) as resp:
                 drain = await resp.read()
-                _LOGGER.debug("WS (ducaheat): POST 40/ns -> status=%s len=%s", resp.status, len(drain))
+                _LOGGER.debug(
+                    "WS (ducaheat): POST 40/ns -> status=%s len=%s",
+                    resp.status,
+                    len(drain),
+                )
                 if resp.status != 200:
                     raise HandshakeError(resp.status, post_url, "POST 40/ns")
 
-        # 2b) Polling GET to drain acks
-        drain_params = dict(post_params); drain_params["t"] = _rand_t()
+        drain_params = dict(post_params)
+        drain_params["t"] = _rand_t()
         drain_url = urlunsplit(urlsplit(self._base_host())._replace(path=self._path(), query=urlencode(drain_params)))
         _LOGGER.debug("WS (ducaheat): DRAIN GET %s", drain_url.replace(token, "…"))
         async with asyncio.timeout(15):
             async with self._session.get(drain_url, headers=headers) as resp:
                 body = await resp.read()
-                _LOGGER.debug("WS (ducaheat): DRAIN GET -> status=%s len=%s", resp.status, len(body))
+                _LOGGER.debug(
+                    "WS (ducaheat): DRAIN GET -> status=%s len=%s",
+                    resp.status,
+                    len(body),
+                )
                 if resp.status != 200:
                     raise HandshakeError(resp.status, drain_url, "drain GET")
 
-        # 3) WebSocket upgrade (no t)
-        ws_params = {"token": token, "dev_id": self.dev_id, "EIO": "3", "transport": "websocket", "sid": sid}
+        ws_params = {
+            "token": token,
+            "dev_id": self.dev_id,
+            "EIO": "3",
+            "transport": "websocket",
+            "sid": sid,
+        }
         ws_url = urlunsplit(urlsplit(self._base_host())._replace(path=self._path(), query=urlencode(ws_params)))
         ws_headers = {k: v for k, v in headers.items() if k.lower() not in ("connection", "accept-encoding")}
         _LOGGER.debug("WS (ducaheat): upgrading WS %s", ws_url.replace(token, "…"))
-        self._ws = await self._session.ws_connect(ws_url, headers=ws_headers,
-                                                  heartbeat=None, autoclose=False,
-                                                  timeout=aiohttp.ClientTimeout(total=15))
+        self._ws = await self._session.ws_connect(
+            ws_url,
+            headers=ws_headers,
+            heartbeat=None,
+            autoclose=False,
+            timeout=aiohttp.ClientTimeout(total=15),
+        )
         _LOGGER.info("WS (ducaheat): upgrade OK")
 
-        # EIO3 probe/upgrade
-        await self._ws.send_str("2probe"); _LOGGER.debug("WS (ducaheat): -> 2probe")
-        probe = await self._ws.receive_str(); _LOGGER.debug("WS (ducaheat): <- %r", probe)
-        if probe != "3probe": _LOGGER.debug("WS (ducaheat): unexpected probe ack: %r", probe)
-        await self._ws.send_str("5"); _LOGGER.debug("WS (ducaheat): -> 5 (upgrade)")
+        await self._ws.send_str("2probe")
+        _LOGGER.debug("WS (ducaheat): -> 2probe")
+        probe = await self._ws.receive_str()
+        _LOGGER.debug("WS (ducaheat): <- %r", probe)
+        if probe != "3probe":
+            _LOGGER.debug("WS (ducaheat): unexpected probe ack: %r", probe)
+        await self._ws.send_str("5")
+        _LOGGER.debug("WS (ducaheat): -> 5 (upgrade)")
 
-        # Namespace open + dev_data + subscriptions
-        await self._ws.send_str(f"40{self._namespace}"); _LOGGER.debug("WS (ducaheat): -> 40%s", self._namespace)
-        await self._emit_sio("dev_data"); _LOGGER.debug("WS (ducaheat): -> 42 dev_data")
+        await self._ws.send_str(f"40{self._namespace}")
+        _LOGGER.debug("WS (ducaheat): -> 40%s", self._namespace)
+        await self._emit_sio("dev_data")
+        _LOGGER.debug("WS (ducaheat): -> 42 dev_data")
 
-        subs = await self._subscribe_samples(); _LOGGER.info("WS (ducaheat): subscribed %d sample targets", subs)
+        subs = await self._subscribe_samples()
+        _LOGGER.info("WS (ducaheat): subscribed %d sample targets", subs)
         self._update_status("connected")
 
     async def _read_loop_ws(self) -> None:
@@ -437,34 +329,34 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     data = msg.data
                     self._stats.frames_total += 1
-                    # Engine.IO ping -> pong
                     if data == "2":
                         _LOGGER.debug("WS (ducaheat): <- EIO 2 (ping) -> EIO 3 (pong)")
-                        await ws.send_str("3"); continue
+                        await ws.send_str("3")
+                        continue
                     if not data.startswith("4"):
                         continue
                     payload = data[1:]
-
-                    # Socket.IO control ping (2[/ns]) -> pong (3[/ns])
                     if payload == "2" or payload.startswith("2/"):
                         if payload == "2":
                             _LOGGER.debug("WS (ducaheat): <- SIO 2 (ping) -> SIO 3 (pong)")
                             await ws.send_str("3")
                         else:
-                            ns = payload[1:].split(",", 1)[0]  # '/ns'
+                            ns = payload[1:].split(",", 1)[0]
                             _LOGGER.debug("WS (ducaheat): <- SIO 2%s (ping) -> SIO 3%s (pong)", ns, ns)
                             await ws.send_str("3" + ns)
                         continue
 
                     if payload.startswith("40"):
                         _LOGGER.debug("WS (ducaheat): <- SIO 40 (namespace ack)")
-                        self._update_status("healthy"); continue
+                        self._update_status("healthy")
+                        continue
 
                     if payload.startswith("42"):
                         content = payload[2:]
                         if content.startswith("/"):
                             _ns, sep, content = content.partition(",")
-                            if sep != ",": continue
+                            if sep != ",":
+                                continue
                         try:
                             arr = json.loads(content)
                         except Exception:
@@ -476,7 +368,8 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
 
                         if evt == "message" and args and args[0] == "ping":
                             _LOGGER.debug("WS (ducaheat): app ping -> pong")
-                            await self._emit_sio("message", "pong"); continue
+                            await self._emit_sio("message", "pong")
+                            continue
 
                         if evt == "dev_data" and args and isinstance(args[0], dict):
                             nodes = args[0].get("nodes") if isinstance(args[0], dict) else None
@@ -499,28 +392,34 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             _LOGGER.debug("WS (ducaheat): read loop ended (ws closed or error)")
 
     def _log_nodes_summary(self, nodes: Mapping[str, Any]) -> None:
-        if not _LOGGER.isEnabledFor(logging.INFO): return
+        if not _LOGGER.isEnabledFor(logging.INFO):
+            return
         kinds = []
-        for k, v in nodes.items():
-            if isinstance(v, Mapping):
+        for key, value in nodes.items():
+            if isinstance(value, Mapping):
                 addrs = set()
                 for section in ("settings", "samples", "status", "advanced"):
-                    sec = v.get(section)
+                    sec = value.get(section)
                     if isinstance(sec, Mapping):
-                        addrs.update(a for a in sec.keys() if isinstance(a, str))
-                kinds.append(f"{k}={len(addrs) if addrs else 0}")
+                        addrs.update(addr for addr in sec.keys() if isinstance(addr, str))
+                kinds.append(f"{key}={len(addrs) if addrs else 0}")
         _LOGGER.info("WS (ducaheat): dev_data nodes: %s", " ".join(kinds) if kinds else "(no nodes)")
 
     def _log_update_brief(self, body: Any) -> None:
-        if not _LOGGER.isEnabledFor(logging.DEBUG): return
-        path = None; keys = None
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        path = None
+        keys = None
         if isinstance(body, Mapping):
-            path = body.get("path"); b = body.get("body")
-            if isinstance(b, Mapping): keys = ",".join(list(b.keys())[:6])
+            path = body.get("path")
+            payload = body.get("body")
+            if isinstance(payload, Mapping):
+                keys = ",".join(list(payload.keys())[:6])
         _LOGGER.debug("WS (ducaheat): update path=%s keys=%s", path, keys)
 
     async def _emit_sio(self, event: str, *args: Any) -> None:
-        if not self._ws or self._ws.closed: raise RuntimeError("websocket not connected")
+        if not self._ws or self._ws.closed:
+            raise RuntimeError("websocket not connected")
         arr = [event, *args]
         payload = json.dumps(arr, separators=(",", ":"), default=str)
         await self._ws.send_str(f"42{DUCAHEAT_NAMESPACE}," + payload)
@@ -529,21 +428,27 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         count = 0
         try:
             record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
-            inventory, normalized_map, _ = collect_heater_sample_addresses(record, coordinator=self._coordinator)
+            inventory, normalized_map, _ = collect_heater_sample_addresses(
+                record,
+                coordinator=self._coordinator,
+            )
             normalized_map, _ = normalize_heater_addresses(normalized_map)
             targets = list(heater_sample_subscription_targets(normalized_map))
             for node_type, addr in targets:
                 await self._emit_sio("subscribe", f"/{node_type}/{addr}/samples")
             count = len(targets)
-        except Exception:
+        except Exception:  # pragma: no cover - defensive
             _LOGGER.debug("WS (ducaheat): subscribe failed", exc_info=True)
         return count
 
     async def _disconnect(self, reason: str) -> None:
         if self._ws:
             try:
-                await self._ws.close(code=aiohttp.WSCloseCode.GOING_AWAY, message=reason.encode())
-            except Exception:
+                await self._ws.close(
+                    code=aiohttp.WSCloseCode.GOING_AWAY,
+                    message=reason.encode(),
+                )
+            except Exception:  # pragma: no cover - defensive
                 _LOGGER.debug("WS (ducaheat): close failed", exc_info=True)
             self._ws = None
 
@@ -555,4 +460,4 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         return auth.split(" ", 1)[1]
 
 
-__all__ = ["WebSocketClient", "DucaheatWSClient", "TermoWebWSClient"]
+__all__ = ["DucaheatWSClient"]

--- a/custom_components/termoweb/backend/termoweb.py
+++ b/custom_components/termoweb/backend/termoweb.py
@@ -6,7 +6,7 @@ import sys
 from types import ModuleType
 from typing import Any
 
-from custom_components.termoweb.ws_client import WebSocketClient
+from .ws_client import WebSocketClient
 
 from .base import Backend, WsClientProto
 
@@ -37,7 +37,7 @@ class TermoWebBackend(Backend):
         if not saw_real_module:
             return WebSocketClient
         try:
-            ws_module = import_module("custom_components.termoweb.ws_client")
+            ws_module = import_module("custom_components.termoweb.backend.termoweb_ws")
         except ImportError:
             return WebSocketClient
         ws_cls = getattr(ws_module, "TermoWebWSClient", None)

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -1,0 +1,2029 @@
+"""Unified websocket client for TermoWeb backends."""
+
+from __future__ import annotations
+
+import asyncio
+import codecs
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
+from contextlib import suppress
+from copy import deepcopy
+from dataclasses import dataclass
+from functools import partial, wraps
+import json
+import logging
+import random
+import time
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+import weakref
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+import socketio
+
+from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.const import (
+    ACCEPT_LANGUAGE,
+    API_BASE,
+    BRAND_DUCAHEAT,
+    BRAND_TERMOWEB,
+    DOMAIN,
+    USER_AGENT,
+    WS_NAMESPACE,
+    get_brand_requested_with,
+    get_brand_user_agent,
+    signal_ws_data,
+    signal_ws_status,
+)
+from custom_components.termoweb.installation import (
+    InstallationSnapshot,
+    ensure_snapshot,
+)
+from custom_components.termoweb.nodes import (
+    NODE_CLASS_BY_TYPE,
+    addresses_by_node_type,
+    build_node_inventory as _build_node_inventory,
+    collect_heater_sample_addresses,
+    ensure_node_inventory,
+    heater_sample_subscription_targets,
+    normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+build_node_inventory = _build_node_inventory  # re-exported for tests
+
+
+@dataclass
+class WSStats:
+    """Track websocket activity statistics."""
+
+    frames_total: int = 0
+    events_total: int = 0
+    last_event_ts: float = 0.0
+    last_paths: list[str] | None = None
+
+
+class HandshakeError(RuntimeError):
+    """Capture context for failed websocket handshakes."""
+
+    def __init__(self, status: int, url: str, body_snippet: str) -> None:
+        """Initialise the error with the HTTP response details."""
+
+        super().__init__(f"handshake failed (status={status})")
+        self.status = status
+        self.url = url
+        self.body_snippet = body_snippet
+
+
+class WebSocketClient:
+    """Unified websocket client wrapping ``socketio.AsyncClient``."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry_id: str,
+        dev_id: str,
+        api_client: RESTClient,
+        coordinator: Any,
+        session: aiohttp.ClientSession | None = None,
+        handshake_fail_threshold: int = 5,  # legacy compatibility
+        protocol: str | None = None,
+        namespace: str = WS_NAMESPACE,
+    ) -> None:
+        """Initialise the websocket client container."""
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self._client = api_client
+        self._coordinator = coordinator
+        self._session = session or getattr(api_client, "_session", None)
+        self._protocol_hint = protocol
+        self._loop = getattr(hass, "loop", None) or asyncio.get_event_loop()
+        self._task: asyncio.Task | None = None
+        self._namespace = namespace or WS_NAMESPACE
+
+        is_ducaheat = getattr(api_client, "_is_ducaheat", False)
+        brand = BRAND_DUCAHEAT if is_ducaheat else BRAND_TERMOWEB
+        self._user_agent = (
+            getattr(api_client, "user_agent", None)
+            or get_brand_user_agent(brand)
+        )
+        requested_with = getattr(api_client, "requested_with", None)
+        if requested_with is None:
+            requested_with = get_brand_requested_with(brand)
+        self._requested_with = requested_with
+
+        http_session = (
+            self._session
+            if isinstance(self._session, aiohttp.ClientSession)
+            else None
+        )
+        self._sio = socketio.AsyncClient(
+            reconnection=False,
+            logger=_LOGGER.getChild(f"socketio.{dev_id}"),
+            engineio_logger=_LOGGER.getChild(f"engineio.{dev_id}"),
+            http_session=http_session,
+        )
+        self._sio.start_background_task = self._wrap_background_task
+        http_target: Any = self._session
+        if http_target is None or not hasattr(http_target, "closed"):
+            http_target = SimpleNamespace(closed=True)
+        try:
+            self._sio.http = http_target
+        except AttributeError:
+            setattr(self._sio, "http", http_target)
+        if hasattr(self._sio, "eio"):
+            self._sio.eio.start_background_task = self._wrap_background_task
+            eio_http = getattr(self._sio.eio, "http", None)
+            if eio_http is None or not hasattr(eio_http, "closed"):
+                self._sio.eio.http = http_target
+            else:
+                self._sio.eio.http = eio_http
+
+        self._sio.on("connect", handler=self._on_connect)
+        self._sio.on("disconnect", handler=self._on_disconnect)
+        self._sio.on("reconnect", handler=self._on_reconnect)
+        self._sio.on("connect_error", handler=self._on_connect_error)
+        self._sio.on("error", handler=self._on_error)
+        self._sio.on("reconnect_failed", handler=self._on_reconnect_failed)
+        self._sio.on(
+            "connect", namespace=self._namespace, handler=self._on_namespace_connect
+        )
+        self._sio.on(
+            "disconnect",
+            namespace=self._namespace,
+            handler=self._on_namespace_disconnect,
+        )
+        self._sio.on(
+            "dev_handshake", namespace=self._namespace, handler=self._on_dev_handshake
+        )
+        self._sio.on("dev_data", namespace=self._namespace, handler=self._on_dev_data)
+        self._sio.on("update", namespace=self._namespace, handler=self._on_update)
+
+        self._closing = False
+        self._status: str = "stopped"
+        self._stop_event = asyncio.Event()
+        self._disconnected = asyncio.Event()
+        self._disconnected.set()
+        self._backoff_seq = [5, 10, 30, 120, 300]
+        self._backoff_idx = 0
+
+        self._connected_since: float | None = None
+        self._healthy_since: float | None = None
+        self._last_event_at: float | None = None
+        self._last_payload_at: float | None = None
+        self._stats = WSStats()
+
+        self._handshake_payload: dict[str, Any] | None = None
+        self._nodes: dict[str, Any] = {}
+        self._nodes_raw: dict[str, Any] = {}
+
+        self._payload_idle_window: float = 240.0
+        self._idle_restart_task: asyncio.Task | None = None
+        self._idle_restart_pending = False
+        self._idle_monitor_task: asyncio.Task | None = None
+
+        self._subscription_refresh_lock = asyncio.Lock()
+        self._subscription_refresh_failed = False
+        self._subscription_refresh_last_attempt: float = 0.0
+        self._subscription_refresh_last_success: float | None = None
+        self._handshake_logged = False
+        self._debug_catch_all_registered = False
+
+        self._ws_state: dict[str, Any] | None = None
+        state = self._ws_state_bucket()
+        state.setdefault("last_payload_at", None)
+        state.setdefault("idle_restart_pending", False)
+
+    def _brand_headers(self, *, origin: str | None = None) -> dict[str, str]:
+        """Return baseline headers aligned with the REST client brand."""
+
+        headers = {
+            "User-Agent": self._user_agent or USER_AGENT,
+            "Accept-Language": ACCEPT_LANGUAGE,
+        }
+        if self._requested_with:
+            headers["X-Requested-With"] = self._requested_with
+        if origin:
+            headers["Origin"] = origin
+        return headers
+
+    def _redact_value(self, value: str) -> str:
+        """Return a redacted representation of sensitive values."""
+
+        trimmed = value.strip()
+        if not trimmed:
+            return ""
+        if len(trimmed) <= 4:
+            return "***"
+        if len(trimmed) <= 8:
+            return f"{trimmed[:2]}***{trimmed[-2:]}"
+        return f"{trimmed[:4]}...{trimmed[-4:]}"
+
+    def _mask_identifier(self, value: str) -> str:
+        """Return a partially masked identifier for log output."""
+
+        trimmed = value.strip()
+        if not trimmed:
+            return ""
+        if len(trimmed) <= 4:
+            return "***"
+        if len(trimmed) <= 8:
+            return f"{trimmed[:2]}...{trimmed[-2:]}"
+        prefix = trimmed[:6]
+        suffix = trimmed[-4:]
+        return f"{prefix}...{suffix}"
+
+    def _sanitise_headers(self, headers: Mapping[str, Any]) -> dict[str, Any]:
+        """Redact sensitive header values for logging."""
+
+        sanitised: dict[str, Any] = {}
+        for key, value in headers.items():
+            text: str
+            if isinstance(value, bytes):
+                text = value.decode(errors="ignore")
+            else:
+                text = str(value)
+            if key.lower() == "authorization":
+                prefix, _, token = text.partition(" ")
+                if token:
+                    text = f"{prefix} {self._redact_value(token)}".strip()
+                else:
+                    text = self._redact_value(text)
+            elif key.lower() in {"cookie", "set-cookie"}:
+                text = self._redact_value(text)
+            sanitised[key] = text
+        return sanitised
+
+    def _sanitise_params(self, params: Mapping[str, str]) -> dict[str, str]:
+        """Redact sensitive query parameter values for logging."""
+
+        sanitised: dict[str, str] = {}
+        for key, value in params.items():
+            if key == "token":
+                sanitised[key] = self._redact_value(str(value))
+            elif key == "dev_id":
+                sanitised[key] = self._mask_identifier(str(value))
+            else:
+                sanitised[key] = value
+        return sanitised
+
+    def _sanitise_url(self, url: str) -> str:
+        """Return a redacted representation of the websocket URL."""
+
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            return url
+        query_items = parse_qsl(parsed.query, keep_blank_values=True)
+        sanitised_pairs = [
+            (
+                key,
+                self._redact_value(value)
+                if key == "token"
+                else self._mask_identifier(value)
+                if key == "dev_id"
+                else value,
+            )
+            for key, value in query_items
+        ]
+        sanitised_query = urlencode(sanitised_pairs, doseq=True)
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, sanitised_query, parsed.fragment))
+
+
+    # ------------------------------------------------------------------
+    # Public control
+    # ------------------------------------------------------------------
+    def _wrap_background_task(
+        self, target: Any, *args: Any, **kwargs: Any
+    ) -> asyncio.Task:
+        """Schedule socket.io background tasks on the HA loop."""
+        coro = target(*args, **kwargs)
+        if not asyncio.iscoroutine(coro):
+
+            async def _runner() -> Any:
+                return coro
+
+            coro = _runner()
+        return self._loop.create_task(coro)
+
+    def start(self) -> asyncio.Task:
+        """Start the websocket client background task."""
+        if self._task and not self._task.done():
+            return self._task
+        _LOGGER.debug("WS: start requested")
+        self._closing = False
+        self._stop_event = asyncio.Event()
+        self._handshake_logged = False
+        self._subscription_refresh_failed = False
+        self._task = self._loop.create_task(
+            self._runner(), name=f"{DOMAIN}-ws-{self.dev_id}"
+        )
+        return self._task
+
+    async def stop(self) -> None:
+        """Cancel tasks and close websocket sessions."""
+        _LOGGER.debug("WS: stop requested")
+        self._closing = True
+        self._stop_event.set()
+        if self._idle_restart_task:
+            self._idle_restart_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._idle_restart_task
+            self._idle_restart_task = None
+        self._idle_restart_pending = False
+        if self._idle_monitor_task:
+            self._idle_monitor_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._idle_monitor_task
+            self._idle_monitor_task = None
+        self._subscription_refresh_failed = False
+        await self._disconnect(reason="client stop")
+        if self._task:
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        self._update_status("stopped")
+
+    def is_running(self) -> bool:
+        """Return True if the websocket client task is active."""
+        return bool(self._task and not self._task.done())
+
+    async def ws_url(self) -> str:
+        """Return the websocket URL using the API client's token helper."""
+
+        url, _ = await self._build_engineio_target()
+        return url
+
+    async def debug_probe(self) -> None:
+        """Emit a dev_data probe for debugging purposes."""
+
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        try:
+            await self._sio.emit("dev_data", namespace=self._namespace)
+            _LOGGER.debug("WS: debug probe dev_data emitted")
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("WS: debug probe dev_data emit failed", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Core loop and protocol dispatch
+    # ------------------------------------------------------------------
+    async def _runner(self) -> None:
+        """Manage connection attempts with backoff."""
+        self._update_status("starting")
+        try:
+            while not self._closing:
+                error: Exception | None = None
+                try:
+                    await self._connect_once()
+                    await self._wait_for_events()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as err:  # noqa: BLE001
+                    error = err
+                    _LOGGER.info(
+                        "WS: connection error (%s: %s); will retry",
+                        type(err).__name__,
+                        err,
+                    )
+                    _LOGGER.debug("WS: connection error details", exc_info=True)
+                finally:
+                    await self._disconnect(reason="loop cleanup")
+                    if not self._closing:
+                        self._update_status("disconnected")
+                        await self._handle_connection_lost(error)
+                if self._closing:
+                    break
+                delay = self._backoff_seq[
+                    min(self._backoff_idx, len(self._backoff_seq) - 1)
+                ]
+                self._backoff_idx = min(
+                    self._backoff_idx + 1, len(self._backoff_seq) - 1
+                )
+                await asyncio.sleep(delay * random.uniform(0.8, 1.2))
+        finally:
+            self._update_status("stopped")
+
+    async def _handle_connection_lost(self, error: Exception | None) -> None:
+        """Record connection loss metadata before the next restart."""
+
+        state = self._ws_state_bucket()
+        restart_count = int(state.get("restart_count") or 0) + 1
+        state["restart_count"] = restart_count
+        state["last_disconnect_at"] = time.time()
+        state["last_disconnect_error"] = (
+            f"{type(error).__name__}: {error}" if error else None
+        )
+
+    async def _connect_once(self) -> None:
+        """Open the Socket.IO connection."""
+        if self._stop_event.is_set():
+            return
+        url, engineio_path = await self._build_engineio_target()
+        _LOGGER.debug("WS: connecting to %s (path=%s)", url, engineio_path)
+        self._disconnected.clear()
+        self._backoff_idx = 0
+        await self._sio.connect(
+            url,
+            transports=["websocket"],
+            namespaces=[self._namespace],
+            socketio_path=engineio_path,
+            wait=True,
+            wait_timeout=15,
+        )
+
+    async def _wait_for_events(self) -> None:
+        """Wait for the connection to close or stop to be requested."""
+        stop_task = self._loop.create_task(self._stop_event.wait())
+        disconnect_task = self._loop.create_task(self._disconnected.wait())
+        try:
+            done, pending = await asyncio.wait(
+                [stop_task, disconnect_task], return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+            for task in done:
+                with suppress(asyncio.CancelledError):
+                    await task
+        finally:
+            stop_task.cancel()
+            disconnect_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await stop_task
+            with suppress(asyncio.CancelledError):
+                await disconnect_task
+
+    async def _disconnect(self, *, reason: str) -> None:
+        """Ensure the AsyncClient is disconnected."""
+        if self._sio.connected:
+            try:
+                await self._sio.disconnect()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("WS: disconnect due to %s failed", reason, exc_info=True)
+        self._disconnected.set()
+
+    async def _build_engineio_target(self) -> tuple[str, str]:
+        """Return the Engine.IO base URL and path."""
+        token = await self._get_token()
+        base = self._api_base().rstrip("/")
+        parsed = urlsplit(base if base else API_BASE)
+        scheme = parsed.scheme or "https"
+        netloc = parsed.netloc or parsed.path
+        if not netloc:
+            raise RuntimeError("invalid API base")
+        query = urlencode({"token": token, "dev_id": self.dev_id})
+        url = urlunsplit((scheme, netloc, "/socket.io", query, ""))
+        return url, "socket.io"
+        query = urlencode({"token": token, "dev_id": self.dev_id})
+        url = urlunsplit((scheme, netloc, "/socket.io", query, ""))
+        return url, "socket.io"
+
+    # ------------------------------------------------------------------
+    # Socket.IO event handlers
+    # ------------------------------------------------------------------
+    async def _on_connect(self) -> None:
+        """Handle socket connection establishment."""
+        _LOGGER.debug("WS: connected")
+        now = time.time()
+        self._connected_since = now
+        self._healthy_since = None
+        self._last_event_at = now
+        self._stats.frames_total = 0
+        self._stats.events_total = 0
+        self._handshake_logged = False
+        self._subscription_refresh_failed = False
+        self._update_status("connected")
+        if self._idle_monitor_task is None or self._idle_monitor_task.done():
+            self._idle_monitor_task = self._loop.create_task(self._idle_monitor())
+        self._register_debug_catch_all()
+
+    async def _on_namespace_connect(self) -> None:
+        """Join the namespace and request the initial snapshot."""
+
+        try:
+            if self._namespace != "/":
+                await self._sio.emit("join", namespace=self._namespace)
+            await self._sio.emit("dev_data", namespace=self._namespace)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("WS: namespace join failed", exc_info=True)
+
+    def _register_debug_catch_all(self) -> None:
+        """Register a catch-all listener to trace websocket traffic when debugging."""
+
+        if self._debug_catch_all_registered:
+            return
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+
+        async def _log_catch_all(event: str, *args: Any, **kwargs: Any) -> None:
+            """Emit DEBUG logs for all websocket events received."""
+
+            if not _LOGGER.isEnabledFor(logging.DEBUG):
+                return
+            _LOGGER.debug(
+                "WS: catch-all (%s) event=%s args=%s kwargs=%s",
+                self._namespace,
+                event,
+                args,
+                kwargs,
+            )
+
+        self._sio.on("*", handler=_log_catch_all, namespace=self._namespace)
+        self._debug_catch_all_registered = True
+
+    async def _on_disconnect(self) -> None:
+        """Handle socket disconnection."""
+        _LOGGER.debug("WS: disconnected")
+        if self._idle_monitor_task:
+            self._idle_monitor_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._idle_monitor_task
+            self._idle_monitor_task = None
+        self._subscription_refresh_failed = False
+        self._handshake_logged = False
+        self._disconnected.set()
+
+    async def _on_reconnect(self) -> None:
+        """Handle socket reconnection attempts."""
+        _LOGGER.debug("WS: reconnect event")
+        await self._subscribe_heater_samples()
+
+    async def _on_connect_error(self, data: Any) -> None:
+        """Log ``connect_error`` events with their payload."""
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("WS: connect_error payload: %s", data)
+
+    async def _on_error(self, data: Any) -> None:
+        """Log socket.io ``error`` events with full details."""
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("WS: error event payload: %s", data)
+
+    async def _on_reconnect_failed(self, data: Any | None = None) -> None:
+        """Log ``reconnect_failed`` events with the reported context."""
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("WS: reconnect_failed details: %s", data)
+
+    async def _on_namespace_disconnect(self, reason: Any | None = None) -> None:
+        """Log namespace-level disconnect callbacks with their reason."""
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("WS: namespace disconnect (%s): %s", self._namespace, reason)
+
+    async def _on_dev_handshake(self, data: Any) -> None:
+        """Handle the ``dev_handshake`` payload."""
+        self._stats.frames_total += 1
+        if not self._handshake_logged and _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("WS: dev_handshake payload: %s", data)
+            self._handshake_logged = True
+        self._handle_handshake(data)
+
+    async def _on_dev_data(self, data: Any) -> None:
+        """Handle the ``dev_data`` payload."""
+        self._stats.frames_total += 1
+        self._handle_dev_data(data)
+        await self._subscribe_heater_samples()
+
+    async def _on_update(self, data: Any) -> None:
+        """Handle the ``update`` payload."""
+        self._stats.frames_total += 1
+        self._handle_update(data)
+
+    async def _idle_monitor(self) -> None:
+        """Monitor idle websocket periods and trigger restarts."""
+        while not self._closing:
+            await asyncio.sleep(60)
+            if not self._sio.connected:
+                if self._disconnected.is_set():
+                    break
+                continue
+            last_event = self._last_event_at or self._stats.last_event_ts
+            if not last_event:
+                continue
+            idle_for = time.time() - last_event
+            if idle_for >= self._payload_idle_window:
+                _LOGGER.info("WS: idle for %.0fs; refreshing websocket lease", idle_for)
+                try:
+                    await self._refresh_subscription(reason="idle monitor")
+                except asyncio.CancelledError:  # pragma: no cover - task lifecycle
+                    raise
+                except Exception:  # noqa: BLE001
+                    self._schedule_idle_restart(
+                        idle_for=idle_for, source="idle monitor refresh failed"
+                    )
+                    break
+                continue
+            if self._subscription_refresh_failed:
+                # Retry quickly if the last scheduled renewal failed.
+                _LOGGER.info(
+                    "WS: retrying websocket lease after failure; idle for %.0fs",
+                    idle_for,
+                )
+                try:
+                    await self._refresh_subscription(reason="idle monitor retry")
+                except asyncio.CancelledError:  # pragma: no cover - task lifecycle
+                    raise
+                except Exception:  # noqa: BLE001
+                    self._schedule_idle_restart(
+                        idle_for=idle_for, source="idle monitor retry failed"
+                    )
+                    break
+
+    async def _refresh_subscription(self, *, reason: str) -> None:
+        """Re-request device data to keep the websocket session active."""
+
+        async with self._subscription_refresh_lock:
+            if not self._sio.connected:
+                raise RuntimeError("websocket not connected")
+            now = time.time()
+            self._subscription_refresh_last_attempt = now
+            if _LOGGER.isEnabledFor(logging.INFO):
+                _LOGGER.info("WS: refreshing websocket lease (%s)", reason)
+            await self._sio.emit("dev_data", namespace=self._namespace)
+            await self._subscribe_heater_samples()
+            self._subscription_refresh_failed = False
+            self._subscription_refresh_last_success = time.time()
+    # ------------------------------------------------------------------
+    # Payload handlers
+    # ------------------------------------------------------------------
+    def _handle_handshake(self, data: Any) -> None:
+        """Process the initial handshake payload from the server."""
+        if isinstance(data, dict):
+            self._handshake_payload = deepcopy(data)
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "WS: dev_handshake payload keys: %s", ", ".join(sorted(data.keys()))
+                )
+            self._update_status("connected")
+        else:
+            _LOGGER.debug("WS: invalid handshake payload")
+
+    def _handle_dev_data(self, data: Any) -> None:
+        """Handle the first full snapshot of nodes from the websocket."""
+        self._apply_nodes_payload(data, merge=False, event="dev_data")
+
+    def _handle_update(self, data: Any) -> None:
+        """Merge incremental node updates from the websocket feed."""
+        self._apply_nodes_payload(data, merge=True, event="update")
+
+    def _apply_nodes_payload(self, payload: Any, *, merge: bool, event: str) -> None:
+        """Update cached nodes from the websocket payload and notify listeners."""
+        nodes = self._extract_nodes(payload)
+        if nodes is None:
+            nodes = self._translate_path_update(payload)
+        if nodes is None:
+            _LOGGER.debug("WS: %s without nodes", event)
+            return
+        normaliser = getattr(self._client, "normalise_ws_nodes", None)
+        if callable(normaliser):
+            try:
+                nodes = normaliser(nodes)  # type: ignore[arg-type]
+            except Exception:  # noqa: BLE001  # pragma: no cover - defensive logging only
+                _LOGGER.debug("WS: normalise_ws_nodes failed; using raw payload")
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            changed = self._collect_update_addresses(nodes)
+            if merge:
+                if changed:
+                    _LOGGER.debug(
+                        "WS: update event for %s",
+                        ", ".join(f"{node_type}/{addr}" for node_type, addr in changed),
+                    )
+                else:
+                    _LOGGER.debug("WS: update event without address changes")
+            else:
+                _LOGGER.debug(
+                    "WS: dev_data snapshot contains %d node groups", len(nodes)
+                )
+        sample_updates: dict[str, dict[str, Any]] = {}
+        for node_type, type_payload in nodes.items():
+            if not isinstance(node_type, str) or not isinstance(type_payload, Mapping):
+                continue
+            samples = type_payload.get("samples")
+            if not isinstance(samples, Mapping):
+                continue
+            bucket: dict[str, Any] = {}
+            for addr, sample_payload in samples.items():
+                normalised_addr = normalize_node_addr(addr)
+                if not normalised_addr:
+                    continue
+                bucket[normalised_addr] = sample_payload
+            if bucket:
+                sample_updates[node_type] = bucket
+
+        if merge and self._nodes_raw:
+            self._merge_nodes(self._nodes_raw, nodes)
+        else:
+            self._nodes_raw = deepcopy(nodes)
+        self._nodes = self._build_nodes_snapshot(self._nodes_raw)
+        self._dispatch_nodes(self._nodes)
+        if sample_updates:
+            self._forward_sample_updates(sample_updates)
+        self._mark_event(paths=None, count_event=True)
+
+    def _translate_path_update(self, payload: Any) -> dict[str, Any] | None:
+        """Translate Ducaheat ``{"path": ..., "body": ...}`` frames into nodes."""
+
+        if not isinstance(payload, Mapping):
+            return None
+        if "nodes" in payload:
+            return None
+        path = payload.get("path")
+        body = payload.get("body")
+        if not isinstance(path, str) or body is None:
+            return None
+
+        path = path.split("?", 1)[0]
+        segments = [segment for segment in path.split("/") if segment]
+        if not segments:
+            return None
+
+        try:
+            devs_idx = segments.index("devs")
+        except ValueError:
+            devs_idx = -1
+
+        if devs_idx >= 0:
+            relevant = segments[devs_idx + 1 :]
+            node_type_idx = 1
+            addr_idx = 2
+            section_idx = 3
+            if len(relevant) <= addr_idx:
+                return None
+        else:
+            relevant = segments
+            node_type_idx = 0
+            addr_idx = 1
+            section_idx = 2
+            if len(relevant) <= addr_idx:
+                return None
+
+        node_type = normalize_node_type(relevant[node_type_idx])
+        addr = normalize_node_addr(relevant[addr_idx])
+        if not node_type or not addr:
+            return None
+
+        section = relevant[section_idx] if len(relevant) > section_idx else None
+        remainder = (
+            relevant[section_idx + 1 :]
+            if len(relevant) > section_idx + 1
+            else []
+        )
+
+        target_section, nested_key = self._resolve_update_section(section)
+        if target_section is None:
+            return None
+
+        payload_body: Any = body
+        for segment in reversed(remainder):
+            payload_body = {segment: payload_body}
+        if nested_key:
+            payload_body = {nested_key: payload_body}
+
+        return {node_type: {target_section: {addr: payload_body}}}
+
+    @staticmethod
+    def _resolve_update_section(section: str | None) -> tuple[str | None, str | None]:
+        """Map a websocket path segment onto the node bucket name."""
+
+        if not section:
+            return None, None
+
+        lowered = section.lower()
+        if lowered in {"status", "samples", "settings", "advanced"}:
+            return lowered, None
+        if lowered in {"advanced_setup"}:
+            return "advanced", "advanced_setup"
+        if lowered in {"setup", "prog", "prog_temps", "capabilities"}:
+            return "settings", lowered
+        return "settings", lowered
+
+    def _forward_sample_updates(self, updates: Mapping[str, Mapping[str, Any]]) -> None:
+        """Relay websocket heater sample updates to the energy coordinator."""
+
+        record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
+        if not isinstance(record, Mapping):
+            return
+        energy_coordinator = record.get("energy_coordinator")
+        handler = getattr(energy_coordinator, "handle_ws_samples", None)
+        if not callable(handler):
+            return
+        try:
+            handler(
+                self.dev_id,
+                {node_type: dict(section) for node_type, section in updates.items()},
+            )
+        except Exception:  # noqa: BLE001  # pragma: no cover - defensive logging
+            _LOGGER.debug("WS: forwarding heater samples failed", exc_info=True)
+
+    def _extract_nodes(self, data: Any) -> dict[str, Any] | None:
+        """Extract the nodes dictionary from a websocket payload."""
+        if not isinstance(data, dict):
+            return None
+        nodes = data.get("nodes")
+        if isinstance(nodes, dict):
+            return nodes
+        if isinstance(nodes, list):
+            mapped = self._translate_nodes_list(nodes)
+            data["nodes"] = mapped
+            return mapped
+        return None
+
+    def _translate_nodes_list(
+        self, nodes: Iterable[Any]
+    ) -> dict[str, dict[str, dict[str, Any]]]:
+        """Convert list-based node payloads into the nested mapping schema."""
+
+        translated: dict[str, dict[str, dict[str, Any]]] = {}
+        for entry in nodes:
+            if not isinstance(entry, Mapping):
+                continue
+            node_type = normalize_node_type(entry.get("type"))
+            addr = normalize_node_addr(entry.get("addr"))
+            if not node_type or not addr:
+                continue
+            node_bucket = translated.setdefault(node_type, {})
+            added = False
+            for key, value in entry.items():
+                if key in {"type", "addr"}:
+                    continue
+                if not isinstance(key, str):
+                    continue
+                section, nested_key = self._resolve_update_section(key)
+                if section is None:
+                    continue
+                section_bucket = node_bucket.setdefault(section, {})
+                if nested_key:
+                    existing = section_bucket.get(addr)
+                    if isinstance(existing, Mapping):
+                        merged = dict(existing)
+                    else:
+                        merged = {}
+                    merged[nested_key] = deepcopy(value)
+                    section_bucket[addr] = merged
+                else:
+                    section_bucket[addr] = deepcopy(value)
+                added = True
+            if not added and not node_bucket:
+                translated.pop(node_type, None)
+        return translated
+    @staticmethod
+    def _collect_update_addresses(nodes: Mapping[str, Any]) -> list[tuple[str, str]]:
+        """Return a sorted list of ``(node_type, addr)`` pairs in ``nodes``."""
+
+        found: set[tuple[str, str]] = set()
+        for node_type, payload in nodes.items():
+            if not isinstance(node_type, str) or not isinstance(payload, Mapping):
+                continue
+            for section in payload.values():
+                if not isinstance(section, Mapping):
+                    continue
+                for addr, value in section.items():
+                    if isinstance(addr, str) and value is not None:
+                        found.add((node_type, addr))
+        return sorted(found)
+
+    def _dispatch_nodes(self, payload: dict[str, Any]) -> dict[str, list[str]]:
+        """Publish node updates and return the address map by node type."""
+
+        if not isinstance(payload, dict):  # pragma: no cover - defensive
+            return {}
+
+        is_snapshot = isinstance(payload.get("nodes_by_type"), dict)
+        raw_nodes: Any
+        snapshot: dict[str, Any]
+
+        if is_snapshot:
+            snapshot = payload
+            raw_nodes = snapshot.get("nodes")
+        else:
+            raw_nodes = payload
+            snapshot = {"nodes": deepcopy(raw_nodes), "nodes_by_type": {}}
+
+        record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
+        snapshot_obj = ensure_snapshot(record)
+        if isinstance(snapshot_obj, InstallationSnapshot):
+            snapshot_obj.update_nodes(raw_nodes)
+            inventory = snapshot_obj.inventory
+            if isinstance(record, dict):
+                record["node_inventory"] = list(inventory)
+        else:
+            record_map: Mapping[str, Any]
+            if isinstance(record, Mapping):
+                record_map = record
+            else:
+                record_map = {}  # pragma: no cover - defensive default
+
+            inventory = ensure_node_inventory(record_map, nodes=raw_nodes)
+
+        addr_map, unknown_types = addresses_by_node_type(
+            inventory, known_types=NODE_CLASS_BY_TYPE
+        )
+        if unknown_types:  # pragma: no cover - diagnostic branch
+            _LOGGER.debug(
+                "WS: unknown node types in inventory: %s",
+                ", ".join(sorted(unknown_types)),
+            )
+
+        if not is_snapshot:  # pragma: no cover - legacy branch
+            nodes_by_type = {
+                node_type: {"addrs": list(addrs)}
+                for node_type, addrs in addr_map.items()
+            }
+            snapshot["nodes_by_type"] = nodes_by_type
+            if "htr" in nodes_by_type:
+                snapshot.setdefault("htr", nodes_by_type["htr"])
+
+        if raw_nodes is None:  # pragma: no cover - defensive default
+            raw_nodes = {}
+
+        if hasattr(self._coordinator, "update_nodes"):
+            self._coordinator.update_nodes(raw_nodes, inventory)
+
+        if isinstance(record, dict) and snapshot_obj is None:
+            record["nodes"] = raw_nodes
+            record["node_inventory"] = inventory
+
+        self._apply_heater_addresses(addr_map, inventory=None)
+
+        payload_copy = {
+            "dev_id": self.dev_id,
+            "node_type": None,
+            "nodes": deepcopy(snapshot.get("nodes")),
+            "nodes_by_type": deepcopy(snapshot.get("nodes_by_type", {})),
+        }
+        payload_copy.setdefault(
+            "addr_map",
+            {node_type: list(addrs) for node_type, addrs in addr_map.items()},
+        )
+        if unknown_types:
+            payload_copy.setdefault("unknown_types", sorted(unknown_types))
+
+        def _send() -> None:
+            """Fire the dispatcher signal with the latest node payload."""
+
+            async_dispatcher_send(
+                self.hass, signal_ws_data(self.entry_id), payload_copy
+            )
+
+        loop = getattr(self.hass, "loop", None)
+        call_soon = getattr(loop, "call_soon_threadsafe", None)
+        if callable(call_soon):
+            call_soon(_send)
+        else:  # pragma: no cover - legacy hass loop stub
+            _send()
+
+        return {node_type: list(addrs) for node_type, addrs in addr_map.items()}
+
+    def _ensure_type_bucket(
+        self, dev_map: dict[str, Any], nodes_by_type: dict[str, Any], node_type: str
+    ) -> dict[str, Any]:
+        """Return the node bucket for ``node_type`` with default sections."""
+        bucket = nodes_by_type.get(node_type)
+        if bucket is None:
+            bucket = {
+                "addrs": [],
+                "settings": {},
+                "advanced": {},
+                "samples": {},
+            }
+            nodes_by_type[node_type] = bucket
+        else:
+            bucket.setdefault("addrs", [])
+            bucket.setdefault("settings", {})
+            bucket.setdefault("advanced", {})
+            bucket.setdefault("samples", {})
+        if node_type == "htr":
+            dev_map["htr"] = bucket
+        return bucket
+
+    def _apply_heater_addresses(
+        self,
+        addr_map: Mapping[Any, Iterable[Any]] | Iterable[Any] | None,
+        *,
+        inventory: list[Any] | None = None,
+    ) -> dict[str, list[str]]:
+        """Update entry and coordinator state with heater address data."""
+
+        normalized_map, _compat_aliases = normalize_heater_addresses(addr_map)
+        record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
+        snapshot_obj = ensure_snapshot(record)
+        if isinstance(snapshot_obj, InstallationSnapshot) and inventory is not None:
+            snapshot_obj.update_nodes(snapshot_obj.raw_nodes, node_inventory=inventory)
+            if isinstance(record, dict):
+                record["node_inventory"] = list(snapshot_obj.inventory)
+
+        if isinstance(record, dict) and snapshot_obj is None:
+            if inventory is not None:
+                record["node_inventory"] = inventory
+            energy_coordinator = record.get("energy_coordinator")
+            if hasattr(energy_coordinator, "update_addresses"):
+                energy_coordinator.update_addresses(normalized_map)
+        else:
+            energy_coordinator = (
+                record.get("energy_coordinator")
+                if isinstance(record, Mapping)
+                else None
+            )
+            if hasattr(energy_coordinator, "update_addresses"):
+                energy_coordinator.update_addresses(normalized_map)
+
+        coordinator_data = getattr(self._coordinator, "data", None)
+        if isinstance(coordinator_data, dict):
+            dev_map = coordinator_data.get(self.dev_id)
+            if isinstance(dev_map, dict):
+                nodes_by_type: dict[str, Any] = dev_map.setdefault("nodes_by_type", {})
+                for node_type, addrs in normalized_map.items():
+                    if not addrs and node_type != "htr":
+                        continue
+                    bucket = self._ensure_type_bucket(dev_map, nodes_by_type, node_type)
+                    if addrs:
+                        bucket["addrs"] = list(addrs)
+                updated = dict(coordinator_data)
+                updated[self.dev_id] = dev_map
+                self._coordinator.data = updated  # type: ignore[attr-defined]
+
+        return normalized_map
+
+    def _heater_sample_subscription_targets(self) -> list[tuple[str, str]]:
+        """Return ordered ``(node_type, addr)`` heater sample subscriptions."""
+
+        record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
+        inventory, normalized_map, _ = collect_heater_sample_addresses(
+            record, coordinator=self._coordinator
+        )
+        normalized_map = self._apply_heater_addresses(
+            normalized_map, inventory=inventory or None
+        )
+        return heater_sample_subscription_targets(normalized_map)
+
+    async def _subscribe_heater_samples(self) -> None:
+        """Subscribe to heater and accumulator sample updates."""
+
+        try:
+            for node_type, addr in self._heater_sample_subscription_targets():
+                await self._sio.emit(
+                    "subscribe",
+                    f"/{node_type}/{addr}/samples",
+                    namespace=self._namespace,
+                )
+        except asyncio.CancelledError:  # pragma: no cover - task lifecycle
+            raise
+        except Exception:  # noqa: BLE001 - defensive logging
+            _LOGGER.debug("WS: sample subscription setup failed", exc_info=True)
+
+    @staticmethod
+    def _build_nodes_snapshot(nodes: dict[str, Any]) -> dict[str, Any]:
+        """Normalise the nodes payload for consumers."""
+        nodes_copy = deepcopy(nodes)
+        nodes_by_type: dict[str, Any] = {
+            node_type: payload
+            for node_type, payload in nodes_copy.items()
+            if isinstance(payload, dict)
+        }
+        snapshot: dict[str, Any] = {
+            "nodes": nodes_copy,
+            "nodes_by_type": nodes_by_type,
+        }
+        snapshot.update(nodes_by_type)
+        if "htr" in nodes_by_type:
+            snapshot.setdefault("htr", nodes_by_type["htr"])
+        return snapshot
+
+    @staticmethod
+    def _merge_nodes(target: dict[str, Any], source: dict[str, Any]) -> None:
+        """Deep-merge incremental node updates into the stored snapshot."""
+        for key, value in source.items():
+            if isinstance(value, dict):
+                existing = target.get(key)
+                if isinstance(existing, dict):
+                    WebSocketClient._merge_nodes(existing, value)
+                else:
+                    target[key] = deepcopy(value)
+            else:
+                target[key] = value
+
+    # ------------------------------------------------------------------
+    # Helpers shared across implementations
+    # ------------------------------------------------------------------
+    def _ws_state_bucket(self) -> dict[str, Any]:
+        """Return the websocket state bucket for this device."""
+        if self._ws_state is None:
+            if not hasattr(self.hass, "data") or self.hass.data is None:  # type: ignore[attr-defined]
+                setattr(self.hass, "data", {})  # type: ignore[attr-defined]
+            domain_bucket = self.hass.data.setdefault(DOMAIN, {})  # type: ignore[attr-defined]
+            entry_bucket = domain_bucket.setdefault(self.entry_id, {})
+            ws_state = entry_bucket.setdefault("ws_state", {})
+            self._ws_state = ws_state.setdefault(self.dev_id, {})
+        return self._ws_state
+
+    def _update_status(self, status: str) -> None:
+        """Publish the websocket status to Home Assistant listeners."""
+        if status == self._status and status not in {"healthy", "connected"}:
+            return
+        self._status = status
+        now = time.time()
+        state = self._ws_state_bucket()
+        last_event = self._stats.last_event_ts or self._last_event_at
+        state["status"] = status
+        state["last_event_at"] = last_event or None
+        state["healthy_since"] = self._healthy_since
+        state["healthy_minutes"] = (
+            int((now - self._healthy_since) / 60) if self._healthy_since else 0
+        )
+        state["frames_total"] = self._stats.frames_total
+        state["events_total"] = self._stats.events_total
+        async_dispatcher_send(
+            self.hass,
+            signal_ws_status(self.entry_id),
+            {"dev_id": self.dev_id, "status": status},
+        )
+
+    def _mark_event(
+        self, *, paths: list[str] | None, count_event: bool = False
+    ) -> None:
+        """Record receipt of a websocket event batch for health tracking."""
+        now = time.time()
+        self._cancel_idle_restart()
+        self._stats.last_event_ts = now
+        self._last_event_at = now
+        self._last_payload_at = now
+        if paths:
+            self._stats.events_total += 1
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                uniq: list[str] = []
+                for path in paths:
+                    if path not in uniq:
+                        uniq.append(path)
+                    if len(uniq) >= 5:
+                        break
+                self._stats.last_paths = uniq
+        elif count_event:
+            self._stats.events_total += 1
+        state: dict[str, Any] = self._ws_state_bucket()
+        state["last_event_at"] = now
+        state["last_payload_at"] = self._last_payload_at
+        state["frames_total"] = self._stats.frames_total
+        state["events_total"] = self._stats.events_total
+        if self._healthy_since is None:
+            self._healthy_since = now
+            self._update_status("healthy")
+
+    def _schedule_idle_restart(self, *, idle_for: float, source: str) -> None:
+        """Log idle payload detection and close the websocket for restart."""
+
+        if self._closing or self._idle_restart_pending:
+            return
+        self._idle_restart_pending = True
+        self._ws_state_bucket()["idle_restart_pending"] = True
+        _LOGGER.warning(
+            "WS: no payloads for %.0f s (%s heartbeat); restarting", idle_for, source
+        )
+
+        async def _restart() -> None:
+            try:
+                await self._disconnect(reason="idle restart")
+            finally:
+                self._idle_restart_pending = False
+                self._idle_restart_task = None
+                self._ws_state_bucket()["idle_restart_pending"] = False
+
+        self._idle_restart_task = self._loop.create_task(_restart())
+
+    def _cancel_idle_restart(self) -> None:
+        """Cancel any scheduled idle restart due to new payload activity."""
+
+        task = self._idle_restart_task
+        if task and not task.done():
+            task.cancel()
+        self._idle_restart_task = None
+        self._idle_restart_pending = False
+        self._ws_state_bucket()["idle_restart_pending"] = False
+
+    async def _get_token(self) -> str:
+        """Reuse the REST client token for websocket authentication."""
+        headers = await self._client._authed_headers()  # noqa: SLF001
+        auth_header = (
+            headers.get("Authorization") if isinstance(headers, dict) else None
+        )
+        if not auth_header:
+            raise RuntimeError("authorization token missing")
+        return auth_header.split(" ", 1)[1]
+
+    async def _force_refresh_token(self) -> None:
+        """Force the REST client to fetch a fresh access token."""
+        with suppress(AttributeError, RuntimeError):
+            self._client._access_token = None  # type: ignore[attr-defined]  # noqa: SLF001
+        await self._client._ensure_token()  # noqa: SLF001
+
+    def _api_base(self) -> str:
+        """Return the base REST API URL used for websocket routes."""
+        base = getattr(self._client, "api_base", None)
+        if isinstance(base, str) and base:
+            return base.rstrip("/")
+        return API_BASE
+
+# ----------------------------------------------------------------------
+# Legacy Socket.IO 0.9 client
+# ----------------------------------------------------------------------
+
+
+class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network client
+    """Legacy Socket.IO 0.9 websocket client for TermoWeb."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry_id: str,
+        dev_id: str,
+        api_client: RESTClient,
+        coordinator: Any,
+        session: aiohttp.ClientSession | None = None,
+        handshake_fail_threshold: int = 5,
+        protocol: str | None = None,
+    ) -> None:
+        """Initialise the legacy websocket client container."""
+
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self._client = api_client
+        self._coordinator = coordinator
+        self._session = session or getattr(api_client, "_session", None)
+        if self._session is None:
+            raise RuntimeError("aiohttp session required for websocket client")
+        self._protocol_hint = protocol
+        self._loop = getattr(hass, "loop", None) or asyncio.get_event_loop()
+        self._task: asyncio.Task | None = None
+        self._namespace = WS_NAMESPACE
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._disconnected = asyncio.Event()
+        self._disconnected.set()
+
+        self._user_agent = get_brand_user_agent(BRAND_TERMOWEB)
+        self._requested_with = get_brand_requested_with(BRAND_TERMOWEB)
+
+        self._closing = False
+        self._connected_since: float | None = None
+        self._healthy_since: float | None = None
+        self._hb_send_interval: float = 27.0
+        self._hb_task: asyncio.Task | None = None
+        self._rtc_keepalive_task: asyncio.Task | None = None
+        self._rtc_keepalive_interval: float = 30.0
+
+        self._backoff_seq = [5, 10, 30, 120, 300]
+        self._backoff_idx = 0
+        self._hs_fail_threshold = handshake_fail_threshold
+        self._hs_fail_count: int = 0
+        self._hs_fail_start: float = 0.0
+
+        self._stats = WSStats()
+        self._status: str = "stopped"
+        self._stop_event = asyncio.Event()
+        self._handshake_logged = False
+        self._last_event_at: float | None = None
+        self._last_payload_at: float | None = None
+        self._last_heartbeat_at: float | None = None
+
+        self._handshake_payload: dict[str, Any] | None = None
+        self._nodes: dict[str, Any] = {}
+        self._nodes_raw: dict[str, Any] = {}
+
+        self._payload_idle_window: float = 240.0
+        self._idle_restart_task: asyncio.Task | None = None
+        self._idle_restart_pending = False
+        self._idle_monitor_task: asyncio.Task | None = None
+
+        self._subscription_refresh_lock = asyncio.Lock()
+        self._subscription_refresh_failed = False
+        self._subscription_refresh_last_attempt: float = 0.0
+        self._subscription_refresh_last_success: float | None = None
+
+        self._ws_state: dict[str, Any] | None = None
+        state = self._ws_state_bucket()
+        state.setdefault("last_payload_at", None)
+        state.setdefault("idle_restart_pending", False)
+
+        self._write_hook_installed = False
+        self._write_hook_original: Callable[..., Awaitable[Any]] | None = None
+        self._install_write_hook()
+
+    # ------------------------------------------------------------------
+    # Public control
+    # ------------------------------------------------------------------
+    def _install_write_hook(self) -> None:
+        """Wrap REST writes so we can observe successful node updates."""
+
+        if self._write_hook_installed:
+            return
+        client = self._client
+        original = getattr(client, "set_node_settings", None)
+        if not callable(original):
+            self._write_hook_installed = True
+            return
+
+        watchers: dict[str, weakref.WeakSet[TermoWebWSClient]]
+        watchers = getattr(client, "_tw_ws_write_watchers", None)
+        if watchers is None:
+            watchers = {}
+            setattr(client, "_tw_ws_write_watchers", watchers)
+
+        dev_watchers = watchers.get(self.dev_id)
+        if dev_watchers is None:
+            dev_watchers = weakref.WeakSet()
+            watchers[self.dev_id] = dev_watchers
+        dev_watchers.add(self)
+
+        if not hasattr(client, "_tw_ws_write_wrapper"):
+
+            @wraps(original)
+            async def _wrapped_set_node_settings(*args: Any, **kwargs: Any) -> Any:
+                result = await original(*args, **kwargs)
+                dev_id_arg = kwargs.get("dev_id") if "dev_id" in kwargs else None
+                if dev_id_arg is None and args:
+                    dev_id_arg = args[0]
+                if isinstance(dev_id_arg, str):
+                    hooks = getattr(client, "_tw_ws_write_watchers", {})
+                    watchers_for_dev = hooks.get(dev_id_arg)
+                    if watchers_for_dev:
+                        for ws_client in list(watchers_for_dev):
+                            maybe = getattr(
+                                ws_client, "maybe_restart_after_write", None
+                            )
+                            if maybe is None or not callable(maybe):
+                                continue
+                            try:
+                                await maybe()
+                            except (
+                                asyncio.CancelledError
+                            ):  # pragma: no cover - passthrough
+                                raise
+                            except Exception:  # noqa: BLE001 - defensive logging
+                                _LOGGER.debug(
+                                    "WS: maybe_restart_after_write failed: %s",
+                                    ws_client.dev_id,
+                                    exc_info=True,
+                                )
+                        if not watchers_for_dev:
+                            hooks.pop(dev_id_arg, None)
+                return result
+
+            setattr(client, "set_node_settings", _wrapped_set_node_settings)
+            setattr(client, "_tw_ws_write_wrapper", _wrapped_set_node_settings)
+            setattr(client, "_tw_ws_write_original", original)
+
+        self._write_hook_original = getattr(client, "_tw_ws_write_original", original)
+        self._write_hook_installed = True
+
+    async def maybe_restart_after_write(self) -> None:
+        """Restart the websocket if writes follow long periods of inactivity."""
+
+        last_payload = self._last_payload_at
+        if last_payload is None:
+            last_payload = self._stats.last_event_ts or self._last_event_at
+        if not last_payload:
+            return
+        idle_for = time.time() - last_payload
+        if idle_for < self._payload_idle_window:
+            return
+        if _LOGGER.isEnabledFor(logging.INFO):
+            _LOGGER.info(
+                "WS: write acknowledged after %.0f s without payloads; restarting",
+                idle_for,
+            )
+        self._schedule_idle_restart(idle_for=idle_for, source="write notification")
+
+    async def stop(self) -> None:
+        """Cancel tasks, close websocket sessions and reset legacy state."""
+
+        self._closing = True
+        if self._hb_task:
+            self._hb_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._hb_task
+            self._hb_task = None
+        if self._rtc_keepalive_task:
+            self._rtc_keepalive_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._rtc_keepalive_task
+            self._rtc_keepalive_task = None
+        await super().stop()
+
+    # ------------------------------------------------------------------
+    # Core loop and protocol dispatch
+    # ------------------------------------------------------------------
+    async def _runner(self) -> None:
+        """Manage reconnection attempts and lifecycle."""
+
+        self._update_status("starting")
+        try:
+            await self._run_socketio_09()
+        finally:
+            self._update_status("stopped")
+
+    async def _run_socketio_09(self) -> None:
+        """Manage reconnection loops for the legacy Socket.IO protocol."""
+
+        while not self._closing:
+            should_retry = True
+            try:
+                _LOGGER.debug("WS: initiating Socket.IO 0.9 handshake")
+                sid, hb_timeout = await self._handshake()
+                _LOGGER.debug(
+                    "WS: handshake succeeded sid=%s hb_timeout=%s", sid, hb_timeout
+                )
+                self._hs_fail_count = 0
+                self._hs_fail_start = 0.0
+                self._hb_send_interval = max(5.0, min(30.0, hb_timeout * 0.45))
+                await self._connect_ws(sid)
+                _LOGGER.debug("WS: websocket connection established")
+                await self._join_namespace()
+                await self._send_snapshot_request()
+                await self._subscribe_session_metadata()
+                await self._subscribe_htr_samples()
+                self._connected_since = time.time()
+                self._healthy_since = None
+                self._update_status("connected")
+                if self._idle_monitor_task is None or self._idle_monitor_task.done():
+                    _LOGGER.debug("WS: starting legacy idle monitor")
+                    self._idle_monitor_task = self._loop.create_task(
+                        self._idle_monitor()
+                    )
+                self._hb_task = self._loop.create_task(self._heartbeat_loop())
+                if self._rtc_keepalive_task and not self._rtc_keepalive_task.done():
+                    self._rtc_keepalive_task.cancel()
+                self._rtc_keepalive_task = self._loop.create_task(
+                    self._rtc_keepalive_loop()
+                )
+                await self._read_loop()
+            except asyncio.CancelledError:
+                should_retry = False
+            except HandshakeError as err:
+                self._hs_fail_count += 1
+                if self._hs_fail_count == 1:
+                    self._hs_fail_start = time.time()
+                _LOGGER.info(
+                    "WS: connection error (%s: %s); will retry", type(err).__name__, err
+                )
+                if self._hs_fail_count >= self._hs_fail_threshold:
+                    elapsed = time.time() - self._hs_fail_start
+                    _LOGGER.warning(
+                        "WS: handshake failed %d times over %.1f s",
+                        self._hs_fail_count,
+                        elapsed,
+                    )
+                    self._hs_fail_count = 0
+                    self._hs_fail_start = 0.0
+                _LOGGER.debug(
+                    "WS: handshake error url=%s body=%r",
+                    self._sanitise_url(err.url),
+                    err.body_snippet,
+                )
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.info(
+                    "WS: connection error (%s: %s); will retry", type(err).__name__, err
+                )
+                _LOGGER.debug("WS: connection error details", exc_info=True)
+            finally:
+                if self._hb_task:
+                    self._hb_task.cancel()
+                    self._hb_task = None
+                if self._rtc_keepalive_task:
+                    self._rtc_keepalive_task.cancel()
+                    self._rtc_keepalive_task = None
+                if self._idle_monitor_task:
+                    _LOGGER.debug("WS: stopping legacy idle monitor")
+                    self._idle_monitor_task.cancel()
+                    if hasattr(self._idle_monitor_task, "__await__"):
+                        with suppress(asyncio.CancelledError):
+                            await self._idle_monitor_task
+                    self._idle_monitor_task = None
+                self._subscription_refresh_failed = False
+                if self._ws:
+                    with suppress(aiohttp.ClientError, RuntimeError):
+                        await self._ws.close()
+                    self._ws = None
+                self._update_status("disconnected")
+            if self._closing or not should_retry:
+                break
+            delay = self._backoff_seq[
+                min(self._backoff_idx, len(self._backoff_seq) - 1)
+            ]
+            self._backoff_idx = min(self._backoff_idx + 1, len(self._backoff_seq) - 1)
+            jitter = random.uniform(0.8, 1.2)
+            await asyncio.sleep(delay * jitter)
+
+    async def _handshake(self) -> tuple[str, int]:
+        """Perform the legacy GET /socket.io/1/ handshake."""
+
+        token = await self._get_token()
+        t_ms = int(time.time() * 1000)
+        base = self._api_base()
+        url = f"{base}/socket.io/1/?token={token}&dev_id={self.dev_id}&t={t_ms}"
+        try:
+            async with asyncio.timeout(15):
+                headers = self._brand_headers(origin="https://localhost")
+                async with self._session.get(
+                    url,
+                    timeout=aiohttp.ClientTimeout(total=15),
+                    headers=headers,
+                ) as resp:
+                    body = await resp.text()
+                    if resp.status == 401:
+                        _LOGGER.info("WS: handshake 401; refreshing token")
+                        await self._force_refresh_token()
+                        raise HandshakeError(resp.status, url, body)
+                    if resp.status != 200:
+                        raise HandshakeError(resp.status, url, body)
+        except TimeoutError as err:
+            raise HandshakeError(599, url, "timeout") from err
+        except aiohttp.ClientError as err:
+            raise HandshakeError(598, url, str(err)) from err
+        parts = body.strip().split(":")
+        if len(parts) < 3:
+            raise HandshakeError(590, url, body[:120])
+        sid = parts[0]
+        try:
+            hb_timeout = int(parts[1])
+        except ValueError as err:
+            raise HandshakeError(591, url, body[:120]) from err
+        return sid, hb_timeout
+
+    async def _connect_ws(self, sid: str) -> None:
+        """Open the websocket connection using the handshake session id."""
+
+        token = await self._get_token()
+        ws_url = (
+            f"{self._socket_base()}/socket.io/1/websocket/{sid}"
+            f"?token={token}&dev_id={self.dev_id}"
+        )
+        _LOGGER.info("WS: connecting to %s", self._sanitise_url(ws_url))
+        headers = self._brand_headers(origin="https://localhost")
+        self._ws = await self._session.ws_connect(
+            ws_url,
+            timeout=aiohttp.ClientTimeout(total=15),
+            heartbeat=None,
+            autoclose=False,
+            headers=headers,
+        )
+
+    async def _join_namespace(self) -> None:
+        """Join the API namespace after the websocket connects."""
+
+        await self._send_text(f"1::{self._namespace}")
+
+    async def _send_snapshot_request(self) -> None:
+        """Request the initial device snapshot."""
+
+        payload = {"name": "dev_data", "args": []}
+        await self._send_text(
+            f"5::{self._namespace}:{json.dumps(payload, separators=(',', ':'))}"
+        )
+
+    async def _subscribe_session_metadata(self) -> None:
+        """Subscribe to legacy session metadata updates."""
+
+        payload = {"name": "subscribe", "args": ["/mgr/session"]}
+        await self._send_text(
+            f"5::{self._namespace}:{json.dumps(payload, separators=(',', ':'))}"
+        )
+
+    async def _subscribe_htr_samples(self) -> None:
+        """Subscribe to heater sample updates."""
+
+        targets = self._heater_sample_subscription_targets()
+        if not targets:
+            return
+        for node_type, addr in targets:
+            payload = {
+                "name": "subscribe",
+                "args": [f"/{node_type}/{addr}/samples"],
+            }
+            await self._send_text(
+                f"5::{self._namespace}:{json.dumps(payload, separators=(',', ':'))}"
+            )
+    async def _heartbeat_loop(self) -> None:
+        """Send periodic heartbeat frames to keep the connection alive."""
+
+        try:
+            await self._run_heartbeat(
+                self._hb_send_interval, partial(self._send_text, "2::")
+            )
+        except asyncio.CancelledError:
+            return
+        except (aiohttp.ClientError, RuntimeError):  # pragma: no cover - best effort
+            return
+
+    async def _rtc_keepalive_loop(self) -> None:
+        """Poll the REST API to keep the device session alive."""
+
+        interval = self._rtc_keepalive_interval
+        try:
+            while not self._closing:
+                try:
+                    await self._client.get_rtc_time(self.dev_id)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as err:  # noqa: BLE001
+                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                        _LOGGER.debug(
+                            "WS: RTC keep-alive failed (%s: %s)",
+                            type(err).__name__,
+                            err,
+                        )
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001  # pragma: no cover - defensive best effort
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "WS: RTC keep-alive loop stopped unexpectedly", exc_info=True
+                )
+
+    async def _read_loop(self) -> None:
+        """Consume websocket frames and route events for the legacy protocol."""
+
+        ws = self._ws
+        if ws is None:
+            return
+        async for data in self._ws_payload_stream(ws, context="websocket"):
+            if data.startswith("2::"):
+                self._record_heartbeat(source="socketio09")
+                continue
+            if data.startswith(f"1::{self._namespace}"):
+                continue
+            if data.startswith(f"5::{self._namespace}:"):
+                try:
+                    payload = json.loads(data.split(f"5::{self._namespace}:", 1)[1])
+                except Exception:  # noqa: BLE001
+                    continue
+                self._handle_event(payload)
+                continue
+            if data.startswith("0::"):
+                raise RuntimeError("server disconnect")
+
+    def _handle_event(self, evt: dict[str, Any]) -> None:
+        """Process a Socket.IO 0.9 event payload."""
+
+        if not isinstance(evt, dict):
+            return
+        name = evt.get("name")
+        args = evt.get("args")
+        if name != "data" or not isinstance(args, list) or not args:
+            return
+        batch = args[0] if isinstance(args[0], list) else None
+        if not isinstance(batch, list):
+            return
+        paths: list[str] = []
+        updated_nodes = False
+        updated_addrs: list[tuple[str, str]] = []
+        sample_addrs: list[tuple[str, str]] = []
+
+        def _extract_type_addr(path: str) -> tuple[str | None, str | None]:
+            """Extract the node type and address from a websocket path."""
+
+            if not path:
+                return None, None
+            parts = [segment for segment in path.split("/") if segment]
+            for idx in range(len(parts) - 2):
+                node_type = parts[idx]
+                addr = parts[idx + 1]
+                leaf = parts[idx + 2]
+                if leaf in {"settings", "samples", "advanced_setup"}:
+                    return node_type, addr
+            return None, None
+
+        for item in batch:
+            if not isinstance(item, Mapping):
+                continue
+            path = item.get("path")
+            body = item.get("body")
+            if not isinstance(path, str):
+                continue
+            paths.append(path)
+            dev_map: dict[str, Any] = (self._coordinator.data or {}).get(
+                self.dev_id
+            ) or {}
+            if not dev_map:
+                htr_bucket: dict[str, Any] = {
+                    "addrs": [],
+                    "settings": {},
+                    "advanced": {},
+                    "samples": {},
+                }
+                dev_map = {
+                    "dev_id": self.dev_id,
+                    "name": f"Device {self.dev_id}",
+                    "raw": {},
+                    "connected": True,
+                    "nodes": None,
+                    "nodes_by_type": {"htr": htr_bucket},
+                    "htr": htr_bucket,
+                }
+                cur = dict(self._coordinator.data or {})
+                cur[self.dev_id] = dev_map
+                self._coordinator.data = cur  # type: ignore[attr-defined]
+            nodes_by_type: dict[str, Any] = dev_map.setdefault("nodes_by_type", {})
+            if path.endswith("/mgr/nodes"):
+                if isinstance(body, dict):
+                    dev_map["nodes"] = body
+                    self._nodes_raw = deepcopy(body)
+                    self._nodes = self._build_nodes_snapshot(self._nodes_raw)
+                    type_to_addrs = self._dispatch_nodes(body)
+                    for node_type, addrs in type_to_addrs.items():
+                        bucket = self._ensure_type_bucket(
+                            dev_map, nodes_by_type, node_type
+                        )
+                        bucket["addrs"] = list(addrs)
+                    updated_nodes = True
+                continue
+            node_type, addr = _extract_type_addr(path)
+            if node_type and addr and node_type != "mgr":
+                section = self._legacy_section_for_path(path)
+                if section:
+                    if section in {"settings", "advanced"} and not isinstance(
+                        body, Mapping
+                    ):
+                        continue
+                    if self._update_legacy_section(
+                        node_type=node_type,
+                        addr=addr,
+                        section=section,
+                        body=body,
+                        dev_map=dev_map,
+                        nodes_by_type=nodes_by_type,
+                    ):
+                        if section == "samples":
+                            sample_addrs.append((node_type, addr))
+                        elif section == "settings":
+                            updated_addrs.append((node_type, addr))
+                        updated_nodes = True
+                    continue
+            raw = dev_map.setdefault("raw", {})
+            key = path.strip("/").replace("/", "_")
+            raw[key] = body
+
+        if updated_nodes:
+            self._nodes = self._build_nodes_snapshot(self._nodes_raw)
+        self._mark_event(paths=paths)
+        payload_base = {
+            "dev_id": self.dev_id,
+            "ts": self._stats.last_event_ts,
+            "node_type": None,
+        }
+        if updated_nodes:
+            async_dispatcher_send(
+                self.hass,
+                signal_ws_data(self.entry_id),
+                {**payload_base, "addr": None, "kind": "nodes"},
+            )
+        for node_type, addr in set(updated_addrs):
+            async_dispatcher_send(
+                self.hass,
+                signal_ws_data(self.entry_id),
+                {
+                    **payload_base,
+                    "addr": addr,
+                    "kind": f"{node_type}_settings",
+                    "node_type": node_type,
+                },
+            )
+        for node_type, addr in set(sample_addrs):
+            async_dispatcher_send(
+                self.hass,
+                signal_ws_data(self.entry_id),
+                {
+                    **payload_base,
+                    "addr": addr,
+                    "kind": f"{node_type}_samples",
+                    "node_type": node_type,
+                },
+            )
+        self._log_legacy_update(
+            updated_nodes=updated_nodes,
+            updated_addrs=updated_addrs,
+            sample_addrs=sample_addrs,
+        )
+
+    def _mark_event(
+        self, *, paths: list[str] | None, count_event: bool = False
+    ) -> None:
+        """Record payload batches and update the payload timestamp."""
+
+        super()._mark_event(paths=paths, count_event=count_event)
+        self._last_payload_at = self._stats.last_event_ts or self._last_event_at
+        state = self._ws_state_bucket()
+        state["last_payload_at"] = self._last_payload_at
+
+    def _update_legacy_section(
+        self,
+        *,
+        node_type: str,
+        addr: str,
+        section: str,
+        body: Any,
+        dev_map: dict[str, Any],
+        nodes_by_type: dict[str, Any],
+    ) -> bool:
+        """Store legacy section updates and mirror them in raw state."""
+
+        bucket = self._ensure_type_bucket(dev_map, nodes_by_type, node_type)
+        section_map: dict[str, Any] = bucket.setdefault(section, {})
+        if not isinstance(section_map, dict):
+            return False
+        value: Any = dict(body) if isinstance(body, Mapping) else body
+        section_map[addr] = value
+        raw_bucket = self._nodes_raw.setdefault(node_type, {})
+        raw_section = raw_bucket.setdefault(section, {})
+        if isinstance(raw_section, dict):
+            raw_section[addr] = deepcopy(body)
+        return True
+
+    @staticmethod
+    def _legacy_section_for_path(path: str) -> str | None:
+        """Return the legacy section identifier for ``path`` if supported."""
+
+        if path.endswith("/settings"):
+            return "settings"
+        if path.endswith("/advanced_setup"):
+            return "advanced"
+        if path.endswith("/samples"):
+            return "samples"
+        return None
+
+    def _log_legacy_update(
+        self,
+        *,
+        updated_nodes: bool,
+        updated_addrs: Iterable[tuple[str, str]],
+        sample_addrs: Iterable[tuple[str, str]],
+    ) -> None:
+        """Emit debug logging for the legacy websocket update batch."""
+
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        addr_pairs = {f"{node_type}/{addr}" for node_type, addr in updated_addrs}
+        addr_pairs.update(f"{node_type}/{addr}" for node_type, addr in sample_addrs)
+        if addr_pairs:
+            _LOGGER.debug("WS: legacy update for %s", ", ".join(sorted(addr_pairs)))
+        elif updated_nodes:
+            _LOGGER.debug("WS: legacy nodes refresh")
+
+    async def _refresh_subscription(self, *, reason: str) -> None:
+        """Replay subscription calls to keep the legacy websocket active."""
+
+        async with self._subscription_refresh_lock:
+            ws = self._ws
+            if ws is None or getattr(ws, "closed", False):
+                raise RuntimeError("websocket not connected")
+            now = time.time()
+            self._subscription_refresh_last_attempt = now
+            _LOGGER.info("WS: refreshing websocket lease (%s)", reason)
+            try:
+                await self._send_snapshot_request()
+                await self._subscribe_session_metadata()
+                await self._subscribe_htr_samples()
+            except asyncio.CancelledError:  # pragma: no cover - task lifecycle
+                raise
+            except Exception as err:
+                self._subscription_refresh_failed = True
+                _LOGGER.warning(
+                    "WS: legacy lease refresh failed (%s: %s)",
+                    type(err).__name__,
+                    err,
+                    exc_info=True,
+                )
+                self._schedule_idle_restart(
+                    idle_for=self._payload_idle_window, source="lease refresh failure"
+                )
+                raise
+            self._subscription_refresh_failed = False
+            self._subscription_refresh_last_success = time.time()
+
+    async def _send_text(self, data: str) -> None:
+        """Send a websocket text frame."""
+
+        if not self._ws:
+            raise RuntimeError("websocket not connected")
+        await self._ws.send_str(data)
+
+    async def _disconnect(self, *, reason: str) -> None:
+        """Close the websocket connection if active."""
+
+        if self._ws:
+            with suppress(aiohttp.ClientError, RuntimeError):
+                await self._ws.close(
+                    code=aiohttp.WSCloseCode.GOING_AWAY, message=reason.encode()
+                )
+            self._ws = None
+
+    async def _ws_payload_stream(
+        self, ws: aiohttp.ClientWebSocketResponse, *, context: str
+    ) -> AsyncIterator[str]:
+        """Yield websocket payload strings."""
+
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                self._stats.frames_total += 1
+                yield msg.data
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                try:
+                    decoded = codecs.decode(msg.data, "utf-8")
+                except Exception:  # noqa: BLE001
+                    continue
+                self._stats.frames_total += 1
+                yield decoded
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                raise RuntimeError(f"{context} error: {ws.exception()}")
+            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED}:
+                raise RuntimeError(f"{context} closed")
+
+    def _record_heartbeat(self, *, source: str) -> None:
+        """Record receipt of a heartbeat frame."""
+
+        _ = source
+        now = time.time()
+        self._stats.last_event_ts = now
+        self._last_event_at = now
+        self._last_heartbeat_at = now
+
+    async def _idle_monitor(self) -> None:
+        """Monitor payload idleness and restart stale websocket sessions."""
+
+        while not self._closing:
+            await asyncio.sleep(60)
+            ws = self._ws
+            if ws is None or getattr(ws, "closed", True):
+                if self._disconnected.is_set():
+                    break
+                continue
+            last_payload = self._last_payload_at
+            now = time.time()
+            idle_for: float | None = None
+            if last_payload:
+                idle_for = now - last_payload
+                if idle_for >= self._payload_idle_window:
+                    _LOGGER.info(
+                        "WS: no payloads for %.0f s; scheduling websocket restart",
+                        idle_for,
+                    )
+                    self._schedule_idle_restart(
+                        idle_for=idle_for, source="idle monitor payload timeout"
+                    )
+                    break
+            if self._subscription_refresh_failed:
+                try:
+                    await self._refresh_subscription(reason="idle monitor retry")
+                except asyncio.CancelledError:  # pragma: no cover - task lifecycle
+                    raise
+                except Exception:  # noqa: BLE001
+                    fallback_idle = (
+                        idle_for if idle_for is not None else self._payload_idle_window
+                    )
+                    self._schedule_idle_restart(
+                        idle_for=fallback_idle, source="idle monitor retry failed"
+                    )
+                    break
+
+    async def _run_heartbeat(
+        self, interval: float, send: Callable[[], Awaitable[Any]]
+    ) -> None:
+        """Send periodic heartbeats until cancelled."""
+
+        while not self._closing:
+            await asyncio.sleep(interval)
+            try:
+                await send()
+            except Exception:  # noqa: BLE001
+                return
+
+    def _socket_base(self) -> str:
+        """Return the base URL for websocket connections."""
+
+        base = self._api_base().rstrip("/")
+        parsed = urlsplit(base if base else API_BASE)
+        scheme = parsed.scheme or "https"
+        netloc = parsed.netloc or parsed.path
+        path = parsed.path.rstrip("/")
+        return urlunsplit((scheme, netloc, path or "", "", ""))
+
+
+__all__ = [
+    "HandshakeError",
+    "TermoWebWSClient",
+    "WSStats",
+    "WebSocketClient",
+    "build_node_inventory",
+]

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+"""Shared websocket helpers."""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import dataclass
+import gzip
+import json
+import logging
+import random
+import string
+import time
+from typing import TYPE_CHECKING, Any, Mapping
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+import aiohttp
+import socketio
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from ..api import RESTClient
+from ..const import (
+    ACCEPT_LANGUAGE,
+    API_BASE,
+    BRAND_DUCAHEAT,
+    BRAND_TERMOWEB,
+    DOMAIN,
+    USER_AGENT,
+    WS_NAMESPACE,
+    get_brand_api_base,
+    get_brand_requested_with,
+    get_brand_user_agent,
+    signal_ws_data,
+    signal_ws_status,
+)
+from ..installation import InstallationSnapshot, ensure_snapshot
+from ..nodes import (
+    NODE_CLASS_BY_TYPE,
+    addresses_by_node_type,
+    collect_heater_sample_addresses,
+    ensure_node_inventory,
+    heater_sample_subscription_targets,
+    normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .ducaheat_ws import DucaheatWSClient
+    from .termoweb_ws import TermoWebWSClient
+
+_LOGGER = logging.getLogger(__name__)
+
+DUCAHEAT_NAMESPACE = "/api/v2/socket_io"
+
+
+@dataclass
+class WSStats:
+    """Track websocket frame and event stats."""
+
+    frames_total: int = 0
+    events_total: int = 0
+    last_event_ts: float = 0.0
+
+
+class HandshakeError(RuntimeError):
+    """Raised when a websocket handshake fails."""
+
+    def __init__(self, status: int, url: str, detail: str) -> None:
+        super().__init__(f"handshake failed: status={status}, detail={detail}")
+        self.status = status
+        self.url = url
+
+
+class _WsLeaseMixin:
+    """Provide reconnect backoff management for websocket clients."""
+
+    def __init__(self) -> None:
+        self._payload_idle_window: float = 240.0
+        self._subscription_refresh_lock = asyncio.Lock()
+        self._subscription_refresh_failed = False
+        self._backoff_idx = 0
+        self._backoff = (5, 10, 30, 120, 300)
+
+    def _reset_backoff(self) -> None:
+        self._backoff_idx = 0
+
+    def _next_backoff(self) -> float:
+        idx = min(self._backoff_idx, len(self._backoff) - 1)
+        self._backoff_idx = min(self._backoff_idx + 1, len(self._backoff) - 1)
+        return self._backoff[idx]
+
+
+class _WSCommon:
+    """Shared helpers for websocket clients."""
+
+    hass: HomeAssistant
+    entry_id: str
+    dev_id: str
+    _coordinator: Any
+
+    def _ws_state_bucket(self) -> dict[str, Any]:
+        domain_bucket = self.hass.data.setdefault(DOMAIN, {})
+        entry_bucket = domain_bucket.setdefault(self.entry_id, {})
+        ws_state = entry_bucket.setdefault("ws_state", {})
+        return ws_state.setdefault(self.dev_id, {})
+
+    def _update_status(self, status: str) -> None:
+        async_dispatcher_send(
+            self.hass,
+            signal_ws_status(self.entry_id),
+            {"dev_id": self.dev_id, "status": status},
+        )
+
+    def _dispatch_nodes(self, payload: dict[str, Any]) -> None:
+        raw_nodes = payload.get("nodes") if "nodes" in payload else payload
+        record = self.hass.data.get(DOMAIN, {}).get(self.entry_id)
+        snapshot_obj = ensure_snapshot(record)
+        if isinstance(snapshot_obj, InstallationSnapshot):
+            snapshot_obj.update_nodes(raw_nodes)
+            inventory = snapshot_obj.inventory
+            if isinstance(record, dict):
+                record["node_inventory"] = list(inventory)
+        else:
+            record_map: Mapping[str, Any] = record if isinstance(record, Mapping) else {}
+            inventory = ensure_node_inventory(record_map, nodes=raw_nodes)
+        addr_map, _ = addresses_by_node_type(inventory, known_types=NODE_CLASS_BY_TYPE)
+        if hasattr(self._coordinator, "update_nodes"):
+            self._coordinator.update_nodes(raw_nodes, inventory)
+        payload_copy = {
+            "dev_id": self.dev_id,
+            "node_type": None,
+            "nodes": deepcopy(raw_nodes),
+            "addr_map": {t: list(a) for t, a in addr_map.items()},
+        }
+        async_dispatcher_send(self.hass, signal_ws_data(self.entry_id), payload_copy)
+
+
+class WebSocketClient(_WsLeaseMixin):
+    """Delegate to the correct backend websocket client."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        entry_id: str,
+        dev_id: str,
+        api_client: RESTClient,
+        coordinator: Any,
+        session: aiohttp.ClientSession | None = None,
+        protocol: str | None = None,
+        namespace: str = WS_NAMESPACE,
+    ) -> None:
+        _WsLeaseMixin.__init__(self)
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self._client = api_client
+        self._coordinator = coordinator
+        self._session = session or getattr(api_client, "_session", None)
+        self._protocol_hint = protocol
+        self._namespace = namespace or WS_NAMESPACE
+        self._loop = getattr(hass, "loop", None) or asyncio.get_event_loop()
+        self._delegate: DucaheatWSClient | TermoWebWSClient | None = None
+        self._brand = (
+            BRAND_DUCAHEAT
+            if getattr(api_client, "_is_ducaheat", False)
+            else BRAND_TERMOWEB
+        )
+
+    def start(self) -> asyncio.Task:
+        if self._delegate is not None:
+            return self._delegate.start()
+        if self._brand == BRAND_DUCAHEAT:
+            from .ducaheat_ws import DucaheatWSClient
+
+            self._delegate = DucaheatWSClient(
+                self.hass,
+                entry_id=self.entry_id,
+                dev_id=self.dev_id,
+                api_client=self._client,
+                coordinator=self._coordinator,
+                session=self._session,
+                namespace=DUCAHEAT_NAMESPACE,
+            )
+        else:
+            from .termoweb_ws import TermoWebWSClient
+
+            self._delegate = TermoWebWSClient(
+                self.hass,
+                entry_id=self.entry_id,
+                dev_id=self.dev_id,
+                api_client=self._client,
+                coordinator=self._coordinator,
+                session=self._session,
+                namespace=self._namespace,
+            )
+        return self._delegate.start()
+
+    async def stop(self) -> None:
+        if self._delegate is not None:
+            await self._delegate.stop()
+
+    def is_running(self) -> bool:
+        return bool(self._delegate and self._delegate.is_running())
+
+    async def ws_url(self) -> str:
+        if self._delegate and hasattr(self._delegate, "ws_url"):
+            return await self._delegate.ws_url()
+        return ""
+
+
+__all__ = [
+    "ACCEPT_LANGUAGE",
+    "API_BASE",
+    "BRAND_DUCAHEAT",
+    "BRAND_TERMOWEB",
+    "DOMAIN",
+    "DUCAHEAT_NAMESPACE",
+    "DucaheatWSClient",
+    "HandshakeError",
+    "HomeAssistant",
+    "RESTClient",
+    "USER_AGENT",
+    "WS_NAMESPACE",
+    "WSStats",
+    "WebSocketClient",
+    "_WSCommon",
+    "_WsLeaseMixin",
+    "addresses_by_node_type",
+    "aiohttp",
+    "async_dispatcher_send",
+    "asyncio",
+    "collect_heater_sample_addresses",
+    "ensure_node_inventory",
+    "get_brand_api_base",
+    "get_brand_requested_with",
+    "get_brand_user_agent",
+    "gzip",
+    "heater_sample_subscription_targets",
+    "json",
+    "logging",
+    "normalize_heater_addresses",
+    "normalize_node_addr",
+    "normalize_node_type",
+    "random",
+    "signal_ws_data",
+    "signal_ws_status",
+    "socketio",
+    "string",
+    "time",
+    "time_mod",
+    "TermoWebWSClient",
+    "urlencode",
+    "urlsplit",
+    "urlunsplit",
+]
+
+time_mod = time.monotonic
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose backend websocket client implementations."""
+
+    if name == "DucaheatWSClient":
+        from .ducaheat_ws import DucaheatWSClient as _DucaheatWSClient
+
+        return _DucaheatWSClient
+    if name == "TermoWebWSClient":
+        from .termoweb_ws import TermoWebWSClient as _TermoWebWSClient
+
+        return _TermoWebWSClient
+    raise AttributeError(name)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ operations flow through brand-specific REST clients, while push updates and
 connection health are maintained through websocket clients that the backend
 constructs for each gateway. Home Assistant maintains per-installation caches of
 nodes, coordinates REST polling, merges websocket deltas, and exposes entity
-state and energy statistics to the rest of the platform.【F:custom_components/termoweb/__init__.py†L140-L233】【F:custom_components/termoweb/ws_client.py†L760-L833】【F:custom_components/termoweb/energy.py†L421-L512】
+state and energy statistics to the rest of the platform.【F:custom_components/termoweb/__init__.py†L140-L233】【F:custom_components/termoweb/backend/ws_client.py†L77-L193】【F:custom_components/termoweb/backend/ducaheat_ws.py†L188-L386】【F:custom_components/termoweb/energy.py†L421-L512】
 
 ## Key components
 
@@ -40,7 +40,7 @@ state and energy statistics to the rest of the platform.【F:custom_components/t
 - **Websocket layer** – `WebSocketClient` negotiates the correct Socket.IO or
   Engine.IO handshake, keeps per-device health metrics, updates coordinator
   caches, and broadcasts dispatcher signals. `DucaheatWSClient` layers brand-
-  specific logging atop the shared implementation.【F:custom_components/termoweb/ws_client.py†L40-L104】【F:custom_components/termoweb/ws_client.py†L760-L833】【F:custom_components/termoweb/ws_client.py†L1580-L1637】【F:custom_components/termoweb/ws_client.py†L1856-L1896】
+  specific logging atop the shared implementation.【F:custom_components/termoweb/backend/ws_client.py†L40-L193】【F:custom_components/termoweb/backend/ducaheat_ws.py†L188-L386】
 - **Energy services** – the energy helper enforces a shared rate limiter for
   historical sample queries, performs targeted imports based on entity
   selection, and registers the `import_energy_history` service only once per

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -518,174 +518,30 @@ custom_components/termoweb/utils.py :: build_gateway_device_info
     Return canonical ``DeviceInfo`` for the TermoWeb gateway.
 custom_components/termoweb/utils.py :: float_or_none
     Return value as ``float`` if possible, else ``None``.
-custom_components/termoweb/ws_client.py :: HandshakeError.__init__
+custom_components/termoweb/backend/ws_client.py :: HandshakeError.__init__
     Initialise the error with the HTTP response details.
-custom_components/termoweb/ws_client.py :: WebSocketClient.__init__
+custom_components/termoweb/backend/ws_client.py :: WebSocketClient.__init__
     Initialise the websocket client container.
-custom_components/termoweb/ws_client.py :: WebSocketClient._wrap_background_task
-    Schedule socket.io background tasks on the HA loop.
-custom_components/termoweb/ws_client.py :: WebSocketClient.start
+custom_components/termoweb/backend/ws_client.py :: WebSocketClient.start
     Start the websocket client background task.
-custom_components/termoweb/ws_client.py :: WebSocketClient.stop
+custom_components/termoweb/backend/ws_client.py :: WebSocketClient.stop
     Cancel tasks and close websocket sessions.
-custom_components/termoweb/ws_client.py :: WebSocketClient.is_running
+custom_components/termoweb/backend/ws_client.py :: WebSocketClient.is_running
     Return True if the websocket client task is active.
-custom_components/termoweb/ws_client.py :: WebSocketClient.ws_url
+custom_components/termoweb/backend/ws_client.py :: WebSocketClient.ws_url
     Return the websocket URL using the API client's token helper.
-custom_components/termoweb/ws_client.py :: WebSocketClient._runner
-    Manage connection attempts with backoff.
-custom_components/termoweb/ws_client.py :: WebSocketClient._connect_once
-    Open the Socket.IO connection.
-custom_components/termoweb/ws_client.py :: WebSocketClient._wait_for_events
-    Wait for the connection to close or stop to be requested.
-custom_components/termoweb/ws_client.py :: WebSocketClient._disconnect
-    Ensure the AsyncClient is disconnected.
-custom_components/termoweb/ws_client.py :: WebSocketClient._build_engineio_target
-    Return the Engine.IO base URL and path.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_connect
-    Handle socket connection establishment.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_disconnect
-    Handle socket disconnection.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_reconnect
-    Handle socket reconnection attempts.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_connect_error
-    Log ``connect_error`` events with their payload.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_error
-    Log socket.io ``error`` events with full details.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_reconnect_failed
-    Log ``reconnect_failed`` events with the reported context.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_namespace_disconnect
-    Log namespace-level disconnect callbacks with their reason.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_dev_handshake
-    Handle the ``dev_handshake`` payload.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_dev_data
-    Handle the ``dev_data`` payload.
-custom_components/termoweb/ws_client.py :: WebSocketClient._on_update
-    Handle the ``update`` payload.
-custom_components/termoweb/ws_client.py :: WebSocketClient._idle_monitor
-    Monitor idle websocket periods and trigger restarts.
-custom_components/termoweb/ws_client.py :: WebSocketClient._refresh_subscription
-    Re-request device data to keep the websocket session active.
-custom_components/termoweb/ws_client.py :: WebSocketClient._handle_handshake
-    Process the initial handshake payload from the server.
-custom_components/termoweb/ws_client.py :: WebSocketClient._handle_dev_data
-    Handle the first full snapshot of nodes from the websocket.
-custom_components/termoweb/ws_client.py :: WebSocketClient._handle_update
-    Merge incremental node updates from the websocket feed.
-custom_components/termoweb/ws_client.py :: WebSocketClient._apply_nodes_payload
-    Update cached nodes from the websocket payload and notify listeners.
-custom_components/termoweb/ws_client.py :: WebSocketClient._translate_path_update
-    Translate Ducaheat ``{"path": ..., "body": ...}`` frames into nodes.
-custom_components/termoweb/ws_client.py :: WebSocketClient._resolve_update_section
-    Map a websocket path segment onto the node bucket name.
-custom_components/termoweb/ws_client.py :: WebSocketClient._forward_sample_updates
-    Relay websocket heater sample updates to the energy coordinator.
-custom_components/termoweb/ws_client.py :: WebSocketClient._extract_nodes
-    Extract the nodes dictionary from a websocket payload.
-custom_components/termoweb/ws_client.py :: WebSocketClient._translate_nodes_list
-    Convert list-based node payloads into the nested mapping schema.
-custom_components/termoweb/ws_client.py :: WebSocketClient._collect_update_addresses
-    Return a sorted list of ``(node_type, addr)`` pairs in ``nodes``.
-custom_components/termoweb/ws_client.py :: WebSocketClient._dispatch_nodes
-    Publish node updates and return the address map by node type.
-custom_components/termoweb/ws_client.py :: WebSocketClient._dispatch_nodes._send
-    Fire the dispatcher signal with the latest node payload.
-custom_components/termoweb/ws_client.py :: WebSocketClient._ensure_type_bucket
-    Return the node bucket for ``node_type`` with default sections.
-custom_components/termoweb/ws_client.py :: WebSocketClient._apply_heater_addresses
-    Update entry and coordinator state with heater address data.
-custom_components/termoweb/ws_client.py :: WebSocketClient._heater_sample_subscription_targets
-    Return ordered ``(node_type, addr)`` heater sample subscriptions.
-custom_components/termoweb/ws_client.py :: WebSocketClient._subscribe_heater_samples
-    Subscribe to heater and accumulator sample updates.
-custom_components/termoweb/ws_client.py :: WebSocketClient._build_nodes_snapshot
-    Normalise the nodes payload for consumers.
-custom_components/termoweb/ws_client.py :: WebSocketClient._merge_nodes
-    Deep-merge incremental node updates into the stored snapshot.
-custom_components/termoweb/ws_client.py :: WebSocketClient._ws_state_bucket
-    Return the websocket state bucket for this device.
-custom_components/termoweb/ws_client.py :: WebSocketClient._update_status
-    Publish the websocket status to Home Assistant listeners.
-custom_components/termoweb/ws_client.py :: WebSocketClient._mark_event
-    Record receipt of a websocket event batch for health tracking.
-custom_components/termoweb/ws_client.py :: WebSocketClient._schedule_idle_restart
-    Log idle payload detection and close the websocket for restart.
-custom_components/termoweb/ws_client.py :: WebSocketClient._cancel_idle_restart
-    Cancel any scheduled idle restart due to new payload activity.
-custom_components/termoweb/ws_client.py :: WebSocketClient._get_token
-    Reuse the REST client token for websocket authentication.
-custom_components/termoweb/ws_client.py :: WebSocketClient._force_refresh_token
-    Force the REST client to fetch a fresh access token.
-custom_components/termoweb/ws_client.py :: WebSocketClient._api_base
-    Return the base REST API URL used for websocket routes.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient.__init__
-    Initialise the legacy websocket client container.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._install_write_hook
-    Wrap REST writes so we can observe successful node updates.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient.maybe_restart_after_write
-    Restart the websocket if writes follow long periods of inactivity.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient.stop
-    Cancel tasks, close websocket sessions and reset legacy state.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._runner
-    Manage reconnection attempts and lifecycle.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._run_socketio_09
-    Manage reconnection loops for the legacy Socket.IO protocol.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._handshake
-    Perform the legacy GET /socket.io/1/ handshake.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._connect_ws
-    Open the websocket connection using the handshake session id.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._join_namespace
-    Join the API namespace after the websocket connects.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._send_snapshot_request
-    Request the initial device snapshot.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._subscribe_session_metadata
-    Subscribe to legacy session metadata updates.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._subscribe_htr_samples
-    Subscribe to heater sample updates.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._heartbeat_loop
-    Send periodic heartbeat frames to keep the connection alive.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._read_loop
-    Consume websocket frames and route events for the legacy protocol.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._handle_event
-    Process a Socket.IO 0.9 event payload.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._handle_event._extract_type_addr
-    Extract the node type and address from a websocket path.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._mark_event
-    Record payload batches and update the payload timestamp.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._update_legacy_section
-    Store legacy section updates and mirror them in raw state.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._legacy_section_for_path
-    Return the legacy section identifier for ``path`` if supported.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._log_legacy_update
-    Emit debug logging for the legacy websocket update batch.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._refresh_subscription
-    Replay subscription calls to keep the legacy websocket active.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._send_text
-    Send a websocket text frame.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._disconnect
-    Close the websocket connection if active.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._ws_payload_stream
-    Yield websocket payload strings.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._record_heartbeat
-    Record receipt of a heartbeat frame.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._idle_monitor
-    Monitor payload idleness and restart stale websocket sessions.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._run_heartbeat
-    Send periodic heartbeats until cancelled.
-custom_components/termoweb/ws_client.py :: TermoWebWSClient._socket_base
-    Return the base URL for websocket connections.
-custom_components/termoweb/ws_client.py :: DucaheatWSClient._summarise_addresses
-    Return a condensed summary of node addresses in ``data``.
-custom_components/termoweb/ws_client.py :: DucaheatWSClient._on_connect
-    Log connect events before delegating to the base implementation.
-custom_components/termoweb/ws_client.py :: DucaheatWSClient._on_disconnect
-    Log disconnect events before delegating.
-custom_components/termoweb/ws_client.py :: DucaheatWSClient._on_dev_handshake
-    Log handshake payloads prior to standard handling.
-custom_components/termoweb/ws_client.py :: DucaheatWSClient._on_dev_data
-    Log initial dev_data snapshots with condensed address details.
-custom_components/termoweb/ws_client.py :: DucaheatWSClient._on_update
-    Log incremental update payloads with condensed address details.
+custom_components/termoweb/backend/ws_client.py :: _WSCommon._dispatch_nodes
+    Dispatch node payloads to listeners.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.__init__
+    Initialise the Engine.IO websocket client for Ducaheat.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._runner
+    Manage websocket connection attempts with backoff.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._connect_once
+    Perform the Engine.IO polling and websocket upgrade handshake.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._read_loop_ws
+    Process websocket frames from the server.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._log_nodes_summary
+    Summarise node snapshots received from the backend.
 scripts/generate_function_map.py :: DocExtractor.__init__
     Initialise the extractor for ``file_path``.
 scripts/generate_function_map.py :: DocExtractor.visit_ClassDef

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -12,7 +12,8 @@ from custom_components.termoweb.backend.ducaheat import (
     _redact_log_value,
 )
 from custom_components.termoweb.const import WS_NAMESPACE
-from custom_components.termoweb.ws_client import DucaheatWSClient, WebSocketClient
+from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient
+from custom_components.termoweb.backend.ws_client import WebSocketClient
 
 
 class DummyClient:

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -13,10 +13,8 @@ from custom_components.termoweb.backend import termoweb as termoweb_backend
 from custom_components.termoweb.backend.ducaheat import DucaheatBackend
 from custom_components.termoweb.backend.termoweb import TermoWebBackend
 from custom_components.termoweb.const import BRAND_DUCAHEAT
-from custom_components.termoweb.ws_client import (
-    WebSocketClient,
-    TermoWebWSClient,
-)
+from custom_components.termoweb.backend.termoweb_ws import TermoWebWSClient
+from custom_components.termoweb.backend.ws_client import WebSocketClient
 
 
 class DummyHttpClient:
@@ -213,7 +211,7 @@ def test_termoweb_backend_resolve_ws_missing_attr(
     monkeypatch.setitem(termoweb_backend.sys.modules, module.__name__, module)
     monkeypatch.setitem(termoweb_backend.sys.modules, init_module.__name__, init_module)
 
-    ws_module = ModuleType("custom_components.termoweb.ws_client")
+    ws_module = ModuleType("custom_components.termoweb.backend.termoweb_ws")
     monkeypatch.setattr(termoweb_backend, "import_module", lambda name: ws_module)
     resolved = backend._resolve_ws_client_cls()
     assert resolved is WebSocketClient

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,11 +16,9 @@ from custom_components.termoweb.backend import (  # noqa: E402
     create_backend,
 )
 from custom_components.termoweb.const import BRAND_DUCAHEAT, WS_NAMESPACE  # noqa: E402
-from custom_components.termoweb.ws_client import (  # noqa: E402
-    DucaheatWSClient,
-    TermoWebWSClient,
-    WebSocketClient,
-)
+from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient  # noqa: E402
+from custom_components.termoweb.backend.termoweb_ws import TermoWebWSClient  # noqa: E402
+from custom_components.termoweb.backend.ws_client import WebSocketClient  # noqa: E402
 
 
 class DummyHttpClient:

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -249,7 +249,9 @@ async def _load_module(
 
     monkeypatch.setattr(api_module, "RESTClient", _FakeRESTClient)
 
-    ws_module = importlib.import_module("custom_components.termoweb.ws_client")
+    ws_module = importlib.import_module(
+        "custom_components.termoweb.backend.ws_client"
+    )
 
     class _FakeWSClient:
         def __init__(self, hass: Any, dev_id: str, *args: Any, **kwargs: Any) -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
-import custom_components.termoweb.ws_client as module
+from custom_components.termoweb.backend import ws_client as module
 from custom_components.termoweb.installation import InstallationSnapshot
 
 


### PR DESCRIPTION
## Summary
- restore the working TermoWeb WebSocket client implementation, including the shared Socket.IO helpers and legacy client logic, in `custom_components/termoweb/backend/termoweb_ws.py`
- expose the compatibility exports (`WebSocketClient`, `WSStats`, `HandshakeError`, and `build_node_inventory`) expected by the integration and test suite

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e3aef50d4c8329932c549e47e24c2c