### PR TITLE
Expand websocket protocol coverage

### DIFF
--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -1,0 +1,104 @@
+"""Tests for the abstract backend base helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.termoweb.backend.base import Backend
+
+
+class DummyWsClient:
+    """Simple websocket client stub that tracks lifecycle calls."""
+
+    def __init__(self, hass: SimpleNamespace, *, entry_id: str, dev_id: str) -> None:
+        self.hass = hass
+        self.entry_id = entry_id
+        self.dev_id = dev_id
+        self._loop = getattr(hass, "loop", asyncio.get_event_loop())
+        self._task: asyncio.Task | None = None
+        self.started = False
+        self.stopped = False
+
+    async def _runner(self) -> None:
+        self.started = True
+        await asyncio.sleep(0)
+
+    def start(self) -> asyncio.Task:
+        if self._task is None:
+            self._task = self._loop.create_task(self._runner())
+        return self._task
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+        self.stopped = True
+
+
+class ExampleBackend(Backend):
+    """Concrete backend used to exercise the abstract base class."""
+
+    def __init__(self, *, brand: str, client: Any) -> None:
+        super().__init__(brand=brand, client=client)
+        self.calls: list[dict[str, Any]] = []
+
+    def create_ws_client(
+        self,
+        hass: SimpleNamespace,
+        entry_id: str,
+        dev_id: str,
+        coordinator: Any,
+    ) -> DummyWsClient:
+        self.calls.append(
+            {
+                "hass": hass,
+                "entry_id": entry_id,
+                "dev_id": dev_id,
+                "coordinator": coordinator,
+            }
+        )
+        return DummyWsClient(hass, entry_id=entry_id, dev_id=dev_id)
+
+
+@pytest.mark.asyncio
+async def test_backend_properties_and_ws_creation() -> None:
+    """The backend stores metadata and returns the websocket stub."""
+
+    hass = SimpleNamespace(loop=asyncio.get_running_loop())
+    client = object()
+    coordinator = object()
+    backend = ExampleBackend(brand="termoweb", client=client)
+
+    assert backend.brand == "termoweb"
+    assert backend.client is client
+
+    ws_client = backend.create_ws_client(
+        hass,
+        entry_id="entry-1",
+        dev_id="dev-1",
+        coordinator=coordinator,
+    )
+    assert isinstance(ws_client, DummyWsClient)
+    assert backend.calls == [
+        {
+            "hass": hass,
+            "entry_id": "entry-1",
+            "dev_id": "dev-1",
+            "coordinator": coordinator,
+        }
+    ]
+
+    task = ws_client.start()
+    assert isinstance(task, asyncio.Task)
+    assert not task.done()
+
+    await ws_client.stop()
+    assert ws_client.stopped is True

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,17 @@
+"""Tests for the TermoWeb constants module."""
+
+from __future__ import annotations
+
+from custom_components.termoweb import const
+
+
+def test_get_brand_socketio_path_known_brand() -> None:
+    """Return the configured Socket.IO path for known brands."""
+
+    assert const.get_brand_socketio_path(const.BRAND_DUCAHEAT) == "api/v2/socket_io"
+
+
+def test_get_brand_socketio_path_unknown_brand() -> None:
+    """Default to the generic Socket.IO path for unknown brands."""
+
+    assert const.get_brand_socketio_path("unknown") == "socket.io"

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -1,0 +1,654 @@
+"""Additional Ducaheat websocket client coverage tests."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any, AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.termoweb.backend import ducaheat_ws
+
+
+class DummyREST:
+    """Provide the minimal interface required by the websocket client."""
+
+    def __init__(self) -> None:
+        self._session = SimpleNamespace()
+        self._headers = {"Authorization": "Bearer rest-token"}
+
+    async def authed_headers(self) -> dict[str, str]:
+        """Return cached REST headers with an access token."""
+
+        return self._headers
+
+
+class StubResponse:
+    """Async context manager returning a predetermined payload."""
+
+    def __init__(self, *, status: int = 200, body: bytes = b"") -> None:
+        self.status = status
+        self._body = body
+        self._read = AsyncMock(return_value=body)
+
+    async def read(self) -> bytes:
+        """Return the response body."""
+
+        return await self._read()
+
+    async def __aenter__(self) -> "StubResponse":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+class StubWebSocket:
+    """Simple websocket stub capturing sent frames."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+        self._receive = asyncio.Queue[str]()
+        self._receive.put_nowait("3probe")
+
+    async def send_str(self, payload: str) -> None:
+        """Record outgoing websocket frames."""
+
+        self.sent.append(payload)
+
+    async def receive_str(self) -> str:
+        """Return the next queued incoming frame."""
+
+        return await self._receive.get()
+
+    async def close(self, *, code: int, message: bytes) -> None:
+        """Record that the websocket has been closed."""
+
+        self.closed = True
+
+
+class StubSession:
+    """Sequence driven aiohttp session stub for handshake operations."""
+
+    def __init__(self, ws: StubWebSocket) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self._ws = ws
+        self._open_body = ducaheat_ws._encode_polling_packet(
+            '0{"sid":"abc","pingInterval":25000,"pingTimeout":60000}'
+        )
+
+    def get(self, url: str, *, headers: dict[str, str]) -> StubResponse:
+        """Return responses for the open and drain polling calls."""
+
+        self.calls.append(("GET", url))
+        if "sid=" not in url:
+            return StubResponse(body=self._open_body)
+        return StubResponse(body=b"6:40[]")
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        data: bytes,
+    ) -> StubResponse:
+        """Record POST invocations during handshake."""
+
+        self.calls.append(("POST", url))
+        return StubResponse(body=b"")
+
+    async def ws_connect(self, url: str, **_: Any) -> StubWebSocket:
+        """Return the preconfigured websocket stub."""
+
+        self.calls.append(("WS", url))
+        return self._ws
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch) -> ducaheat_ws.DucaheatWSClient:
+    """Create a websocket client with deterministic helpers."""
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+    ws = StubWebSocket()
+    session = StubSession(ws)
+    hass = SimpleNamespace(loop=loop, data={ducaheat_ws.DOMAIN: {"entry": {}}})
+    client = ducaheat_ws.DucaheatWSClient(
+        hass,
+        entry_id="entry",
+        dev_id="device",
+        api_client=DummyREST(),
+        coordinator=SimpleNamespace(update_nodes=AsyncMock()),
+        session=session,  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(client, "_get_token", AsyncMock(return_value="token"))
+    monkeypatch.setattr(ducaheat_ws, "_rand_t", lambda: "P123456")
+    monkeypatch.setattr(
+        ducaheat_ws,
+        "collect_heater_sample_addresses",
+        lambda *_args, **_kwargs: ([], {"htr": ["1"]}, {}),
+    )
+    monkeypatch.setattr(
+        ducaheat_ws,
+        "normalize_heater_addresses",
+        lambda mapping: (mapping, {}),
+    )
+    monkeypatch.setattr(
+        ducaheat_ws,
+        "heater_sample_subscription_targets",
+        lambda mapping: [(kind, addr) for kind, addrs in mapping.items() for addr in addrs],
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_connect_once_performs_full_handshake(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exhaust the polling and websocket upgrade handshake."""
+
+    statuses: list[str] = []
+    monkeypatch.setattr(
+        ducaheat_ws._WSCommon,
+        "_update_status",
+        lambda self, status: statuses.append(status),
+    )
+    monkeypatch.setattr(
+        ducaheat_ws,
+        "_decode_polling_packets",
+        lambda body: ['0{"sid":"abc","pingInterval":25000,"pingTimeout":60000}'],
+    )
+    client = _make_client(monkeypatch)
+    await client._connect_once()
+
+    assert client._ws is not None
+    assert statuses[-1] == "connected"
+    assert "42/api/v2/socket_io,[\"dev_data\"]" in client._ws.sent
+    assert client._ws.sent.count("3") == 0  # handshake should not issue pong during setup
+
+
+def test_rand_t_token_format() -> None:
+    """Random polling tokens should be eight alphanumeric characters with a P prefix."""
+
+    token = ducaheat_ws._rand_t()
+
+    assert token.startswith("P")
+    assert len(token) == 8
+    assert token[1:].isalnum()
+
+
+def test_decode_polling_packets_additional_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise defensive Engine.IO polling decoder branches."""
+
+    # Short buffers should trigger the early break condition.
+    assert ducaheat_ws._decode_polling_packets(b"\x00\x00\x00") == []
+
+    # Invalid digit bytes should abort parsing without raising.
+    assert ducaheat_ws._decode_polling_packets(b"\x00\x0A") == []
+
+    # Missing digit markers should also result in an empty decode.
+    assert ducaheat_ws._decode_polling_packets(b"\x00\xFF\x00\x00") == []
+
+    # Length overruns should be handled gracefully.
+    assert ducaheat_ws._decode_polling_packets(b"\x00\x02\xFF\x00") == []
+
+    class FailingPayload(bytes):
+        def decode(self, *_: Any, **__: Any) -> str:  # pragma: no cover - exercised via test
+            raise ValueError
+
+    class ByteLike:
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def __len__(self) -> int:
+            return len(self._data)
+
+        def __getitem__(self, item: Any) -> Any:
+            result = self._data[item]
+            if isinstance(item, slice) and item.start and item.start >= 3:
+                return FailingPayload(result)
+            return result
+
+    # Emulate a decode failure to reach the exception branch.
+    assert ducaheat_ws._decode_polling_packets(ByteLike(b"\x00\x01\xFF\x00")) == []
+
+    # Trigger gzip decompression fallback by raising from gzip.decompress.
+    monkeypatch.setattr(ducaheat_ws, "gzip", SimpleNamespace(decompress=MagicMock(side_effect=OSError)))
+    assert ducaheat_ws._decode_polling_packets(b"\x1f\x8bbad") == []
+
+
+def test_brand_headers_apply_defaults() -> None:
+    """Brand headers should retain required defaults when optional values are missing."""
+
+    headers = ducaheat_ws._brand_headers("", "")
+
+    assert headers["User-Agent"] == ducaheat_ws.USER_AGENT
+    assert headers["X-Requested-With"] == ""
+    assert headers["Accept-Language"] == ducaheat_ws.ACCEPT_LANGUAGE
+
+
+def test_client_requires_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Constructing without an aiohttp session should fail."""
+
+    hass = SimpleNamespace(loop=asyncio.new_event_loop(), data={})
+    with pytest.raises(RuntimeError):
+        ducaheat_ws.DucaheatWSClient(
+            hass,
+            entry_id="entry",
+            dev_id="device",
+            api_client=SimpleNamespace(_session=None),  # type: ignore[arg-type]
+            coordinator=SimpleNamespace(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_and_runner_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_runner should cycle through connect, read, and disconnect before stopping."""
+
+    client = _make_client(monkeypatch)
+    statuses: list[str] = []
+    monkeypatch.setattr(client, "_disconnect", AsyncMock())
+    monkeypatch.setattr(client, "_update_status", lambda status: statuses.append(status))
+
+    async def _connect_once() -> None:
+        statuses.append("connect_once")
+
+    async def _read_loop() -> None:
+        statuses.append("read_loop")
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(client, "_connect_once", AsyncMock(side_effect=_connect_once))
+    monkeypatch.setattr(client, "_read_loop_ws", AsyncMock(side_effect=_read_loop))
+
+    await client._runner()
+
+    assert statuses[0] == "starting"
+    assert "connect_once" in statuses
+    assert "read_loop" in statuses
+    assert statuses[-1] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_start_method_reuses_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """start should cache the created asyncio task."""
+
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(client, "_runner", AsyncMock(return_value=None))
+
+    task_one = client.start()
+    task_two = client.start()
+
+    assert task_one is task_two
+    await asyncio.wait_for(task_one, 0.1)
+
+
+def test_is_running_reflects_task_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """is_running should track whether the background task is active."""
+
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(client, "_runner", AsyncMock(return_value=None))
+
+    assert client.is_running() is False
+    task = client.start()
+    assert client.is_running() is True
+    loop = client._loop
+    loop.run_until_complete(asyncio.sleep(0))
+    assert client.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_connect_once_open_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Different handshake failures should surface as HandshakeError instances."""
+
+    async def run(
+        expected_status: int,
+        *,
+        open_status: int = 200,
+        post_status: int = 200,
+        drain_status: int = 200,
+        decode_return: list[str] | None = None,
+        open_body: bytes | None = None,
+    ) -> None:
+        with monkeypatch.context() as patch:
+            client = _make_client(patch)
+            ws = client._session._ws  # type: ignore[attr-defined]
+            call_count = 0
+
+            if decode_return is not None:
+                patch.setattr(ducaheat_ws, "_decode_polling_packets", lambda _body: decode_return)
+
+            def fake_get(url: str, *, headers: dict[str, str]) -> StubResponse:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return StubResponse(status=open_status, body=open_body or client._session._open_body)  # type: ignore[attr-defined]
+                return StubResponse(status=drain_status)
+
+            def fake_post(
+                url: str, *, headers: dict[str, str], data: bytes
+            ) -> StubResponse:
+                return StubResponse(status=post_status)
+
+            patch.setattr(client._session, "get", fake_get)
+            patch.setattr(client._session, "post", fake_post)
+            patch.setattr(client._session, "ws_connect", AsyncMock(return_value=ws))
+
+            with pytest.raises(ducaheat_ws.HandshakeError) as err:
+                await client._connect_once()
+            assert err.value.status == expected_status
+
+    await run(403, open_status=403)
+    await run(590, decode_return=[])
+    await run(592, decode_return=['0{"pingInterval":1,"pingTimeout":1}'])
+    await run(500, decode_return=['0{"sid":"abc"}'], post_status=500)
+    await run(504, decode_return=['0{"sid":"abc"}'], drain_status=504)
+
+
+@pytest.mark.asyncio
+async def test_connect_once_probe_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unexpected probe acknowledgements should not abort the handshake."""
+
+    statuses: list[str] = []
+    monkeypatch.setattr(
+        ducaheat_ws._WSCommon,
+        "_update_status",
+        lambda self, status: statuses.append(status),
+    )
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(
+        ducaheat_ws,
+        "_decode_polling_packets",
+        lambda _body: ['0{"sid":"abc"}'],
+    )
+    assert client._session._ws is not None  # type: ignore[attr-defined]
+    client._session._ws._receive = asyncio.Queue()  # type: ignore[attr-defined]
+    client._session._ws._receive.put_nowait("weird")  # type: ignore[attr-defined]
+
+    await client._connect_once()
+
+    assert statuses[-1] == "connected"
+    assert any(frame == "5" for frame in client._ws.sent)  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_read_loop_additional_flows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise ping, namespace, and event handling branches."""
+
+    client = _make_client(monkeypatch)
+    send_history: list[str] = []
+
+    class RichWS:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def send_str(self, payload: str) -> None:
+            send_history.append(payload)
+
+        def __aiter__(self) -> Any:
+            async def _iterate() -> AsyncIterator[Any]:
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="1ignore")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="42")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="42/api,[\"ping\"]")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="442/invalid")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="442invalid")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="442[]")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="442[\"message\",\"ping\"]")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="442[\"other\",{}]")
+                yield SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="440")
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="442[\"dev_data\",{\"nodes\":{\"htr\":{\"samples\":{\"1\":{}}}}}]",
+                )
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="442[\"update\",{\"body\":{\"temp\":1},\"path\":\"/path\"}]",
+                )
+            return _iterate()
+
+    monkeypatch.setattr(client, "_dispatch_nodes", MagicMock())
+    emit_mock = AsyncMock()
+    monkeypatch.setattr(client, "_emit_sio", emit_mock)
+    updates: list[str] = []
+    monkeypatch.setattr(client, "_update_status", lambda status: updates.append(status))
+    client._ws = RichWS()  # type: ignore[assignment]
+
+    await client._read_loop_ws()
+
+    assert send_history.count("3/api") == 1
+    assert any(call.args == ("message", "pong") for call in emit_mock.await_args_list)
+    assert "healthy" in updates
+
+
+@pytest.mark.asyncio
+async def test_read_loop_handles_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Error frames should raise runtime exceptions."""
+
+    client = _make_client(monkeypatch)
+
+    class ErrorWS:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __aiter__(self) -> Any:
+            async def _iterate() -> AsyncIterator[Any]:
+                yield SimpleNamespace(type=aiohttp.WSMsgType.ERROR, data=None)
+            return _iterate()
+
+        def exception(self) -> str:
+            return "boom"
+
+    client._ws = ErrorWS()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError):
+        await client._read_loop_ws()
+
+
+@pytest.mark.asyncio
+async def test_read_loop_handles_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Close frames should surface as runtime errors."""
+
+    client = _make_client(monkeypatch)
+
+    class CloseWS:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __aiter__(self) -> Any:
+            async def _iterate() -> AsyncIterator[Any]:
+                yield SimpleNamespace(type=aiohttp.WSMsgType.CLOSE)
+            return _iterate()
+
+    client._ws = CloseWS()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError):
+        await client._read_loop_ws()
+
+
+@pytest.mark.asyncio
+async def test_read_loop_processes_update_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Update events should invoke the brief logger and mark the connection healthy."""
+
+    client = _make_client(monkeypatch)
+    log_calls: list[Any] = []
+    monkeypatch.setattr(client, "_log_update_brief", lambda body: log_calls.append(body))
+    statuses: list[str] = []
+    monkeypatch.setattr(client, "_update_status", lambda status: statuses.append(status))
+
+    class UpdateWS:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def __aiter__(self) -> Any:
+            async def _iterate() -> AsyncIterator[Any]:
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="442[\"update\",{\"body\":{\"temp\":1},\"path\":\"/path\"}]",
+                )
+            return _iterate()
+
+    client._ws = UpdateWS()  # type: ignore[assignment]
+
+    await client._read_loop_ws()
+
+    assert log_calls and log_calls[0]["body"]["temp"] == 1
+    assert statuses and statuses[-1] == "healthy"
+
+
+def test_log_nodes_summary_branches(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure node summary logging honours the configured log level."""
+
+    client = _make_client(monkeypatch)
+    nodes = {"htr": {"samples": {"1": {}}, "settings": {"2": {}}, "status": 3}}
+
+    monkeypatch.setattr(ducaheat_ws._LOGGER, "isEnabledFor", lambda level: False)
+    client._log_nodes_summary(nodes)
+
+    monkeypatch.setattr(ducaheat_ws._LOGGER, "isEnabledFor", lambda level: True)
+    with caplog.at_level(logging.INFO):
+        client._log_nodes_summary(nodes)
+
+    assert "htr=2" in caplog.text
+
+
+def test_log_update_brief_variants(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """_log_update_brief should handle mapping and non-mapping payloads."""
+
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(ducaheat_ws._LOGGER, "isEnabledFor", lambda level: True)
+
+    with caplog.at_level(logging.DEBUG):
+        client._log_update_brief({"path": "/x", "body": {"one": 1, "two": 2, "three": 3}})
+        client._log_update_brief("not a mapping")
+
+    assert "path=/x" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_emit_sio_requires_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Attempting to emit without a websocket should raise a runtime error."""
+
+    client = _make_client(monkeypatch)
+    client._ws = None
+
+    with pytest.raises(RuntimeError):
+        await client._emit_sio("evt")
+
+
+@pytest.mark.asyncio
+async def test_get_token_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The access token should be extracted from the Authorization header."""
+
+    client = _make_client(monkeypatch)
+    client._get_token = ducaheat_ws.DucaheatWSClient._get_token.__get__(  # type: ignore[method-assign]
+        client, ducaheat_ws.DucaheatWSClient
+    )
+    token = await client._get_token()
+
+    assert token == "rest-token"
+
+
+@pytest.mark.asyncio
+async def test_read_loop_returns_when_websocket_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The websocket reader should no-op when no connection is bound."""
+
+    client = _make_client(monkeypatch)
+    client._ws = None
+
+    await client._read_loop_ws()
+
+
+
+@pytest.mark.asyncio
+async def test_read_loop_handles_engineio_and_socketio_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Feed assorted Engine.IO frames through the websocket reader."""
+
+    client = _make_client(monkeypatch)
+    send_history: list[str] = []
+    client._ws = SimpleNamespace(closed=False)
+
+    class FakeWS:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def send_str(self, payload: str) -> None:
+            send_history.append(payload)
+
+        def __aiter__(self) -> Any:
+            async def _iterator() -> Any:
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="2",
+                )
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="42[\"message\",\"ping\"]",
+                )
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="40",
+                )
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="42{\"evt\":\"ignored\"}",
+                )
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="42[\"dev_data\",{\"nodes\":{\"htr\":{\"settings\":{\"1\":{}}}}}]",
+                )
+                yield SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data="42[\"update\",{\"body\":{\"path\":{}}}]",
+                )
+            return _iterator()
+
+    fake_ws = FakeWS()
+    client._ws = fake_ws  # type: ignore[assignment]
+
+    monkeypatch.setattr(client, "_dispatch_nodes", MagicMock())
+    monkeypatch.setattr(client, "_emit_sio", AsyncMock())
+    monkeypatch.setattr(client, "_update_status", lambda status: None)
+    await client._read_loop_ws()
+
+    assert any(frame == "3" for frame in send_history)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_websocket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure _disconnect invokes the aiohttp close sequence."""
+
+    client = _make_client(monkeypatch)
+    close_called: dict[str, Any] = {}
+
+    class ClosingWS:
+        closed = False
+
+        async def close(self, *, code: int, message: bytes) -> None:
+            close_called["code"] = code
+            close_called["message"] = message
+
+    client._ws = ClosingWS()  # type: ignore[assignment]
+    await client._disconnect("reason")
+
+    assert close_called["code"] == aiohttp.WSCloseCode.GOING_AWAY
+    assert close_called["message"] == b"reason"
+    assert client._ws is None
+
+
+@pytest.mark.asyncio
+async def test_get_token_requires_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing Authorization header should raise a runtime error."""
+
+    client = _make_client(monkeypatch)
+    client._get_token = ducaheat_ws.DucaheatWSClient._get_token.__get__(  # type: ignore[method-assign]
+        client, ducaheat_ws.DucaheatWSClient
+    )
+    monkeypatch.setattr(client._client, "authed_headers", AsyncMock(return_value={}))
+
+    with pytest.raises(RuntimeError):
+        await client._get_token()

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -1,0 +1,671 @@
+"""Extended tests for TermoWeb websocket protocol flows."""
+
+from __future__ import annotations
+
+import asyncio
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.termoweb.backend import termoweb_ws as module
+
+
+class DummyREST:
+    """Provide just enough of the REST client interface for websocket tests."""
+
+    def __init__(self) -> None:
+        self._session = SimpleNamespace(closed=True)
+        self._ensure_token = AsyncMock()
+        self._authed_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
+        self.api_base = "https://api.termoweb"
+        self.user_agent = "agent"
+        self.requested_with = "requested"
+
+
+class StubAsyncClient:
+    """Socket.IO client stub recording method invocations."""
+
+    def __init__(self, allow_http_error: bool = False, **_: Any) -> None:
+        object.__setattr__(self, "events", {})
+        object.__setattr__(self, "_connected", False)
+        object.__setattr__(self, "connect_calls", [])
+        object.__setattr__(self, "disconnect_calls", 0)
+        object.__setattr__(self, "emit_calls", [])
+        object.__setattr__(self, "_allow_http_error", allow_http_error)
+        object.__setattr__(self, "_http_attempts", 0)
+        object.__setattr__(self, "eio", SimpleNamespace(start_background_task=None, http=None))
+        object.__setattr__(self, "http", None)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "http" and getattr(self, "_allow_http_error", False):
+            attempts = getattr(self, "_http_attempts")
+            if attempts == 0:
+                object.__setattr__(self, "_http_attempts", attempts + 1)
+                object.__setattr__(self, "_allow_http_error", False)
+                raise AttributeError("http is managed dynamically")
+        object.__setattr__(self, name, value)
+
+    def on(self, event: str, *, handler: Any, namespace: str | None = None) -> None:
+        self.events[(event, namespace)] = handler
+
+    async def connect(self, *args: Any, **kwargs: Any) -> None:
+        self.connect_calls.append((args, kwargs))
+        object.__setattr__(self, "_connected", True)
+
+    async def disconnect(self) -> None:
+        object.__setattr__(self, "_connected", False)
+        object.__setattr__(self, "disconnect_calls", self.disconnect_calls + 1)
+
+    async def emit(self, event: str, data: Any | None = None, *, namespace: str | None = None) -> None:
+        self.emit_calls.append((event, data, namespace))
+
+    @property
+    def connected(self) -> bool:
+        return getattr(self, "_connected")
+
+
+def _make_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    hass_loop: Any | None = None,
+    allow_http_error: bool = False,
+) -> tuple[module.WebSocketClient, StubAsyncClient, MagicMock]:
+    """Instantiate a ``WebSocketClient`` with a controllable AsyncClient stub."""
+
+    holder: dict[str, StubAsyncClient] = {}
+
+    def factory(**kwargs: Any) -> StubAsyncClient:
+        stub = StubAsyncClient(allow_http_error=allow_http_error, **kwargs)
+        holder["client"] = stub
+        return stub
+
+    monkeypatch.setattr(module.socketio, "AsyncClient", factory)
+    dispatcher = MagicMock()
+    monkeypatch.setattr(module, "async_dispatcher_send", dispatcher)
+
+    if hass_loop is None:
+        hass_loop = SimpleNamespace(
+            create_task=lambda coro, **_: SimpleNamespace(done=lambda: False),
+            call_soon_threadsafe=lambda cb, *args: cb(*args),
+        )
+
+    hass = SimpleNamespace(loop=hass_loop, data={module.DOMAIN: {"entry": {}}})
+    coordinator = SimpleNamespace(update_nodes=MagicMock(), data={})
+    client = module.WebSocketClient(
+        hass,
+        entry_id="entry",
+        dev_id="device",
+        api_client=DummyREST(),
+        coordinator=coordinator,
+        session=SimpleNamespace(closed=True),
+    )
+    return client, holder["client"], dispatcher
+
+
+def test_handshake_error_exposes_fields() -> None:
+    """The TermoWeb handshake error should record status, URL and body."""
+
+    error = module.HandshakeError(503, "https://example/ws", "body")
+    assert str(error) == "handshake failed (status=503)"
+    assert error.status == 503
+    assert error.url == "https://example/ws"
+    assert error.body_snippet == "body"
+
+
+def test_init_handles_socketio_http_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Initialisation should recover when AsyncClient rejects ``http`` assignment."""
+
+    client, sio, _ = _make_client(monkeypatch, allow_http_error=True)
+    assert isinstance(client, module.WebSocketClient)
+    assert sio._http_attempts == 1
+    assert sio.http is not None
+    assert sio.eio.http is not None
+
+
+@pytest.mark.asyncio
+async def test_connect_once_invokes_socketio_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_connect_once should reset backoff and call the AsyncClient."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    monkeypatch.setattr(client, "_build_engineio_target", AsyncMock(return_value=("wss://ws", "socket.io")))
+    client._stop_event.clear()
+
+    await client._connect_once()
+
+    assert sio.connect_calls
+    assert client._backoff_idx == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_events_cancels_pending_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_wait_for_events should cancel whichever wait completes second."""
+
+    loop = asyncio.get_running_loop()
+    hass_loop = SimpleNamespace(
+        create_task=lambda coro, **kwargs: loop.create_task(coro, **kwargs),
+        call_soon_threadsafe=lambda cb, *args: loop.call_soon(cb, *args),
+    )
+    client, _sio, _ = _make_client(monkeypatch, hass_loop=hass_loop)
+    client._stop_event = asyncio.Event()
+    client._disconnected = asyncio.Event()
+    client._stop_event.set()
+    client._loop = loop
+
+    await client._wait_for_events()
+
+
+@pytest.mark.asyncio
+async def test_runner_handles_errors_and_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The connection runner should retry until ``_closing`` is set."""
+
+    client, _sio, dispatcher = _make_client(monkeypatch)
+    call_order: list[str] = []
+
+    async def connect_once() -> None:
+        call_order.append("connect")
+
+    async def wait_for_events() -> None:
+        call_order.append("wait")
+
+    async def disconnect(**_: Any) -> None:
+        call_order.append("disconnect")
+
+    async def lost(error: Exception | None) -> None:
+        call_order.append(f"lost:{type(error).__name__ if error else 'none'}")
+        client._closing = True
+
+    client._connect_once = AsyncMock(side_effect=connect_once)  # type: ignore[attr-defined]
+    client._wait_for_events = AsyncMock(side_effect=wait_for_events)  # type: ignore[attr-defined]
+    client._disconnect = AsyncMock(side_effect=disconnect)  # type: ignore[attr-defined]
+    client._handle_connection_lost = AsyncMock(side_effect=lost)  # type: ignore[attr-defined]
+
+    await client._runner()
+
+    assert call_order == ["connect", "wait", "disconnect", "lost:none"]
+    dispatcher.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_connection_lost_updates_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Losing the connection should persist restart metadata."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    state = client._ws_state_bucket()
+    assert state.get("restart_count") is None
+
+    await client._handle_connection_lost(RuntimeError("boom"))
+
+    assert state["restart_count"] == 1
+    assert "RuntimeError" in state["last_disconnect_error"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_calls_socketio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_disconnect should call the AsyncClient when connected."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    await sio.connect()
+    await client._disconnect(reason="tests")
+    assert sio.disconnect_calls == 1
+    assert client._disconnected.is_set()
+
+
+@pytest.mark.asyncio
+async def test_build_engineio_target_uses_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Engine.IO URL builder should include the token and device id."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    monkeypatch.setattr(client, "_get_token", AsyncMock(return_value="tok"))
+    url, path = await client._build_engineio_target()
+    assert url.startswith("https://api.termoweb")
+    assert "token=tok" in url and "dev_id=device" in url
+    assert path == "socket.io"
+
+
+@pytest.mark.asyncio
+async def test_on_connect_schedules_idle_monitor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Connecting should reset metrics and schedule the idle monitor."""
+
+    loop = asyncio.get_running_loop()
+    created: list[asyncio.Task] = []
+
+    def create_task(coro: Any, **_: Any) -> asyncio.Task:
+        task = loop.create_task(asyncio.sleep(0))
+        created.append(task)
+        return task
+
+    hass_loop = SimpleNamespace(
+        create_task=create_task,
+        call_soon_threadsafe=lambda cb, *args: loop.call_soon(cb, *args),
+    )
+    client, _sio, dispatcher = _make_client(monkeypatch, hass_loop=hass_loop)
+    await client._on_connect()
+    assert created
+    dispatcher.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_namespace_connect_emits_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Joining the namespace should emit join and dev_data events."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    await client._on_namespace_connect()
+    assert ("join", None, module.WS_NAMESPACE) in sio.emit_calls
+    assert ("dev_data", None, module.WS_NAMESPACE) in sio.emit_calls
+
+
+def test_register_debug_catch_all_installs_handler(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Debug catch-all registration should wrap the AsyncClient when DEBUG is enabled."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    caplog.set_level("DEBUG", logger=module._LOGGER.name)
+    client._register_debug_catch_all()
+    assert ("*", module.WS_NAMESPACE) in sio.events
+
+
+@pytest.mark.asyncio
+async def test_on_disconnect_cancels_monitor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disconnecting should cancel the idle monitor task and set the flag."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    client._idle_monitor_task = asyncio.create_task(asyncio.sleep(0))
+    await asyncio.sleep(0)
+    await client._on_disconnect()
+    assert client._idle_monitor_task is None
+    assert client._disconnected.is_set()
+
+
+@pytest.mark.asyncio
+async def test_refresh_subscription_emits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refreshing the subscription should emit dev_data and resubscribe samples."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    await sio.connect()
+    monkeypatch.setattr(client, "_subscribe_heater_samples", AsyncMock())
+    await client._refresh_subscription(reason="timer")
+    assert ("dev_data", None, module.WS_NAMESPACE) in sio.emit_calls
+    client._subscribe_heater_samples.assert_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_idle_monitor_refreshes_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The idle monitor should attempt to refresh and exit when closing."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    await sio.connect()
+    client._payload_idle_window = 1.0
+    client._stats.last_event_ts = 100.0
+    client._subscription_refresh_failed = False
+    client._closing = False
+    refresh_calls: list[str] = []
+
+    async def fake_refresh(**_: Any) -> None:
+        refresh_calls.append("refresh")
+        client._closing = True
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(_: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(client, "_refresh_subscription", AsyncMock(side_effect=fake_refresh))
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(module.time, "time", lambda: 200.0)
+
+    await client._idle_monitor()
+
+    assert refresh_calls == ["refresh"]
+
+
+def test_translate_path_update_and_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Path based updates should map onto node sections."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    payload = {
+        "path": "/api/devs/device/htr/1/settings/temp",
+        "body": {"value": 20},
+    }
+    translated = client._translate_path_update(payload)
+    assert translated == {"htr": {"settings": {"1": {"temp": {"value": 20}}}}}
+    assert module.WebSocketClient._resolve_update_section("advanced_setup") == ("advanced", "advanced_setup")
+    assert module.WebSocketClient._resolve_update_section("prog") == ("settings", "prog")
+    assert module.WebSocketClient._resolve_update_section(None) == (None, None)
+
+
+def test_forward_sample_updates_invokes_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sample update forwarding should call the energy coordinator hook."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    handler = MagicMock()
+    client.hass.data[module.DOMAIN]["entry"]["energy_coordinator"] = SimpleNamespace(
+        handle_ws_samples=handler
+    )
+    client._forward_sample_updates({"htr": {"1": {"power": 10}}})
+    handler.assert_called_once()
+
+
+def test_extract_and_translate_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """List based node payloads should be converted into the mapping schema."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    payload = {"nodes": [{"type": "htr", "addr": "1", "settings": {"temp": 20}}]}
+    nodes = client._extract_nodes(payload)
+    assert nodes and "htr" in nodes
+    assert payload["nodes"]["htr"]
+
+
+def test_apply_nodes_payload_merges_and_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Applying node payloads should build snapshots and dispatch updates."""
+
+    client, _sio, dispatcher = _make_client(monkeypatch)
+    client._collect_update_addresses = MagicMock(return_value=[("htr", "1")])  # type: ignore[attr-defined]
+    client._dispatch_nodes = MagicMock(return_value={"htr": ["1"]})  # type: ignore[attr-defined]
+    client._forward_sample_updates = MagicMock()  # type: ignore[attr-defined]
+    client._mark_event = MagicMock()  # type: ignore[attr-defined]
+
+    snapshot_payload = {"nodes": {"htr": {"settings": {"1": {"temp": 20}}}}}
+    client._apply_nodes_payload(snapshot_payload, merge=False, event="dev_data")
+    assert client._nodes["nodes"]["htr"]
+
+    update_payload = {"path": "/api/devs/device/htr/1/samples", "body": {"power": 5}}
+    client._apply_nodes_payload(update_payload, merge=True, event="update")
+    client._forward_sample_updates.assert_called()
+    client._mark_event.assert_called()
+
+
+def test_ensure_type_bucket_and_build_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Helper methods should populate node buckets and snapshot structures."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    dev_map: dict[str, Any] = {}
+    nodes_by_type: dict[str, Any] = {}
+    bucket = client._ensure_type_bucket(dev_map, nodes_by_type, "htr")
+    assert "settings" in bucket and dev_map["htr"] is bucket
+    snapshot = module.WebSocketClient._build_nodes_snapshot({"htr": {"settings": {"1": {}}}})
+    assert "nodes" in snapshot and "nodes_by_type" in snapshot
+
+
+def test_apply_heater_addresses_updates_coordinator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Applying heater addresses should update the coordinator data map."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    client._coordinator.data = {"device": {}}
+    normalized = client._apply_heater_addresses({"htr": ["1"]}, inventory=[("htr", "1")])
+    assert normalized["htr"] == ["1"]
+    assert client._coordinator.data["device"]["nodes_by_type"]
+
+
+def test_heater_sample_subscription_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Subscription helper should normalise addresses before returning targets."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "collect_heater_sample_addresses",
+        lambda record, coordinator=None: ([("htr", "1")], {"htr": ["1"]}, {}),
+    )
+    targets = client._heater_sample_subscription_targets()
+    assert targets == [("htr", "1")]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_heater_samples_emits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Subscribing to heater samples should emit for each address."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    monkeypatch.setattr(
+        client,
+        "_heater_sample_subscription_targets",
+        lambda: [("htr", "1"), ("aux", "2")],
+    )
+    await client._subscribe_heater_samples()
+    assert ("subscribe", "/htr/1/samples", module.WS_NAMESPACE) in sio.emit_calls
+    assert ("subscribe", "/aux/2/samples", module.WS_NAMESPACE) in sio.emit_calls
+
+
+def test_header_sanitizers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Header and URL sanitisation helpers should redact sensitive values."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    client._requested_with = ""
+
+    headers = client._brand_headers(origin="https://app")
+    assert headers["Origin"] == "https://app"
+    assert headers["User-Agent"] == "agent"
+    assert headers["Accept-Language"] == module.ACCEPT_LANGUAGE
+
+    assert client._redact_value("") == ""
+    assert client._redact_value("abc") == "***"
+    assert client._redact_value("abcdefgh") == "ab***gh"
+    assert client._redact_value("abcdefghijklmnop") == "abcd...mnop"
+
+    assert client._mask_identifier("abcd") == "***"
+    assert client._mask_identifier("abcdefgh") == "ab...gh"
+    assert client._mask_identifier("abcdefghijklmnop") == "abcdef...mnop"
+
+    sanitised = client._sanitise_headers(
+        {
+            "Authorization": "Bearer secret-token",
+            "Cookie": "session",
+            "X-Test": b"value",
+        }
+    )
+    assert "..." in sanitised["Authorization"]
+    assert "***" in sanitised["Cookie"]
+    assert sanitised["X-Test"] == "value"
+
+    params = client._sanitise_params({"token": "abc12345", "dev_id": "dev123", "q": "ok"})
+    assert params["token"].startswith("ab") and params["token"].endswith("45")
+    assert params["dev_id"].startswith("de") and params["dev_id"].endswith("23")
+
+    sanitised_url = client._sanitise_url("https://host/socket?token=abc&dev_id=12345")
+    assert "abc" not in sanitised_url
+    assert "12345" not in sanitised_url
+    assert client._sanitise_url("not a url") == "not a url"
+
+
+@pytest.mark.asyncio
+async def test_wrap_background_task_handles_sync_callable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-coroutine targets should be wrapped in an async task."""
+
+    loop = asyncio.get_running_loop()
+    hass_loop = SimpleNamespace(
+        create_task=lambda coro, **kwargs: loop.create_task(coro, **kwargs),
+        call_soon_threadsafe=lambda cb, *args: loop.call_soon(cb, *args),
+    )
+    client, _sio, _ = _make_client(monkeypatch, hass_loop=hass_loop)
+
+    result: list[int] = []
+
+    def add_value(value: int) -> int:
+        result.append(value)
+        return value * 2
+
+    task = client._wrap_background_task(add_value, 3)
+    await task
+
+    assert result == [3]
+    assert asyncio.iscoroutine(task.result())
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_manage_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """start should spawn tasks and stop should cancel them cleanly."""
+
+    loop = asyncio.get_running_loop()
+    hass_loop = SimpleNamespace(
+        create_task=lambda coro, **kwargs: loop.create_task(coro, **kwargs),
+        call_soon_threadsafe=lambda cb, *args: loop.call_soon(cb, *args),
+    )
+    client, _sio, _ = _make_client(monkeypatch, hass_loop=hass_loop)
+
+    runner_gate = asyncio.Event()
+
+    async def runner() -> None:
+        try:
+            await runner_gate.wait()
+        except asyncio.CancelledError:
+            raise
+
+    monkeypatch.setattr(client, "_runner", runner)
+    monkeypatch.setattr(client, "_disconnect", AsyncMock())
+    client._idle_restart_task = loop.create_task(asyncio.sleep(0))
+    client._idle_monitor_task = loop.create_task(asyncio.sleep(0))
+
+    task = client.start()
+    assert client.is_running() is True
+    runner_gate.set()
+    await asyncio.sleep(0)
+    await client.stop()
+    assert client.is_running() is False
+    assert task.cancelled() or task.done()
+
+
+def test_handle_connection_lost_records_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Connection loss metadata should be stored in the state bucket."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    bucket = client._ws_state_bucket()
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(client._handle_connection_lost(RuntimeError("boom")))
+    loop.close()
+    assert bucket["restart_count"] == 1
+    assert "RuntimeError" in bucket["last_disconnect_error"]
+
+
+@pytest.mark.asyncio
+async def test_build_engineio_target_handles_invalid_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid API bases should raise runtime errors."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    url, path = await client._build_engineio_target()
+    assert path == "socket.io"
+    assert "token" in url and "dev_id" in url
+
+    monkeypatch.setattr(client, "_api_base", lambda: "http://")
+    with pytest.raises(RuntimeError):
+        await client._build_engineio_target()
+
+
+def test_register_debug_catch_all_requires_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Debug catch-all should register only when debugging is enabled."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    client._debug_catch_all_registered = False
+    monkeypatch.setattr(module._LOGGER, "isEnabledFor", lambda level: True)
+    client._register_debug_catch_all()
+    assert client._debug_catch_all_registered is True
+    assert ("*", client._namespace) in sio.events
+
+
+@pytest.mark.asyncio
+async def test_event_handlers_update_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    """dev_handshake, dev_data, and update events should update counters."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    monkeypatch.setattr(client, "_handle_dev_data", MagicMock())
+    monkeypatch.setattr(client, "_handle_update", MagicMock())
+    monkeypatch.setattr(client, "_subscribe_heater_samples", AsyncMock())
+
+    await client._on_dev_handshake({"hello": "world"})
+    assert client._stats.frames_total == 1
+
+    await client._on_dev_data({"nodes": {}})
+    await client._on_update({})
+    assert client._stats.frames_total == 3
+    client._handle_dev_data.assert_called_once()
+    client._handle_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_subscription_behaviour(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refreshing subscriptions should emit dev_data and resubscribe."""
+
+    client, sio, _ = _make_client(monkeypatch)
+    sio._connected = True
+    emit = AsyncMock()
+    monkeypatch.setattr(client._sio, "emit", emit)
+    monkeypatch.setattr(client, "_subscribe_heater_samples", AsyncMock())
+    monkeypatch.setattr(module._LOGGER, "isEnabledFor", lambda level: True)
+
+    await client._refresh_subscription(reason="manual")
+    emit.assert_called_with("dev_data", namespace=client._namespace)
+    assert client._subscription_refresh_failed is False
+
+    sio._connected = False
+    with pytest.raises(RuntimeError):
+        await client._refresh_subscription(reason="not connected")
+
+
+def test_apply_nodes_payload_translation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Node payload application should merge data and notify listeners."""
+
+    client, _sio, dispatcher = _make_client(monkeypatch)
+    client._nodes = {}
+    client._nodes_raw = {}
+    client._handshake_payload = {"nodes": {}}
+    client._handle_handshake({"nodes": {"htr": {"status": {"1": {"temp": 20}}}}})
+    client._apply_nodes_payload(
+        {"nodes": {"htr": {"status": {"1": {"temp": 25}}}}}, merge=True, event="update"
+    )
+    assert client._nodes["htr"]["status"]["1"]["temp"] == 25
+    dispatcher.assert_called()
+
+
+def test_translate_nodes_list_handles_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """List-based node payloads should be normalised into mappings."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    nodes = [
+        {"type": "htr", "addr": "1", "status": {"temp": 21}},
+        {"type": "htr", "addr": "1", "advanced_setup": {"mode": "eco"}},
+        {"type": "bad", "addr": None},
+    ]
+    translated = client._translate_nodes_list(nodes)
+    assert translated["htr"]["status"]["1"]["temp"] == 21
+    assert translated["htr"]["advanced"]["1"]["advanced_setup"]["mode"] == "eco"
+
+
+def test_forward_sample_updates_invokes_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Forwarding sample updates should notify the energy coordinator handler."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    handler_called: dict[str, Any] = {}
+    energy_handler = SimpleNamespace(
+        handle_ws_samples=lambda dev_id, payload: handler_called.update({
+            "dev_id": dev_id,
+            "payload": payload,
+        })
+    )
+    client.hass.data[module.DOMAIN]["entry"]["energy_coordinator"] = energy_handler
+    client._forward_sample_updates({"htr": {"samples": {"1": {"temp": 20}}}})
+    assert handler_called["dev_id"] == "device"
+    assert handler_called["payload"]["htr"]["samples"]["1"]["temp"] == 20
+
+
+def test_extract_nodes_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_extract_nodes should handle dicts, lists, and invalid payloads."""
+
+    client, _sio, _ = _make_client(monkeypatch)
+    assert client._extract_nodes({"nodes": {"htr": {}}}) == {"htr": {}}
+    converted = client._extract_nodes({"nodes": [{"type": "htr", "addr": "1", "status": {}}]})
+    assert "htr" in converted
+    assert client._extract_nodes("not a dict") is None
+
+
+def test_resolve_update_section_variants() -> None:
+    """Update section resolver should map known segments consistently."""
+
+    assert module.WebSocketClient._resolve_update_section(None) == (None, None)
+    assert module.WebSocketClient._resolve_update_section("status") == ("status", None)
+    assert module.WebSocketClient._resolve_update_section("advanced_setup") == (
+        "advanced",
+        "advanced_setup",
+    )
+    assert module.WebSocketClient._resolve_update_section("setup") == ("settings", "setup")
+    assert module.WebSocketClient._resolve_update_section("unknown") == ("settings", "unknown")
+

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import gzip
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any, Mapping
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import logging
+import sys
+
 from custom_components.termoweb.backend import ducaheat_ws
 from custom_components.termoweb.backend import termoweb_ws as module
+from custom_components.termoweb.backend import ws_client as base_ws
 
 
 class DummyREST:
@@ -27,9 +31,53 @@ class DummyREST:
     async def authed_headers(self) -> dict[str, str]:
         return self._headers
 
+    async def _authed_headers(self) -> dict[str, str]:
+        return await self.authed_headers()
+
     async def refresh_token(self) -> None:
         self._access_token = None
         await self._ensure_token()
+
+
+class DummyLoop:
+    """Simple event loop stub recording created tasks."""
+
+    def __init__(self) -> None:
+        self.created_tasks: list[DummyTask] = []
+
+    def create_task(self, coro: Any, **_: Any) -> "DummyTask":
+        task = DummyTask(coro)
+        self.created_tasks.append(task)
+        return task
+
+    def call_soon_threadsafe(self, callback: Any, *args: Any) -> None:
+        callback(*args)
+
+
+class DummyTask:
+    """Track coroutine execution for idle restart tests."""
+
+    def __init__(self, coro: Any) -> None:
+        self.coro = coro
+        self._cancelled = False
+        self._completed = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
+        self._completed = True
+        try:
+            self.coro.close()
+        except AttributeError:
+            pass
+
+    def done(self) -> bool:
+        return self._completed
+
+    async def run(self) -> Any:
+        try:
+            return await self.coro
+        finally:
+            self._completed = True
 
 
 @pytest.fixture(autouse=True)
@@ -86,13 +134,16 @@ def _make_termoweb_client(
 
 def _make_ducaheat_client(
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    hass_loop: Any | None = None,
 ) -> ducaheat_ws.DucaheatWSClient:
     """Instantiate a Ducaheat websocket client for tests."""
 
-    hass_loop = SimpleNamespace(
-        create_task=lambda coro, **_: SimpleNamespace(done=lambda: True),
-        call_soon_threadsafe=lambda cb, *args: cb(*args),
-    )
+    if hass_loop is None:
+        hass_loop = SimpleNamespace(
+            create_task=lambda coro, **_: SimpleNamespace(done=lambda: True),
+            call_soon_threadsafe=lambda cb, *args: cb(*args),
+        )
     hass = SimpleNamespace(loop=hass_loop, data={module.DOMAIN: {"entry": {}}})
     rest_client = DummyREST(is_ducaheat=True)
     dispatcher = MagicMock()
@@ -147,6 +198,87 @@ def test_collect_update_addresses_extracts() -> None:
     }
     addresses = module.WebSocketClient._collect_update_addresses(nodes)
     assert addresses == [("aux", "3"), ("htr", "1")]
+
+
+def test_handshake_error_exposes_status_and_url() -> None:
+    """Ensure ``HandshakeError`` forwards the status and URL details."""
+
+    error = base_ws.HandshakeError(470, "https://example/ws", "nope")
+    assert "handshake failed" in str(error)
+    assert error.status == 470
+    assert error.url == "https://example/ws"
+
+
+def test_dispatch_nodes_without_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fall back to ``ensure_node_inventory`` when no snapshot exists."""
+
+    hass_record: dict[str, Any] = {}
+    hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": hass_record}})
+    coordinator = SimpleNamespace(update_nodes=MagicMock())
+    dispatcher = MagicMock()
+    monkeypatch.setattr(base_ws, "async_dispatcher_send", dispatcher)
+    seen: dict[str, Any] = {}
+
+    def fake_ensure(record_map: Mapping[str, Any], *, nodes: Any) -> list[dict[str, str]]:
+        seen["record"] = record_map
+        seen["nodes"] = nodes
+        return [{"addr": "1", "type": "htr"}]
+
+    monkeypatch.setattr(base_ws, "ensure_node_inventory", fake_ensure)
+    monkeypatch.setattr(
+        base_ws,
+        "addresses_by_node_type",
+        lambda inventory, **_: ({"htr": {"1"}}, {}),
+    )
+
+    class DummyCommon(base_ws._WSCommon):
+        def __init__(self) -> None:
+            self.hass = hass
+            self.entry_id = "entry"
+            self.dev_id = "device"
+            self._coordinator = coordinator
+
+    payload = {"nodes": [{"addr": "1", "type": "htr"}]}
+    DummyCommon()._dispatch_nodes(payload)
+
+    assert seen["record"] is hass_record
+    assert seen["nodes"] is payload["nodes"]
+    coordinator.update_nodes.assert_called_once_with(payload["nodes"], [{"addr": "1", "type": "htr"}])
+    dispatcher.assert_called_once()
+    dispatched_payload = dispatcher.call_args.args[2]
+    assert dispatched_payload["addr_map"] == {"htr": ["1"]}
+
+
+@pytest.mark.asyncio
+async def test_websocket_client_reuses_delegate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Starting twice should reuse the already created delegate."""
+
+    hass = SimpleNamespace(loop=asyncio.get_event_loop(), data={base_ws.DOMAIN: {}})
+    client = base_ws.WebSocketClient(
+        hass,
+        entry_id="entry",
+        dev_id="device",
+        api_client=DummyREST(),
+        coordinator=SimpleNamespace(),
+    )
+    delegate = SimpleNamespace(
+        start=MagicMock(return_value="task"),
+        stop=AsyncMock(return_value=None),
+        is_running=MagicMock(return_value=True),
+        ws_url=AsyncMock(return_value="wss://example/ws"),
+    )
+    client._delegate = delegate  # type: ignore[assignment]
+
+    assert client.start() == "task"
+    delegate.start.assert_called_once_with()
+    assert client.is_running() is True
+
+    await client.stop()
+    delegate.stop.assert_awaited_once_with()
+    assert await client.ws_url() == "wss://example/ws"
+
+    client._delegate = None
+    assert await client.ws_url() == ""
 
 
 def test_collect_update_addresses_skips_invalid() -> None:
@@ -251,3 +383,599 @@ def test_ducaheat_log_nodes_summary_includes_counts(
     client._log_nodes_summary({"htr": {"settings": {"1": {}, "2": {}}}})
     assert "htr" in caplog.text
     assert "2" in caplog.text
+
+
+def test_termoweb_brand_headers_optional_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Brand headers should include requested-with and optional origin."""
+
+    client = _make_termoweb_client(monkeypatch)
+    headers = client._brand_headers(origin="https://app.example")
+    assert headers["User-Agent"]
+    assert headers["X-Requested-With"]
+    assert headers["Origin"] == "https://app.example"
+
+
+def test_termoweb_value_redaction_behaviour(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redaction helpers should mask tokens and identifiers consistently."""
+
+    client = _make_termoweb_client(monkeypatch)
+    assert client._redact_value("  ") == ""
+    assert client._redact_value("abcd") == "***"
+    assert client._redact_value("abcdefgh") == "ab***gh"
+    assert client._redact_value("abcdefghijk") == "abcd...hijk"
+    assert client._mask_identifier("   ") == ""
+    assert client._mask_identifier("xy") == "***"
+    assert client._mask_identifier("abcdefgh") == "ab...gh"
+    assert client._mask_identifier("abcdefghijkl") == "abcdef...ijkl"
+
+
+def test_termoweb_sanitise_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sensitive header, parameter and URL values should be redacted."""
+
+    client = _make_termoweb_client(monkeypatch)
+    headers = {
+        "Authorization": "Bearer secret-token-value",
+        "Cookie": "sid=123456789",
+        "X-Test": "value",
+        "Binary": b"token",
+    }
+    sanitised_headers = client._sanitise_headers(headers)
+    assert sanitised_headers["Authorization"].startswith("Bearer ")
+    assert "..." in sanitised_headers["Authorization"]
+    assert sanitised_headers["Cookie"] != "sid=123456789"
+    assert "..." in sanitised_headers["Cookie"]
+    assert sanitised_headers["Binary"] == "token"
+    params = {
+        "token": "secrettoken",
+        "dev_id": "device123456",
+        "other": "keep",
+    }
+    sanitised_params = client._sanitise_params(params)
+    assert sanitised_params["token"].startswith("secr")
+    assert "..." in sanitised_params["token"]
+    assert sanitised_params["dev_id"].startswith("device")
+    url = "wss://example/ws?token=abc123456&dev_id=device123456&flag=1"
+    sanitised_url = client._sanitise_url(url)
+    assert "token=abc1" in sanitised_url and "..." in sanitised_url
+    assert "dev_id=device" in sanitised_url and "..." in sanitised_url
+    assert client._sanitise_url("://bad url") == "://bad url"
+
+
+def test_termoweb_mark_event_updates_state(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Receiving an event should refresh health tracking and state buckets."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+    caplog.set_level("DEBUG", logger=module._LOGGER.name)
+    state_before = client._ws_state_bucket().copy()
+    client._mark_event(paths=["/node/1"])
+    state_after = client._ws_state_bucket()
+    assert state_after["last_event_at"] != state_before.get("last_event_at")
+    assert state_after["events_total"] == 1
+    assert client._healthy_since is not None
+    assert client._stats.last_paths == ["/node/1"]
+
+
+@pytest.mark.asyncio
+async def test_termoweb_idle_restart_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Idle restart scheduling should close the socket and clear pending flags."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+    client._disconnect = AsyncMock()  # type: ignore[attr-defined]
+    client._closing = False
+    client._schedule_idle_restart(idle_for=300.0, source="test idle")
+    assert client._idle_restart_pending is True
+    assert client._ws_state_bucket()["idle_restart_pending"] is True
+    assert loop.created_tasks
+    task = loop.created_tasks[0]
+    await task.run()
+    client._disconnect.assert_awaited()
+    assert client._idle_restart_task is None
+    assert client._idle_restart_pending is False
+    assert client._ws_state_bucket()["idle_restart_pending"] is False
+
+
+@pytest.mark.asyncio
+async def test_termoweb_cancel_idle_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancelling an idle restart should reset pending flags."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+    client._closing = False
+    client._schedule_idle_restart(idle_for=120.0, source="test idle")
+    assert client._idle_restart_pending is True
+    client._cancel_idle_restart()
+    assert client._idle_restart_pending is False
+    assert client._ws_state_bucket()["idle_restart_pending"] is False
+
+
+@pytest.mark.asyncio
+async def test_termoweb_get_token_from_rest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The websocket client should reuse REST client authorization tokens."""
+
+    client = _make_termoweb_client(monkeypatch)
+    rest_client = client._client
+    rest_client._authed_headers = AsyncMock(  # type: ignore[attr-defined]
+        return_value={"Authorization": "Bearer newtoken"}
+    )
+    token = await client._get_token()
+    assert token == "newtoken"
+
+
+@pytest.mark.asyncio
+async def test_termoweb_get_token_missing_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing authorization headers should raise an error."""
+
+    client = _make_termoweb_client(monkeypatch)
+    rest_client = client._client
+    rest_client._authed_headers = AsyncMock(return_value={})  # type: ignore[attr-defined]
+    with pytest.raises(RuntimeError):
+        await client._get_token()
+
+
+def test_termoweb_wrap_background_task_handles_sync_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Background task wrapper should handle synchronous callables."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+
+    task = client._wrap_background_task(lambda value: value + 1, 4)
+    assert isinstance(task, DummyTask)
+    assert loop.created_tasks
+    assert task is loop.created_tasks[0]
+    assert task.done() is False
+
+    async def _async_target(value: int) -> int:
+        return value * 2
+
+    async_task = client._wrap_background_task(_async_target, 6)
+    assert len(loop.created_tasks) == 2
+    assert async_task is loop.created_tasks[1]
+
+    for created in loop.created_tasks:
+        created.cancel()
+
+
+def test_termoweb_start_reuses_existing_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Starting when already running should return the existing task."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+    async def _noop() -> None:
+        return None
+
+    existing = DummyTask(_noop())
+    client._task = existing
+
+    task = client.start()
+    assert task is existing
+    assert not loop.created_tasks
+    existing.cancel()
+
+
+def test_termoweb_start_creates_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Starting without a running task should schedule the runner."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+    runner = AsyncMock()
+    client._runner = runner  # type: ignore[assignment]
+
+    task = client.start()
+    assert task is loop.created_tasks[0]
+    assert runner.await_count == 0
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_termoweb_stop_cancels_background_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping should cancel scheduled background tasks and disconnect."""
+
+    running_loop = asyncio.get_running_loop()
+    hass_loop = SimpleNamespace(
+        create_task=lambda coro, **kwargs: running_loop.create_task(coro, **kwargs),
+        call_soon_threadsafe=lambda cb, *args: running_loop.call_soon(cb, *args),
+    )
+    client = _make_termoweb_client(monkeypatch, hass_loop=hass_loop)
+    client._disconnect = AsyncMock()  # type: ignore[attr-defined]
+    client._idle_restart_task = asyncio.create_task(asyncio.sleep(0))
+    client._idle_monitor_task = asyncio.create_task(asyncio.sleep(0))
+    client._task = asyncio.create_task(asyncio.sleep(0))
+    client._idle_restart_pending = True
+    client._subscription_refresh_failed = True
+
+    await asyncio.sleep(0)
+    await client.stop()
+
+    assert client._idle_restart_task is None
+    assert client._idle_monitor_task is None
+    assert client._task is None
+    assert client._idle_restart_pending is False
+    assert client._subscription_refresh_failed is False
+    client._disconnect.assert_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_termoweb_debug_probe_emits_when_debug_enabled(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Debug probe should emit when debug logging is enabled."""
+
+    client = _make_termoweb_client(monkeypatch)
+    emit = AsyncMock()
+    client._sio.emit = emit  # type: ignore[attr-defined]
+    caplog.set_level(logging.DEBUG, logger=module._LOGGER.name)
+
+    await client.debug_probe()
+
+    emit.assert_awaited_once_with("dev_data", namespace=module.WS_NAMESPACE)
+
+
+def test_termoweb_update_status_records_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Status updates should populate the hass data bucket and dispatch events."""
+
+    client = _make_termoweb_client(monkeypatch)
+    client._stats.frames_total = 4  # type: ignore[attr-defined]
+    client._stats.events_total = 2  # type: ignore[attr-defined]
+    client._stats.last_event_ts = 50.0  # type: ignore[attr-defined]
+    client._healthy_since = 40.0
+    monkeypatch.setattr(module.time, "time", lambda: 100.0)
+
+    client._update_status("connected")
+
+    state = client._ws_state_bucket()
+    assert state["status"] == "connected"
+    assert state["frames_total"] == 4
+    assert state["events_total"] == 2
+    assert state["healthy_minutes"] == 1
+    client._dispatcher_mock.assert_called()  # type: ignore[attr-defined]
+
+
+def test_termoweb_mark_event_without_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Count-only events should still trigger healthy transitions."""
+
+    client = _make_termoweb_client(monkeypatch)
+    client._update_status = MagicMock()  # type: ignore[attr-defined]
+    monkeypatch.setattr(module.time, "time", lambda: 300.0)
+
+    client._mark_event(paths=None, count_event=True)
+
+    assert client._stats.events_total == 1  # type: ignore[attr-defined]
+    assert client._healthy_since == 300.0
+    client._update_status.assert_called_once_with("healthy")  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_termoweb_force_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force refreshing tokens should clear cached access tokens."""
+
+    client = _make_termoweb_client(monkeypatch)
+    rest_client = client._client
+    rest_client._access_token = "cached"  # type: ignore[attr-defined]
+
+    await client._force_refresh_token()
+
+    assert rest_client._access_token is None  # type: ignore[attr-defined]
+    rest_client._ensure_token.assert_awaited()  # type: ignore[attr-defined]
+
+
+def test_termoweb_api_base_prefers_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """API base helper should prefer the REST client's configured base."""
+
+    client = _make_termoweb_client(monkeypatch)
+    client._client.api_base = "https://example/api"  # type: ignore[attr-defined]
+    assert client._api_base() == "https://example/api"
+
+
+def test_termoweb_api_base_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """API base helper should fall back to the integration constant."""
+
+    client = _make_termoweb_client(monkeypatch)
+    client._client.api_base = ""  # type: ignore[attr-defined]
+    assert client._api_base() == module.API_BASE
+
+
+def test_termoweb_schedule_idle_restart_skips_when_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Idle restart scheduling should not occur when closing or already pending."""
+
+    loop = DummyLoop()
+    client = _make_termoweb_client(monkeypatch, hass_loop=loop)
+    client._closing = True
+    client._schedule_idle_restart(idle_for=10.0, source="closing")
+    assert not loop.created_tasks
+
+    client._closing = False
+    client._idle_restart_pending = True
+    client._schedule_idle_restart(idle_for=10.0, source="pending")
+    assert not loop.created_tasks
+
+
+def test_ducaheat_client_start_reuses_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ducaheat client should reuse existing tasks when running."""
+
+    loop = DummyLoop()
+    client = _make_ducaheat_client(monkeypatch, hass_loop=loop)
+    async def _noop() -> None:
+        return None
+
+    existing = DummyTask(_noop())
+    client._task = existing  # type: ignore[attr-defined]
+
+    task = client.start()
+    assert task is existing
+    assert not loop.created_tasks
+    existing.cancel()
+
+
+def test_ducaheat_client_start_creates_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ducaheat client start should create a task when idle."""
+
+    loop = DummyLoop()
+    client = _make_ducaheat_client(monkeypatch, hass_loop=loop)
+    runner = AsyncMock()
+    client._runner = runner  # type: ignore[attr-defined]
+
+    task = client.start()
+    assert task is loop.created_tasks[0]
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_ducaheat_client_stop_cancels_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping the Ducaheat client should cancel background tasks."""
+
+    running_loop = asyncio.get_running_loop()
+    hass_loop = SimpleNamespace(
+        create_task=lambda coro, **kwargs: running_loop.create_task(coro, **kwargs),
+        call_soon_threadsafe=lambda cb, *args: running_loop.call_soon(cb, *args),
+    )
+    client = _make_ducaheat_client(monkeypatch, hass_loop=hass_loop)
+    client._disconnect = AsyncMock()  # type: ignore[attr-defined]
+    client._task = asyncio.create_task(asyncio.sleep(0))
+
+    await asyncio.sleep(0)
+    await client.stop()
+
+    assert client._task is None
+    client._disconnect.assert_awaited_once_with("stop")  # type: ignore[attr-defined]
+
+
+def test_ducaheat_path_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ducaheat websocket path helper should return the Engine.IO path."""
+
+    client = _make_ducaheat_client(monkeypatch)
+    assert client._path() == "/socket.io/"
+
+
+def test_ws_lease_backoff_sequence() -> None:
+    """Backoff helper should iterate through the configured sequence."""
+
+    lease = base_ws._WsLeaseMixin()
+    values = [lease._next_backoff() for _ in range(6)]
+    assert values == [5, 10, 30, 120, 300, 300]
+    lease._reset_backoff()
+    assert lease._next_backoff() == 5
+
+
+def test_ws_common_state_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WS common helper should create domain buckets when missing."""
+
+    hass = SimpleNamespace(data={})
+
+    class Dummy(base_ws._WSCommon):
+        def __init__(self) -> None:
+            self.hass = hass
+            self.entry_id = "entry"
+            self.dev_id = "dev"
+            self._coordinator = SimpleNamespace(update_nodes=MagicMock())
+
+    dummy = Dummy()
+    bucket = dummy._ws_state_bucket()
+    assert bucket == {}
+    assert base_ws.DOMAIN in hass.data
+
+
+def test_ws_common_update_status_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WS common status helper should forward dispatcher signals."""
+
+    hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": {}}})
+    dispatcher = MagicMock()
+    monkeypatch.setattr(base_ws, "async_dispatcher_send", dispatcher)
+
+    class Dummy(base_ws._WSCommon):
+        def __init__(self) -> None:
+            self.hass = hass
+            self.entry_id = "entry"
+            self.dev_id = "dev"
+            self._coordinator = SimpleNamespace(update_nodes=MagicMock())
+
+    dummy = Dummy()
+    dummy._update_status("connected")
+
+    dispatcher.assert_called_once()
+
+
+def test_ws_common_dispatch_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WS common dispatch should update coordinator and emit dispatcher events."""
+
+    hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": {}}})
+    coordinator = SimpleNamespace(update_nodes=MagicMock())
+    dispatcher = MagicMock()
+    monkeypatch.setattr(base_ws, "async_dispatcher_send", dispatcher)
+    class DummySnapshot(base_ws.InstallationSnapshot):
+        def __init__(self) -> None:
+            super().__init__(dev_id="dev", raw_nodes={})
+            self._inventory = [("htr", "1")]
+            self.updated: Any | None = None
+
+        def update_nodes(self, raw_nodes: Any, *, node_inventory: Any | None = None) -> None:
+            self.updated = raw_nodes
+            self._inventory = [("htr", "1")]
+
+        @property
+        def inventory(self) -> list[tuple[str, str]]:
+            return list(self._inventory)
+
+    snapshot = DummySnapshot()
+    monkeypatch.setattr(base_ws, "ensure_snapshot", lambda record: snapshot)
+    monkeypatch.setattr(
+        base_ws,
+        "addresses_by_node_type",
+        lambda inventory, known_types=None: ({"htr": ["1"]}, {}),
+    )
+
+    class Dummy(base_ws._WSCommon):
+        def __init__(self) -> None:
+            self.hass = hass
+            self.entry_id = "entry"
+            self.dev_id = "dev"
+            self._coordinator = coordinator
+
+    dummy = Dummy()
+    payload = {"nodes": {"htr": {"settings": {"1": {"temp": 20}}}}}
+    dummy._dispatch_nodes(payload)
+
+    assert snapshot.updated == payload["nodes"]
+    coordinator.update_nodes.assert_called_once()
+    dispatcher.assert_called_once()
+    record = hass.data[base_ws.DOMAIN]["entry"]
+    assert "node_inventory" in record
+
+
+def test_ws_client_start_selects_delegate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Top-level websocket client should instantiate the appropriate delegate."""
+
+    hass = SimpleNamespace(loop=SimpleNamespace(create_task=lambda coro, **_: DummyTask(coro)))
+    rest_client = DummyREST()
+    coordinator = SimpleNamespace(update_nodes=MagicMock())
+
+    start_mock = MagicMock(return_value="started")
+
+    class StubTermo:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self) -> str:
+            return start_mock()
+
+    fake_termoweb = ModuleType(module.__name__)
+    fake_termoweb.__dict__.update(module.__dict__)
+    fake_termoweb.TermoWebWSClient = StubTermo
+    monkeypatch.setitem(sys.modules, module.__name__, fake_termoweb)
+    monkeypatch.setattr(module, "TermoWebWSClient", StubTermo)
+    monkeypatch.setattr(base_ws, "TermoWebWSClient", StubTermo, raising=False)
+
+    client = base_ws.WebSocketClient(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=rest_client,
+        coordinator=coordinator,
+        session=SimpleNamespace(),
+    )
+
+    result = client.start()
+    assert result == "started"
+    start_mock.assert_called_once()
+
+
+def test_ws_client_start_selects_ducaheat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Top-level websocket client should delegate to the Ducaheat client when flagged."""
+
+    hass = SimpleNamespace(loop=SimpleNamespace(create_task=lambda coro, **_: DummyTask(coro)))
+    rest_client = DummyREST(is_ducaheat=True)
+    coordinator = SimpleNamespace(update_nodes=MagicMock())
+
+    start_mock = MagicMock(return_value="started")
+
+    class StubDucaheat:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self) -> str:
+            return start_mock()
+
+    fake_ducaheat = ModuleType(ducaheat_ws.__name__)
+    fake_ducaheat.__dict__.update(ducaheat_ws.__dict__)
+    fake_ducaheat.DucaheatWSClient = StubDucaheat
+    monkeypatch.setitem(sys.modules, ducaheat_ws.__name__, fake_ducaheat)
+    monkeypatch.setattr(ducaheat_ws, "DucaheatWSClient", StubDucaheat)
+    monkeypatch.setattr(base_ws, "DucaheatWSClient", StubDucaheat, raising=False)
+
+    client = base_ws.WebSocketClient(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=rest_client,
+        coordinator=coordinator,
+        session=SimpleNamespace(),
+    )
+
+    result = client.start()
+    assert result == "started"
+    start_mock.assert_called_once()
+
+
+def test_ws_client_is_running_and_ws_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Top-level helpers should proxy to the delegate when available."""
+
+    hass = SimpleNamespace(loop=SimpleNamespace(create_task=lambda coro, **_: DummyTask(coro)))
+    rest_client = DummyREST()
+    coordinator = SimpleNamespace(update_nodes=MagicMock())
+
+    async def _noop() -> None:
+        return None
+
+    class StubDelegate:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._running = True
+
+        def start(self) -> DummyTask:
+            return DummyTask(_noop())
+
+        def is_running(self) -> bool:
+            return self._running
+
+        async def ws_url(self) -> str:
+            return "wss://example"
+
+        async def stop(self) -> None:
+            self._running = False
+
+    fake_termoweb = ModuleType(module.__name__)
+    fake_termoweb.__dict__.update(module.__dict__)
+    fake_termoweb.TermoWebWSClient = StubDelegate
+    monkeypatch.setitem(sys.modules, module.__name__, fake_termoweb)
+    monkeypatch.setattr(module, "TermoWebWSClient", StubDelegate)
+    monkeypatch.setattr(base_ws, "TermoWebWSClient", StubDelegate, raising=False)
+
+    client = base_ws.WebSocketClient(
+        hass,
+        entry_id="entry",
+        dev_id="dev",
+        api_client=rest_client,
+        coordinator=coordinator,
+        session=SimpleNamespace(),
+    )
+
+    task = client.start()
+    assert client.is_running() is True
+    url = asyncio.run(client.ws_url())
+    assert url == "wss://example"
+    task.cancel()
+


### PR DESCRIPTION
## Summary
- extend the Ducaheat websocket client tests to exercise token generation, polling decode edge cases, lifecycle flows, and error-handling branches
- add focused TermoWeb websocket protocol tests that cover helper sanitisation, background task orchestration, event handling, subscription refreshes, and payload translation utilities
- ensure the TermoWeb backend passes the socket.io protocol hint when instantiating WebSocketClient subclasses

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e3d27650a48329965e0aced4d19c3d