### PR TITLE
Adjust ACM climate modes to expose boost

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -544,8 +544,6 @@ class DucaheatRESTClient(RESTClient):
         mode_value: str | None = None
         if mode is not None:
             mode_value = str(mode).lower()
-            if mode_value == "heat":
-                mode_value = "manual"
 
         status_payload: dict[str, str] = {}
         status_includes_mode = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1920,7 +1920,7 @@ def test_ducaheat_set_acm_settings_client_error(monkeypatch) -> None:
         monkeypatch.setattr(client, "_authed_headers", fake_headers)
 
         with pytest.raises(DucaheatRequestError) as exc:
-            await client.set_node_settings("dev", ("acm", "5"), mode="manual")
+            await client.set_node_settings("dev", ("acm", "5"), mode="boost")
 
         assert "bad request" in str(exc.value)
 

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -189,13 +189,13 @@ async def test_ducaheat_rest_set_node_settings_acm_mode_heat(
     monkeypatch.setattr(ducaheat_rest_client, "_authed_headers", fake_headers)
     monkeypatch.setattr(ducaheat_rest_client, "_request", fake_request)
 
-    await ducaheat_rest_client.set_node_settings("dev", ("acm", "3"), mode="heat")
+    await ducaheat_rest_client.set_node_settings("dev", ("acm", "3"), mode="boost")
 
     assert calls == [
         (
             "POST",
             "/api/v2/devs/dev/acm/3/mode",
-            {"headers": {"Authorization": "Bearer"}, "json": {"mode": "manual"}},
+            {"headers": {"Authorization": "Bearer"}, "json": {"mode": "boost"}},
         )
     ]
 
@@ -238,7 +238,7 @@ async def test_ducaheat_post_acm_endpoint_rethrows_server_error(
 
     with pytest.raises(ClientResponseError):
         await ducaheat_rest_client._post_acm_endpoint(
-            "/api/v2/devs/dev/acm/3/status", {}, {"mode": "manual"}
+            "/api/v2/devs/dev/acm/3/status", {}, {"mode": "boost"}
         )
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -392,7 +392,7 @@ def test_async_setup_entry_creates_accumulator_entity() -> None:
         dev_id = "dev-acm"
         nodes = {"nodes": [{"type": "acm", "addr": "7", "name": "Store"}]}
         settings = {
-            "mode": "manual",
+            "mode": "boost",
             "state": "idle",
             "mtemp": "19.0",
             "stemp": "21.0",
@@ -452,6 +452,8 @@ def test_async_setup_entry_creates_accumulator_entity() -> None:
         assert acc._attr_unique_id == f"{DOMAIN}:{dev_id}:acm:7:climate"
         assert acc.available
         assert acc.device_info["model"] == "Accumulator"
+        assert "boost" in acc._attr_hvac_modes
+        assert acc.hvac_mode == "boost"
 
         prog = [0, 1, 2] * 56
         await acc.async_set_schedule(list(prog))

--- a/tests/test_ducaheat_acm_writes.py
+++ b/tests/test_ducaheat_acm_writes.py
@@ -58,7 +58,7 @@ def _setup_client(
     [
         (HVACMode.AUTO, "auto"),
         (HVACMode.OFF, "off"),
-        (HVACMode.HEAT, "manual"),
+        ("boost", "boost"),
         ("manual", "manual"),
     ],
 )
@@ -189,7 +189,7 @@ def test_ducaheat_acm_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(client, "_request", fake_request)
 
         with pytest.raises(DucaheatRequestError) as exc:
-            await client.set_node_settings("dev", ("acm", "1"), mode="manual")
+            await client.set_node_settings("dev", ("acm", "1"), mode="boost")
 
         assert "malformed" in str(exc.value)
 

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -872,7 +872,7 @@ def test_async_update_data_skips_non_dict_sections() -> None:
         coord.data = {
             "dev": {
                 "nodes_by_type": {
-                    "acm": {"addrs": ["B"], "settings": {"B": {"mode": "manual"}}}
+                    "acm": {"addrs": ["B"], "settings": {"B": {"mode": "auto"}}}
                 },
                 "misc": "invalid",
             }


### PR DESCRIPTION
## Summary
- update the ACM climate entity to advertise off/auto/boost HVAC modes while keeping boost writes unimplemented
- avoid coercing accumulator setpoint writes to manual mode and normalize HVAC mode handling hooks
- drop the heat→manual translation for ACM REST writes and refresh unit tests for the revised behaviour

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e3e89009c08329a97acfc137d60f31