### PR TITLE
Remove REST fallback after heater writes

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 import logging
+import time
 from collections import deque
 from collections.abc import Coroutine
 import types
@@ -824,15 +825,11 @@ def test_async_setup_entry_rebuilds_inventory_when_missing() -> None:
     asyncio.run(_run())
 
 
-def test_refresh_fallback_skips_when_hass_inactive(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_refresh_fallback_logs_skip(caplog: pytest.LogCaptureFixture) -> None:
     async def _run() -> None:
         _reset_environment()
 
         hass = HomeAssistant()
-        hass.is_stopping = True
-        hass.is_running = True
         entry_id = "entry"
         dev_id = "dev"
         addr = "A"
@@ -858,34 +855,13 @@ def test_refresh_fallback_skips_when_hass_inactive(
         heater = HeaterClimateEntity(coordinator, entry_id, dev_id, addr, "Heater")
         await heater.async_added_to_hass()
 
-        async def fast_sleep(_delay: float) -> None:
-            return None
-
-        monkeypatch.setattr(climate_module.asyncio, "sleep", fast_sleep)
-
         caplog.clear()
         with caplog.at_level(logging.DEBUG):
             heater._schedule_refresh_fallback()
-            task = heater._refresh_fallback
-            assert task is not None
-            await task
+
         coordinator.async_refresh_heater.assert_not_awaited()
         assert heater._refresh_fallback is None
-        assert "hass stopping" in caplog.text
-
-        hass.is_stopping = False
-        hass.is_running = False
-        coordinator.async_refresh_heater.reset_mock()
-
-        caplog.clear()
-        with caplog.at_level(logging.DEBUG):
-            heater._schedule_refresh_fallback()
-            task = heater._refresh_fallback
-            assert task is not None
-            await task
-        coordinator.async_refresh_heater.assert_not_awaited()
-        assert heater._refresh_fallback is None
-        assert "hass not running" in caplog.text
+        assert "Skipping refresh fallback" in caplog.text
 
     asyncio.run(_run())
 
@@ -993,9 +969,8 @@ def test_heater_additional_cancelled_edges(
         coordinator.async_refresh_heater = AsyncMock(side_effect=SentinelCancelled())
         heater._refresh_fallback = None
         heater._schedule_refresh_fallback()
-        assert heater._refresh_fallback is not None
-        with pytest.raises(SentinelCancelled):
-            await heater._refresh_fallback
+        assert heater._refresh_fallback is None
+        coordinator.async_refresh_heater.assert_not_awaited()
 
     asyncio.run(_run())
 
@@ -1262,6 +1237,7 @@ def test_heater_write_paths_and_errors(
         write_waiters: Deque[asyncio.Future[None]] = deque()
         write_block = False
         real_sleep = asyncio.sleep
+        fallback_delay = getattr(climate_module, "_WS_ECHO_FALLBACK_REFRESH", None)
 
         async def fake_sleep(delay: float) -> None:
             if delay == climate_module._WRITE_DEBOUNCE:
@@ -1272,7 +1248,7 @@ def test_heater_write_paths_and_errors(
                     await fut
                     return None
                 return None
-            if delay == climate_module._WS_ECHO_FALLBACK_REFRESH:
+            if fallback_delay is not None and delay == fallback_delay:
                 loop = asyncio.get_running_loop()
                 fut: asyncio.Future[None] = loop.create_future()
                 fallback_waiters.append(fut)
@@ -1291,12 +1267,12 @@ def test_heater_write_paths_and_errors(
             created_tasks.append(task)
             return task
 
-        async def _pop_waiter() -> asyncio.Future[None]:
+        async def _pop_waiter() -> asyncio.Future[None] | None:
             for _ in range(10):
                 if fallback_waiters:
                     return fallback_waiters.popleft()
                 await real_sleep(0)
-            raise AssertionError("fallback waiter not created")
+            return None
 
         async def _pop_write_waiter() -> asyncio.Future[None]:
             for _ in range(10):
@@ -1308,12 +1284,13 @@ def test_heater_write_paths_and_errors(
         async def _complete_fallback_once() -> None:
             waiter = await _pop_waiter()
             task = heater._refresh_fallback
-            assert task is not None
-            assert coordinator.async_refresh_heater.await_count == 0
+            if waiter is None or task is None:
+                coordinator.async_refresh_heater.assert_not_awaited()
+                assert heater._refresh_fallback is None
+                return
             waiter.set_result(None)
             await task
-            coordinator.async_refresh_heater.assert_awaited_once_with(("htr", addr))
-            coordinator.async_refresh_heater.reset_mock()
+            coordinator.async_refresh_heater.assert_not_awaited()
             assert heater._refresh_fallback is None
 
         class RaisingMapping:
@@ -1342,7 +1319,7 @@ def test_heater_write_paths_and_errors(
         settings_after = coordinator.data[dev_id]["htr"]["settings"][addr]
         assert settings_after["prog"] == list(base_prog)
 
-        assert heater._refresh_fallback is not None
+        assert heater._refresh_fallback is None
         await _complete_fallback_once()
 
         client.set_htr_settings.reset_mock()
@@ -1389,12 +1366,11 @@ def test_heater_write_paths_and_errors(
         assert "Optimistic update failed" in caplog.text
         waiter = await _pop_waiter()
         task = heater._refresh_fallback
-        assert task is not None
         coordinator.data = old_data
-        waiter.set_result(None)
-        await task
-        coordinator.async_refresh_heater.assert_awaited_once_with(("htr", addr))
-        coordinator.async_refresh_heater.reset_mock()
+        if waiter is not None and task is not None:
+            waiter.set_result(None)
+            await task
+        coordinator.async_refresh_heater.assert_not_awaited()
         assert heater._refresh_fallback is None
         client.set_htr_settings.reset_mock()
 
@@ -1458,12 +1434,11 @@ def test_heater_write_paths_and_errors(
         assert "Optimistic update failed" in caplog.text
         waiter = await _pop_waiter()
         task = heater._refresh_fallback
-        assert task is not None
         coordinator.data = old_data
-        waiter.set_result(None)
-        await task
-        coordinator.async_refresh_heater.assert_awaited_once_with(("htr", addr))
-        coordinator.async_refresh_heater.reset_mock()
+        if waiter is not None and task is not None:
+            waiter.set_result(None)
+            await task
+        coordinator.async_refresh_heater.assert_not_awaited()
         assert heater._refresh_fallback is None
         client.set_htr_settings.reset_mock()
 
@@ -1574,43 +1549,22 @@ def test_heater_write_paths_and_errors(
 
         # -------------------- _schedule_refresh_fallback behaviour --------
         heater._schedule_refresh_fallback()
-        task_a = heater._refresh_fallback
-        waiter_a = await _pop_waiter()
-        heater._schedule_refresh_fallback()
-        task_b = heater._refresh_fallback
-        waiter_b = await _pop_waiter()
-
-        assert task_a is not None and task_b is not None and task_a is not task_b
-        with pytest.raises(asyncio.CancelledError):
-            await task_a
-        if not waiter_a.done():
-            waiter_a.cancel()
-
-        assert coordinator.async_refresh_heater.await_count == 0
-
-        waiter_b.set_result(None)
-        await task_b
-        coordinator.async_refresh_heater.assert_awaited_once_with(("htr", addr))
-        coordinator.async_refresh_heater.reset_mock()
+        assert heater._refresh_fallback is None
+        coordinator.async_refresh_heater.assert_not_awaited()
 
         caplog.clear()
         coordinator.async_refresh_heater.side_effect = RuntimeError("refresh boom")
         heater._schedule_refresh_fallback()
-        waiter_err = await _pop_waiter()
-        task_err = heater._refresh_fallback
-        assert task_err is not None
-        waiter_err.set_result(None)
-        await task_err
-        assert "Refresh fallback failed" in caplog.text
+        assert heater._refresh_fallback is None
+        assert "Skipping refresh fallback" in caplog.text
         coordinator.async_refresh_heater.side_effect = None
         coordinator.async_refresh_heater.reset_mock()
-        assert not fallback_waiters
 
         # -------------------- WS healthy suppresses fallback --------------
         hass.data[DOMAIN][entry_id]["ws_state"][dev_id] = {
             "status": "healthy",
             "last_event_at": 0,
-            "last_payload_at": climate_module.time.time(),
+            "last_payload_at": time.time(),
             "idle_restart_pending": False,
         }
         client.set_htr_settings.reset_mock()
@@ -1622,31 +1576,31 @@ def test_heater_write_paths_and_errors(
         assert not fallback_waiters
         client.set_htr_settings.reset_mock()
 
-        # -------------------- WS healthy but stale payload triggers fallback ----
+        # -------------------- WS healthy but stale payload still relies on WS ----
         hass.data[DOMAIN][entry_id]["ws_state"][dev_id] = {
             "status": "healthy",
             "last_event_at": 0,
-            "last_payload_at": climate_module.time.time() - 60,
+            "last_payload_at": time.time() - 60,
             "idle_restart_pending": False,
         }
         await heater.async_set_temperature(**{ATTR_TEMPERATURE: 21.5})
         assert heater._write_task is not None
         await heater._write_task
         assert client.set_htr_settings.await_count == 1
-        assert heater._refresh_fallback is not None
+        assert heater._refresh_fallback is None
         await _complete_fallback_once()
         client.set_htr_settings.reset_mock()
 
-        # -------------------- WS status missing triggers fallback ---------
+        # -------------------- WS status missing keeps fallback disabled ----
         hass.data[DOMAIN][entry_id]["ws_state"].pop(dev_id, None)
         await heater.async_set_temperature(**{ATTR_TEMPERATURE: 24.5})
         assert heater._write_task is not None
         await heater._write_task
-        assert heater._refresh_fallback is not None
+        assert heater._refresh_fallback is None
         await _complete_fallback_once()
         client.set_htr_settings.reset_mock()
 
-        # -------------------- WS down restores fallback -------------------
+        # -------------------- WS down still relies on websocket updates ---
         hass.data[DOMAIN][entry_id]["ws_state"][dev_id] = {
             "status": "disconnected",
             "last_event_at": None,
@@ -1654,7 +1608,7 @@ def test_heater_write_paths_and_errors(
         await heater.async_set_temperature(**{ATTR_TEMPERATURE: 23.5})
         assert heater._write_task is not None
         await heater._write_task
-        assert heater._refresh_fallback is not None
+        assert heater._refresh_fallback is None
         await _complete_fallback_once()
         client.set_htr_settings.reset_mock()
 
@@ -1831,11 +1785,8 @@ def test_heater_cancellation_and_error_paths(monkeypatch: pytest.MonkeyPatch) ->
 
         coordinator.async_refresh_heater = AsyncMock(side_effect=failing_refresh)
         heater._schedule_refresh_fallback()
-        task = heater._refresh_fallback
-        assert task is not None
-        await task
-        coordinator.async_refresh_heater.assert_awaited_once_with(("htr", addr))
         assert heater._refresh_fallback is None
+        coordinator.async_refresh_heater.assert_not_awaited()
 
     asyncio.run(_run())
 
@@ -1956,10 +1907,7 @@ def test_heater_cancelled_paths_propagate(
             side_effect=asyncio.CancelledError()
         )
         heater._schedule_refresh_fallback()
-        task = heater._refresh_fallback
-        assert task is not None
-        with pytest.raises(asyncio.CancelledError):
-            await task
         assert heater._refresh_fallback is None
+        coordinator.async_refresh_heater.assert_not_awaited()
 
     asyncio.run(_run())

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -2533,12 +2533,8 @@ def test_refresh_fallback_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
         )
         heater.hass = HomeAssistant()
         heater._schedule_refresh_fallback()
-        task = heater._refresh_fallback
-        assert task is not None
-        await asyncio.sleep(0)
+        assert heater._refresh_fallback is None
         await heater.async_will_remove_from_hass()
-        await asyncio.sleep(0)
-        assert task.cancelled()
         assert heater._refresh_fallback is None
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- rely on websocket echoes instead of scheduling REST refreshes after heater writes
- keep websocket cancellation of any pending fallback tasks and improve logging
- update heater and import tests to reflect the removal of the refresh fallback

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e40c01b7f08329ad5385345d1d2f88