### PR TITLE
Convert accumulator boost to preset mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -900,6 +900,7 @@ def _install_stubs() -> None:
         def __init__(self) -> None:
             self.hass: Any | None = None
             self._on_remove: Callable[[], None] | None = None
+            self._attr_preset_modes: list[str] | None = None
 
         async def async_added_to_hass(self) -> None:
             return None
@@ -917,8 +918,13 @@ def _install_stubs() -> None:
         def async_write_ha_state(self) -> None:
             return None
 
+        @property
+        def preset_modes(self) -> list[str] | None:
+            return self._attr_preset_modes
+
     class ClimateEntityFeature(enum.IntFlag):
         TARGET_TEMPERATURE = 1
+        PRESET_MODE = 2
 
     class HVACMode(str, enum.Enum):
         OFF = "off"


### PR DESCRIPTION
## Summary
- expose accumulator boost through preset modes while limiting HVAC modes to off/auto
- add preset handling logic and resume-mode tracking in the accumulator climate entity
- update climate tests and stubs to cover preset behaviour and maintain 100% coverage

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e41b55f41c83299911fda37a49e305