### PR TITLE
Document boost as accumulator-only in Ducaheat API

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -14,6 +14,6 @@ Key observations from traffic captures:
 - The `units` field is **always uppercase** (`"C"` or `"F"`); lowercase variants fail validation.
 - Some operations require a `select: true` POST before the substantive write and `select: false`
   afterwards. Keep the claim short-lived to avoid stepping on app sessions.
-- Boost, lock, and similar toggles are literal booleans; do not send quoted values.
+- Boost (accumulators only), lock, and similar toggles are literal booleans; do not send quoted values.
 
 These semantics apply to both heater (`htr`) and accumulator (`acm`) nodes within the Ducaheat API.

--- a/docs/ducaheat_openapi.yaml
+++ b/docs/ducaheat_openapi.yaml
@@ -106,7 +106,7 @@ components:
           type: string
         node_type:
           type: string
-          example: htr
+          example: acm
         addr:
           type: integer
         status:
@@ -127,6 +127,7 @@ components:
               example: C
             boost_active:
               type: boolean
+              description: Accumulator boost session currently active
         setup:
           type: object
           additionalProperties: true
@@ -141,7 +142,7 @@ components:
                   example: 60
                 boost_temp:
                   type: string
-                  description: Temperature applied during boost, if distinct from `stemp`
+                  description: Temperature applied during accumulator boost, if distinct from `stemp`
                   example: "22.0"
             operational_mode:
               type: integer
@@ -225,7 +226,7 @@ components:
           additionalProperties: false
     HeaterStatusWrite:
       type: object
-      description: Write status for a heater
+      description: Write status for a heater or accumulator
       properties:
         mode:
           type: string
@@ -241,7 +242,7 @@ components:
           example: C
         boost:
           type: boolean
-          description: Start/stop an immediate Boost (runback) session
+          description: Start/stop an immediate Boost (runback) session (accumulators only)
       additionalProperties: false
     HeaterModeWrite:
       type: object
@@ -435,7 +436,7 @@ paths:
   /api/v2/devs/{dev_id}/{node_type}/{addr}/status:
     post:
       tags: [ThermalNodes]
-      summary: Set mode/setpoint/units and optionally trigger Boost
+      summary: Set mode/setpoint/units; accumulators may also trigger Boost
       parameters:
         - name: dev_id
           in: path
@@ -447,6 +448,7 @@ paths:
           schema:
             type: string
             enum: [htr, acm]
+            description: Use `acm` when sending boost-related writes
         - name: addr
           in: path
           required: true
@@ -466,6 +468,7 @@ paths:
               boost_now:
                 value:
                   boost: true
+                summary: Valid only when node_type is acm
       responses:
         "201":
           description: Accepted


### PR DESCRIPTION
## Summary
- clarify that boost telemetry and writes apply only to accumulator (acm) nodes in the Ducaheat API docs
- update the Ducaheat OpenAPI spec to mark boost fields and requests as accumulator-only and fix sample URLs
- note in developer guidance that boost booleans are limited to accumulators

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e425fdd390832988a093b72157a76b