### PR TITLE
Add boost duration selectors for accumulators

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -85,7 +85,7 @@ from .backend.ws_client import TermoWebWSClient  # noqa: F401,E402
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["button", "binary_sensor", "climate", "sensor"]
+PLATFORMS = ["button", "binary_sensor", "climate", "select", "sensor"]
 
 reset_samples_rate_limit_state()
 
@@ -250,6 +250,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "version": version,
         "brand": brand,
         "debug": debug_enabled,
+        "boost_runtime": {},
     }
 
     async def _async_handle_hass_stop(_event: Any) -> None:

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -1,0 +1,223 @@
+"""Select platform entities for configuring TermoWeb boost runtimes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DOMAIN
+from .heater import (
+    BOOST_DURATION_OPTIONS,
+    DEFAULT_BOOST_DURATION,
+    HeaterNodeBase,
+    get_boost_runtime_minutes,
+    iter_heater_nodes,
+    log_skipped_nodes,
+    prepare_heater_platform_data,
+    resolve_boost_runtime_minutes,
+    set_boost_runtime_minutes,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up boost duration selectors for accumulator nodes."""
+
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+    dev_id = data["dev_id"]
+    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
+        data,
+        default_name_simple=lambda addr: f"Heater {addr}",
+    )
+
+    new_entities: list[AccumulatorBoostDurationSelect] = []
+    for node_type, node, addr_str, base_name in iter_heater_nodes(
+        nodes_by_type,
+        resolve_name,
+    ):
+        if node_type != "acm":
+            continue
+        supports_boost = getattr(node, "supports_boost", None)
+        if callable(supports_boost) and not supports_boost():
+            continue
+        unique_id = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:boost_duration"
+        new_entities.append(
+            AccumulatorBoostDurationSelect(
+                coordinator,
+                entry.entry_id,
+                dev_id,
+                addr_str,
+                base_name,
+                unique_id,
+                node_type=node_type,
+            )
+        )
+
+    log_skipped_nodes("select", nodes_by_type, logger=_LOGGER)
+
+    if new_entities:
+        _LOGGER.debug("Adding %d TermoWeb boost selectors", len(new_entities))
+        async_add_entities(new_entities)
+
+
+class AccumulatorBoostDurationSelect(RestoreEntity, HeaterNodeBase, SelectEntity):
+    """Select entity exposing preferred boost duration per accumulator."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:timer-cog-outline"
+
+    _OPTION_MAP = {str(option): option for option in BOOST_DURATION_OPTIONS}
+    _REVERSE_OPTION_MAP = {value: key for key, value in _OPTION_MAP.items()}
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        base_name: str,
+        unique_id: str,
+        *,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise the boost duration selector for an accumulator."""
+
+        HeaterNodeBase.__init__(
+            self,
+            coordinator,
+            entry_id,
+            dev_id,
+            addr,
+            f"{base_name} Boost duration",
+            unique_id,
+            device_name=base_name,
+            node_type=node_type,
+        )
+        self._attr_name = "Boost duration"
+        self._attr_options = list(self._OPTION_MAP.keys())
+        self._attr_current_option: str | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the preferred duration once the entity is added."""
+
+        await HeaterNodeBase.async_added_to_hass(self)
+        await RestoreEntity.async_added_to_hass(self)
+
+        hass = self.hass
+        minutes: int | None = None
+        if hass is not None:
+            minutes = get_boost_runtime_minutes(
+                hass,
+                self._entry_id,
+                self._node_type,
+                self._addr,
+            )
+
+        if minutes is None:
+            last_state = await self.async_get_last_state()
+            if last_state is not None:
+                minutes = self._option_to_minutes(last_state.state)
+
+        if minutes is None:
+            minutes = self._initial_minutes_from_settings()
+
+        self._apply_minutes(minutes, persist=hass is not None)
+        self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        """Handle a new boost duration selection from the user."""
+
+        minutes = self._option_to_minutes(option)
+        if minutes is None:
+            _LOGGER.error(
+                "Invalid boost duration option for %s: %s",
+                self._addr,
+                option,
+            )
+            return
+
+        self._apply_minutes(minutes, persist=True)
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the preferred minutes as an attribute."""
+
+        return {"preferred_minutes": self._current_minutes()}
+
+    def _apply_minutes(self, minutes: int | None, *, persist: bool) -> None:
+        """Update the active option and persist when requested."""
+
+        resolved = self._validate_minutes(minutes)
+        option = self._REVERSE_OPTION_MAP.get(resolved)
+        if option is None:
+            option = str(DEFAULT_BOOST_DURATION)
+            resolved = DEFAULT_BOOST_DURATION
+        self._attr_current_option = option
+        if persist and self.hass is not None:
+            set_boost_runtime_minutes(
+                self.hass,
+                self._entry_id,
+                self._node_type,
+                self._addr,
+                resolved,
+            )
+
+    def _initial_minutes_from_settings(self) -> int:
+        """Return the bootstrap value sourced from cached settings."""
+
+        settings = self.heater_settings() or {}
+        candidate = self._option_to_minutes(settings.get("boost_time"))
+        if candidate is not None:
+            return candidate
+        return DEFAULT_BOOST_DURATION
+
+    def _option_to_minutes(self, value: Any) -> int | None:
+        """Translate ``value`` into a supported minute option."""
+
+        if isinstance(value, str):
+            text = value.strip()
+            if text in self._OPTION_MAP:
+                return self._OPTION_MAP[text]
+            try:
+                numeric = int(float(text))
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                return None
+            if numeric in self._REVERSE_OPTION_MAP:
+                return numeric
+            return None
+        if isinstance(value, (int, float)):
+            numeric = int(value)
+            if numeric in self._REVERSE_OPTION_MAP:
+                return numeric
+        return None
+
+    def _validate_minutes(self, minutes: int | None) -> int:
+        """Return a supported minute value, falling back to the default."""
+
+        resolved = self._option_to_minutes(minutes)
+        if resolved is not None:
+            return resolved
+        return DEFAULT_BOOST_DURATION
+
+    def _current_minutes(self) -> int:
+        """Return the currently selected duration as minutes."""
+
+        if self._attr_current_option in self._OPTION_MAP:
+            return self._OPTION_MAP[self._attr_current_option]
+        hass = self.hass
+        if hass is None:
+            return DEFAULT_BOOST_DURATION
+        return resolve_boost_runtime_minutes(
+            hass,
+            self._entry_id,
+            self._node_type,
+            self._addr,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,6 +439,9 @@ def _install_stubs() -> None:
     update_coordinator_mod = sys.modules.get(
         "homeassistant.helpers.update_coordinator"
     ) or types.ModuleType("homeassistant.helpers.update_coordinator")
+    restore_state_mod = sys.modules.get(
+        "homeassistant.helpers.restore_state"
+    ) or types.ModuleType("homeassistant.helpers.restore_state")
     components_mod = sys.modules.get("homeassistant.components") or types.ModuleType(
         "homeassistant.components"
     )
@@ -450,6 +453,9 @@ def _install_stubs() -> None:
     )
     sensor_mod = sys.modules.get("homeassistant.components.sensor") or types.ModuleType(
         "homeassistant.components.sensor"
+    )
+    select_mod = sys.modules.get("homeassistant.components.select") or types.ModuleType(
+        "homeassistant.components.select"
     )
     climate_mod = sys.modules.get(
         "homeassistant.components.climate"
@@ -470,12 +476,14 @@ def _install_stubs() -> None:
     sys.modules["homeassistant.helpers.entity_registry"] = entity_registry_mod
     sys.modules["homeassistant.helpers.dispatcher"] = dispatcher_mod
     sys.modules["homeassistant.helpers.update_coordinator"] = update_coordinator_mod
+    sys.modules["homeassistant.helpers.restore_state"] = restore_state_mod
     sys.modules["homeassistant.helpers.entity_platform"] = entity_platform_mod
     sys.modules["homeassistant.loader"] = loader_mod
     sys.modules["homeassistant.components"] = components_mod
     sys.modules["homeassistant.components.binary_sensor"] = binary_sensor_mod
     sys.modules["homeassistant.components.button"] = button_mod
     sys.modules["homeassistant.components.sensor"] = sensor_mod
+    sys.modules["homeassistant.components.select"] = select_mod
     sys.modules["homeassistant.components.climate"] = climate_mod
 
     homeassistant_pkg.config_entries = config_entries_mod
@@ -499,9 +507,11 @@ def _install_stubs() -> None:
     helpers_mod.entity_registry = entity_registry_mod
     helpers_mod.dispatcher = dispatcher_mod
     helpers_mod.update_coordinator = update_coordinator_mod
+    helpers_mod.restore_state = restore_state_mod
     components_mod.binary_sensor = binary_sensor_mod
     components_mod.button = button_mod
     components_mod.sensor = sensor_mod
+    components_mod.select = select_mod
 
     const_mod.EVENT_HOMEASSISTANT_STARTED = "homeassistant_started"
 
@@ -778,6 +788,7 @@ def _install_stubs() -> None:
                 self.coordinator = coordinator
                 self.hass = getattr(coordinator, "hass", None)
                 self._remove_callbacks: list[Callable[[], None]] = []
+                self._attr_unique_id: str | None = None
 
             async def async_added_to_hass(self) -> None:
                 return None
@@ -787,6 +798,10 @@ def _install_stubs() -> None:
 
             def schedule_update_ha_state(self) -> None:
                 return None
+
+            @property
+            def unique_id(self) -> str | None:
+                return getattr(self, "_attr_unique_id", None)
 
             @classmethod
             def __class_getitem__(cls, _item: Any) -> type:
@@ -871,7 +886,13 @@ def _install_stubs() -> None:
     class DeviceInfo(dict):
         pass
 
+    class EntityCategory(str, enum.Enum):
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
+        SYSTEM = "system"
+
     entity_mod.DeviceInfo = DeviceInfo
+    entity_mod.EntityCategory = EntityCategory
 
     class EntityPlatform:
         def __init__(self) -> None:
@@ -1018,6 +1039,37 @@ def _install_stubs() -> None:
             return None
 
     button_mod.ButtonEntity = ButtonEntity
+
+    class SelectEntity:
+        def __init__(self) -> None:
+            self.hass: Any | None = None
+
+        async def async_added_to_hass(self) -> None:
+            return None
+
+        async def async_will_remove_from_hass(self) -> None:
+            return None
+
+        def schedule_update_ha_state(self) -> None:
+            return None
+
+        def async_write_ha_state(self) -> None:
+            return None
+
+        @property
+        def current_option(self) -> Any:
+            return getattr(self, "_attr_current_option", None)
+
+    select_mod.SelectEntity = SelectEntity
+
+    class RestoreEntity:
+        async def async_added_to_hass(self) -> None:
+            return None
+
+        async def async_get_last_state(self) -> Any:
+            return None
+
+    restore_state_mod.RestoreEntity = RestoreEntity
 
     class _StubIntegration:
         def __init__(self, domain: str) -> None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -16,6 +16,7 @@ from conftest import FakeCoordinator, _install_stubs
 _install_stubs()
 
 from custom_components.termoweb import climate as climate_module
+from custom_components.termoweb.heater import DEFAULT_BOOST_DURATION
 from custom_components.termoweb.backend.ducaheat import DucaheatRESTClient
 from custom_components.termoweb.const import (
     BRAND_DUCAHEAT,
@@ -725,6 +726,7 @@ def test_accumulator_extra_state_attributes_include_boost_metadata() -> None:
     assert attrs["boost_active"] is True
     assert attrs["boost_minutes_remaining"] == 150
     assert attrs["boost_end"] == "2024-01-01T02:30:00+00:00"
+    assert attrs["preferred_boost_minutes"] == DEFAULT_BOOST_DURATION
 
 
 def test_accumulator_extra_state_attributes_fallbacks() -> None:
@@ -787,6 +789,7 @@ def test_accumulator_extra_state_attributes_fallbacks() -> None:
     assert attrs["boost_end"] == "2024-01-01T00:30:00+00:00"
     assert attrs["program_slot"] == "cold"
     assert attrs["program_setpoint"] == pytest.approx(15.0)
+    assert attrs["preferred_boost_minutes"] == DEFAULT_BOOST_DURATION
 
 
 def test_accumulator_submit_settings_brand_switch() -> None:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from conftest import FakeCoordinator, _install_stubs
+
+_install_stubs()
+
+import custom_components.termoweb.select as select_module
+from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb.heater import (
+    DEFAULT_BOOST_DURATION,
+    get_boost_runtime_minutes,
+)
+from homeassistant.core import HomeAssistant
+
+AccumulatorBoostDurationSelect = select_module.AccumulatorBoostDurationSelect
+async_setup_entry = select_module.async_setup_entry
+
+
+def _make_node(addr: str) -> types.SimpleNamespace:
+    """Return a simple accumulator node stub."""
+
+    return types.SimpleNamespace(
+        addr=addr,
+        type="acm",
+        supports_boost=lambda: True,
+    )
+
+
+def test_select_setup_and_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify setup creates entities and persists selections."""
+
+    async def _run() -> None:
+        hass = HomeAssistant()
+        entry = types.SimpleNamespace(entry_id="entry-select")
+        dev_id = "dev-select"
+        node = _make_node("07")
+        settings = {"boost_time": 120, "prog": [0] * 168}
+        record = {
+            "nodes": {},
+            "nodes_by_type": {"acm": {"settings": {node.addr: settings}}},
+            "htr": {"settings": {}},
+        }
+        coordinator = FakeCoordinator(
+            hass,
+            dev_id=dev_id,
+            dev=record,
+            data={dev_id: record},
+        )
+        hass.data = {
+            DOMAIN: {
+                entry.entry_id: {
+                    "coordinator": coordinator,
+                    "dev_id": dev_id,
+                    "boost_runtime": {"acm": {node.addr: 30}},
+                }
+            }
+        }
+
+        def fake_prepare(entry_data, default_name_simple):
+            return ([node], {"acm": [node]}, {"acm": [node.addr]}, lambda *_: "Accumulator 7")
+
+        monkeypatch.setattr(select_module, "prepare_heater_platform_data", fake_prepare)
+
+        added: list[AccumulatorBoostDurationSelect] = []
+
+        def _add_entities(entities):
+            for entity in entities:
+                entity.hass = hass
+                entity.async_write_ha_state = MagicMock()
+                added.append(entity)
+
+        await async_setup_entry(hass, entry, _add_entities)
+
+        assert len(added) == 1
+        entity = added[0]
+        assert isinstance(entity, AccumulatorBoostDurationSelect)
+        assert entity.unique_id == f"{DOMAIN}:{dev_id}:acm:{node.addr}:boost_duration"
+
+        await entity.async_added_to_hass()
+        assert entity.async_write_ha_state.called
+        assert entity.current_option == "30"
+        assert (
+            get_boost_runtime_minutes(hass, entry.entry_id, "acm", node.addr) == 30
+        )
+
+        entity.async_write_ha_state.reset_mock()
+        await entity.async_select_option("120")
+        entity.async_write_ha_state.assert_called_once()
+        assert entity.current_option == "120"
+        assert (
+            get_boost_runtime_minutes(hass, entry.entry_id, "acm", node.addr) == 120
+        )
+
+        entity.async_write_ha_state.reset_mock()
+        await entity.async_select_option("invalid")
+        entity.async_write_ha_state.assert_not_called()
+        assert entity.current_option == "120"
+
+    asyncio.run(_run())
+
+
+def test_select_restores_last_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure stored state restoration takes precedence over defaults."""
+
+    async def _run() -> None:
+        hass = HomeAssistant()
+        entry = types.SimpleNamespace(entry_id="entry-restore")
+        dev_id = "dev-restore"
+        node = _make_node("09")
+        record = {
+            "nodes": {},
+            "nodes_by_type": {"acm": {"settings": {node.addr: {"boost_time": 90}}}},
+            "htr": {"settings": {}},
+        }
+        coordinator = FakeCoordinator(
+            hass,
+            dev_id=dev_id,
+            dev=record,
+            data={dev_id: record},
+        )
+        hass.data = {
+            DOMAIN: {
+                entry.entry_id: {
+                    "coordinator": coordinator,
+                    "dev_id": dev_id,
+                    "boost_runtime": {},
+                }
+            }
+        }
+
+        def fake_prepare(entry_data, default_name_simple):
+            return ([node], {"acm": [node]}, {"acm": [node.addr]}, lambda *_: "Accumulator 9")
+
+        monkeypatch.setattr(select_module, "prepare_heater_platform_data", fake_prepare)
+
+        added: list[AccumulatorBoostDurationSelect] = []
+
+        def _add_entities(entities):
+            for entity in entities:
+                entity.hass = hass
+                entity.async_get_last_state = AsyncMock(
+                    return_value=types.SimpleNamespace(state="60")
+                )
+                entity.async_write_ha_state = MagicMock()
+                added.append(entity)
+
+        await async_setup_entry(hass, entry, _add_entities)
+        assert len(added) == 1
+        entity = added[0]
+
+        await entity.async_added_to_hass()
+        assert entity.current_option == "60"
+        assert (
+            get_boost_runtime_minutes(hass, entry.entry_id, "acm", node.addr) == 60
+        )
+        assert entity.extra_state_attributes == {"preferred_minutes": 60}
+
+        # Clearing stored value should fall back to defaults
+        hass.data[DOMAIN][entry.entry_id]["boost_runtime"].clear()
+        entity2 = AccumulatorBoostDurationSelect(
+            coordinator,
+            entry.entry_id,
+            dev_id,
+            node.addr,
+            "Accumulator 9",
+            f"{DOMAIN}:{dev_id}:acm:{node.addr}:boost_duration",
+            node_type="acm",
+        )
+        entity2.hass = hass
+        entity2.async_write_ha_state = MagicMock()
+        entity2.async_get_last_state = AsyncMock(return_value=None)
+        await entity2.async_added_to_hass()
+        assert entity2.current_option == str(DEFAULT_BOOST_DURATION)
+        assert (
+            get_boost_runtime_minutes(hass, entry.entry_id, "acm", node.addr)
+            == DEFAULT_BOOST_DURATION
+        )
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a select platform that instantiates per-accumulator boost duration entities and persists their selections
- extend shared heater helpers to cache preferred boost minutes and surface the value via accumulator climate attributes
- exercise the new selectors with dedicated tests and expand Home Assistant stubs to cover select/restore behavior

## Testing
- `ruff check --fix custom_components/termoweb/select.py custom_components/termoweb/heater.py custom_components/termoweb/climate.py custom_components/termoweb/__init__.py tests/test_select.py tests/test_climate.py tests/test_heater_entities.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e42c1682c483299c25f2dcd6359ec2