### PR TITLE
Add boost coverage tests and fix websocket idle monitor warning

### DIFF
--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -424,7 +424,10 @@ async def test_on_connect_schedules_idle_monitor(monkeypatch: pytest.MonkeyPatch
     created: list[asyncio.Task] = []
 
     def create_task(coro: Any, **_: Any) -> asyncio.Task:
-        task = loop.create_task(asyncio.sleep(0))
+        if isinstance(coro, asyncio.Task):
+            task = coro
+        else:
+            task = loop.create_task(coro)
         created.append(task)
         return task
 


### PR DESCRIPTION
## Summary
- expand climate accumulator tests to cover boost metadata fallbacks and resolver errors
- add coordinator helper tests for integer coercion and boost end resolution edge cases
- adjust websocket idle monitor scheduling test to use real tasks and avoid coroutine warnings

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e42f8a1cd4832996ad1ff37f7dc700