### PR TITLE
Add regression test for energy rate limit state

### DIFF
--- a/tests/test_energy_rate_limit.py
+++ b/tests/test_energy_rate_limit.py
@@ -1,0 +1,31 @@
+"""Tests for the shared rate limiter helpers."""
+
+from __future__ import annotations
+
+import asyncio
+
+from custom_components.termoweb.energy import (
+    RateLimitState,
+    default_samples_rate_limit_state,
+    reset_samples_rate_limit_state,
+)
+
+
+def test_default_samples_rate_limit_state_round_trip() -> None:
+    """Shared rate limiter should reuse the same lock and manage timestamps."""
+
+    reset_samples_rate_limit_state()
+
+    state1 = default_samples_rate_limit_state()
+    assert isinstance(state1, RateLimitState)
+    assert isinstance(state1.lock, asyncio.Lock)
+
+    state2 = default_samples_rate_limit_state()
+    assert state1.lock is state2.lock
+
+    state1.set_last_query(123.45)
+    assert state1.get_last_query() == 123.45
+    assert state2.get_last_query() == 123.45
+
+    reset_samples_rate_limit_state()
+    assert state1.get_last_query() == 0.0


### PR DESCRIPTION
## Summary
- add a regression test verifying the shared energy samples rate limit state shares its lock and persists timestamps

## Testing
- uv run --no-project pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e43313ea9883298301cf87fb723683