### PR TITLE
Add accumulator boost helper buttons

### DIFF
--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -2,20 +2,114 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 from homeassistant.components.button import ButtonEntity
-from homeassistant.helpers.entity import DeviceInfo
+
+try:  # pragma: no cover - fallback for stripped Home Assistant stubs in tests
+    from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
+except ImportError:  # pragma: no cover - executed in unit test stubs
+
+    class HomeAssistantError(Exception):
+        """Fallback Home Assistant error used in unit tests."""
+
+    class ServiceNotFound(HomeAssistantError):
+        """Fallback service lookup error used in unit tests."""
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .heater import (
+    HeaterNodeBase,
+    iter_heater_nodes,
+    log_skipped_nodes,
+    prepare_heater_platform_data,
+)
 from .utils import build_gateway_device_info
+
+_LOGGER = logging.getLogger(__name__)
+
+_SERVICE_REQUEST_ACCUMULATOR_BOOST = "request_accumulator_boost"
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Expose only a safe 'Force refresh' hub-level button per device."""
+    """Expose hub refresh and accumulator boost helper buttons."""
+
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    async_add_entities([StateRefreshButton(coordinator, entry.entry_id, dev_id)])
+
+    entities: list[ButtonEntity] = [
+        StateRefreshButton(coordinator, entry.entry_id, dev_id)
+    ]
+
+    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
+        data,
+        default_name_simple=lambda addr: f"Heater {addr}",
+    )
+
+    boost_entities: list[ButtonEntity] = []
+    for node_type, node, addr_str, base_name in iter_heater_nodes(
+        nodes_by_type,
+        resolve_name,
+    ):
+        if node_type != "acm":
+            continue
+        supports_boost = getattr(node, "supports_boost", None)
+        if callable(supports_boost) and not supports_boost():
+            continue
+
+        unique_prefix = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:boost"
+        boost_entities.extend(
+            [
+                AccumulatorBoostButton(
+                    coordinator,
+                    entry.entry_id,
+                    dev_id,
+                    addr_str,
+                    base_name,
+                    f"{unique_prefix}_30",
+                    minutes=30,
+                    node_type=node_type,
+                ),
+                AccumulatorBoostButton(
+                    coordinator,
+                    entry.entry_id,
+                    dev_id,
+                    addr_str,
+                    base_name,
+                    f"{unique_prefix}_60",
+                    minutes=60,
+                    node_type=node_type,
+                ),
+                AccumulatorBoostButton(
+                    coordinator,
+                    entry.entry_id,
+                    dev_id,
+                    addr_str,
+                    base_name,
+                    f"{unique_prefix}_120",
+                    minutes=120,
+                    node_type=node_type,
+                ),
+                AccumulatorBoostCancelButton(
+                    coordinator,
+                    entry.entry_id,
+                    dev_id,
+                    addr_str,
+                    base_name,
+                    f"{unique_prefix}_cancel",
+                    node_type=node_type,
+                ),
+            ]
+        )
+
+    if boost_entities:
+        entities.extend(boost_entities)
+    log_skipped_nodes("button", nodes_by_type, logger=_LOGGER)
+
+    async_add_entities(entities)
 
 
 class StateRefreshButton(CoordinatorEntity, ButtonEntity):
@@ -43,3 +137,152 @@ class StateRefreshButton(CoordinatorEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Request an immediate coordinator refresh when pressed."""
         await self.coordinator.async_request_refresh()
+
+
+class AccumulatorBoostButtonBase(HeaterNodeBase, ButtonEntity):
+    """Base entity for TermoWeb accumulator boost helper buttons."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        base_name: str,
+        unique_id: str,
+        *,
+        label: str,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise an accumulator boost helper button."""
+
+        HeaterNodeBase.__init__(
+            self,
+            coordinator,
+            entry_id,
+            dev_id,
+            addr,
+            f"{base_name} {label}",
+            unique_id,
+            device_name=base_name,
+            node_type=node_type,
+        )
+        self._label = label
+        self._attr_name = label
+
+    @property
+    def _service_minutes(self) -> int | None:
+        """Return the minutes payload passed to the helper service."""
+
+        return None
+
+    async def async_press(self) -> None:
+        """Invoke the helper service to update the accumulator boost state."""
+
+        hass = self.hass
+        if hass is None:
+            return
+
+        data: dict[str, Any] = {
+            "entry_id": self._entry_id,
+            "dev_id": self._dev_id,
+            "node_type": self._node_type,
+            "addr": self._addr,
+        }
+        minutes = self._service_minutes
+        if minutes is not None:
+            data["minutes"] = minutes
+
+        try:
+            await hass.services.async_call(
+                DOMAIN,
+                _SERVICE_REQUEST_ACCUMULATOR_BOOST,
+                data,
+                blocking=True,
+            )
+        except ServiceNotFound as err:
+            _LOGGER.error(
+                "Boost helper service unavailable for %s (%s): %s",
+                self._addr,
+                self._node_type,
+                err,
+            )
+        except HomeAssistantError as err:  # pragma: no cover - defensive logging
+            _LOGGER.error(
+                "Boost helper service failed for %s (%s): %s",
+                self._addr,
+                self._node_type,
+                err,
+            )
+
+
+class AccumulatorBoostButton(AccumulatorBoostButtonBase):
+    """Button that starts an accumulator boost for a fixed duration."""
+
+    _attr_icon = "mdi:timer-play"
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        base_name: str,
+        unique_id: str,
+        *,
+        minutes: int,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise the boost helper button for a fixed duration."""
+
+        self._minutes = minutes
+        super().__init__(
+            coordinator,
+            entry_id,
+            dev_id,
+            addr,
+            base_name,
+            unique_id,
+            label=f"Boost {minutes} minutes",
+            node_type=node_type,
+        )
+
+    @property
+    def _service_minutes(self) -> int | None:
+        """Return the hard-coded boost duration for the button."""
+
+        return self._minutes
+
+
+class AccumulatorBoostCancelButton(AccumulatorBoostButtonBase):
+    """Button that stops the active accumulator boost session."""
+
+    _attr_icon = "mdi:timer-off"
+
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        base_name: str,
+        unique_id: str,
+        *,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise the helper button that cancels an active boost."""
+
+        super().__init__(
+            coordinator,
+            entry_id,
+            dev_id,
+            addr,
+            base_name,
+            unique_id,
+            label="Cancel boost",
+            node_type=node_type,
+        )
+

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import types
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -19,6 +23,8 @@ GatewayOnlineBinarySensor = (
 async_setup_binary_sensor_entry = binary_sensor_module.async_setup_entry
 StateRefreshButton = button_module.StateRefreshButton
 async_setup_button_entry = button_module.async_setup_entry
+AccumulatorBoostButton = button_module.AccumulatorBoostButton
+AccumulatorBoostCancelButton = button_module.AccumulatorBoostCancelButton
 
 
 def test_binary_sensor_setup_and_dispatch() -> None:
@@ -157,6 +163,219 @@ def test_refresh_button_device_info_and_press() -> None:
         assert info == expected_info
 
         await button_entity.async_press()
+        coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_button_setup_adds_accumulator_entities(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        hass = HomeAssistant()
+        entry = types.SimpleNamespace(entry_id="entry-boost")
+        dev_id = "device-boost"
+        coordinator = types.SimpleNamespace(hass=hass, data={})
+
+        hass.data = {
+            DOMAIN: {
+                entry.entry_id: {
+                    "coordinator": coordinator,
+                    "dev_id": dev_id,
+                }
+            }
+        }
+
+        acm_node = types.SimpleNamespace(addr="5", supports_boost=lambda: True)
+        acm_skip = types.SimpleNamespace(addr="6", supports_boost=lambda: False)
+        htr_node = types.SimpleNamespace(addr="3")
+
+        def fake_prepare(entry_data, *, default_name_simple):  # type: ignore[unused-argument]
+            return (
+                [],
+                {"acm": [acm_node, acm_skip], "htr": [htr_node]},
+                {},
+                lambda node_type, addr: f"{node_type.upper()} {addr}",
+            )
+
+        monkeypatch.setattr(button_module, "prepare_heater_platform_data", fake_prepare)
+
+        added: list = []
+
+        def _add_entities(entities):
+            for entity in entities:
+                entity.hass = hass
+            added.extend(entities)
+
+        await async_setup_button_entry(hass, entry, _add_entities)
+
+        assert len(added) == 5
+        assert isinstance(added[0], StateRefreshButton)
+
+        boost_entities = added[1:]
+        assert all(isinstance(entity, ButtonEntity) for entity in boost_entities)
+        names = [getattr(entity, "_attr_name", None) for entity in boost_entities]
+        assert names == [
+            "Boost 30 minutes",
+            "Boost 60 minutes",
+            "Boost 120 minutes",
+            "Cancel boost",
+        ]
+        icons = [getattr(entity, "icon", getattr(entity, "_attr_icon", None)) for entity in boost_entities]
+        assert icons == [
+            "mdi:timer-play",
+            "mdi:timer-play",
+            "mdi:timer-play",
+            "mdi:timer-off",
+        ]
+
+    asyncio.run(_run())
+
+
+def test_accumulator_boost_button_triggers_service() -> None:
+    async def _run() -> None:
+        hass = HomeAssistant()
+        entry_id = "entry-trigger"
+        dev_id = "device-trigger"
+        coordinator = types.SimpleNamespace(hass=hass, data={})
+        hass.services = types.SimpleNamespace(async_call=AsyncMock())
+
+        button = AccumulatorBoostButton(
+            coordinator,
+            entry_id,
+            dev_id,
+            "2",
+            "Living Room",
+            "uid-boost-60",
+            minutes=60,
+            node_type="acm",
+        )
+        button.hass = hass
+
+        await button.async_press()
+
+        hass.services.async_call.assert_awaited_once_with(
+            DOMAIN,
+            button_module._SERVICE_REQUEST_ACCUMULATOR_BOOST,
+            {
+                "entry_id": entry_id,
+                "dev_id": dev_id,
+                "node_type": "acm",
+                "addr": "2",
+                "minutes": 60,
+            },
+            blocking=True,
+        )
+
+    asyncio.run(_run())
+
+
+def test_accumulator_boost_cancel_button_triggers_service_without_minutes() -> None:
+    async def _run() -> None:
+        hass = HomeAssistant()
+        entry_id = "entry-cancel"
+        dev_id = "device-cancel"
+        coordinator = types.SimpleNamespace(hass=hass, data={})
+        hass.services = types.SimpleNamespace(async_call=AsyncMock())
+
+        button = AccumulatorBoostCancelButton(
+            coordinator,
+            entry_id,
+            dev_id,
+            "4",
+            "Bedroom",
+            "uid-cancel",
+            node_type="acm",
+        )
+        button.hass = hass
+
+        await button.async_press()
+
+        hass.services.async_call.assert_awaited_once_with(
+            DOMAIN,
+            button_module._SERVICE_REQUEST_ACCUMULATOR_BOOST,
+            {
+                "entry_id": entry_id,
+                "dev_id": dev_id,
+                "node_type": "acm",
+                "addr": "4",
+            },
+            blocking=True,
+        )
+
+    asyncio.run(_run())
+
+
+def test_accumulator_boost_button_handles_missing_hass() -> None:
+    async def _run() -> None:
+        hass = HomeAssistant()
+        coordinator = types.SimpleNamespace(hass=hass, data={})
+        hass.services = types.SimpleNamespace(async_call=AsyncMock())
+
+        button = AccumulatorBoostButton(
+            coordinator,
+            "entry-no-hass",
+            "device-no-hass",
+            "8",
+            "Kitchen",
+            "uid-no-hass",
+            minutes=30,
+            node_type="acm",
+        )
+        button.hass = None
+
+        await button.async_press()
+
+        hass.services.async_call.assert_not_called()
+
+    asyncio.run(_run())
+
+
+def test_accumulator_boost_button_logs_service_errors(caplog: pytest.LogCaptureFixture) -> None:
+    async def _run() -> None:
+        caplog.set_level(logging.ERROR)
+        hass = HomeAssistant()
+        entry_id = "entry-errors"
+        dev_id = "device-errors"
+        coordinator = types.SimpleNamespace(hass=hass, data={})
+        hass.services = types.SimpleNamespace(async_call=AsyncMock())
+
+        button = AccumulatorBoostButton(
+            coordinator,
+            entry_id,
+            dev_id,
+            "10",
+            "Office",
+            "uid-errors",
+            minutes=120,
+            node_type="acm",
+        )
+        button.hass = hass
+
+        hass.services.async_call.side_effect = button_module.ServiceNotFound("termoweb", "boost")
+        await button.async_press()
+        assert "Boost helper service unavailable" in caplog.text
+
+        hass.services.async_call.reset_mock()
+        hass.services.async_call.side_effect = button_module.HomeAssistantError("boom")
+        await button.async_press()
+        assert "Boost helper service failed" in caplog.text
+
+    asyncio.run(_run())
+
+
+def test_state_refresh_button_direct_press_and_info() -> None:
+    async def _run() -> None:
+        hass = HomeAssistant()
+        coordinator = types.SimpleNamespace(
+            hass=hass,
+            async_request_refresh=AsyncMock(),
+        )
+
+        button = StateRefreshButton(coordinator, "entry-direct", "device-direct")
+        button.hass = hass
+
+        info = button.device_info
+        expected = build_gateway_device_info(hass, "entry-direct", "device-direct")
+        assert info == expected
+
+        await button.async_press()
         coordinator.async_request_refresh.assert_awaited_once()
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- iterate heater metadata in the button setup to register new accumulator boost start/cancel entities alongside the refresh control and call the future helper service
- add dedicated button entity implementations and unit tests that exercise service calls, error handling, and naming for the boost controls

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e432aecf548329900f13e656395a0d