### PR TITLE
Add tests covering boost configuration edge cases

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -243,6 +243,28 @@ def test_async_setup_entry_creates_entities() -> None:
     asyncio.run(_run())
 
 
+def test_accumulator_preferred_boost_defaults_without_hass() -> None:
+    """Ensure accumulators fall back to the default boost duration offline."""
+
+    _reset_environment()
+    hass = HomeAssistant()
+    dev_id = "dev-acc"
+    record = {"nodes": {}, "htr": {"settings": {}}, "nodes_by_type": {}}
+    coordinator = _make_coordinator(hass, dev_id, record)
+
+    entity = climate_module.AccumulatorClimateEntity(
+        coordinator,
+        "entry-acc",
+        dev_id,
+        "01",
+        "Accumulator",
+        node_type="acm",
+    )
+
+    entity.hass = None
+    assert entity._preferred_boost_minutes() == DEFAULT_BOOST_DURATION
+
+
 def test_async_setup_entry_default_names_and_invalid_nodes(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary
- add a climate test covering accumulator boost defaults without Home Assistant context
- expand heater helper tests to exercise boost runtime coercion and storage guards
- extend select platform tests to filter unsupported nodes and validate fallback logic

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e436572f7c8329b0b2af921f89d94c