### PR TITLE
Add test coverage for gateway device info coordinator fallback

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -216,6 +216,16 @@ def test_build_gateway_device_info_uses_brand_and_version() -> None:
     assert info["sw_version"] == "7"
 
 
+def test_build_gateway_device_info_ignores_non_mapping_coordinator_data() -> None:
+    hass = types.SimpleNamespace(
+        data={DOMAIN: {"entry": {"coordinator": types.SimpleNamespace(data=[1, 2, 3])}}}
+    )
+
+    info = build_gateway_device_info(hass, "entry", "dev")
+
+    assert info["model"] == "Gateway/Controller"
+
+
 def test_normalize_heater_addresses_with_none() -> None:
     mapping, aliases = normalize_heater_addresses(None)
 


### PR DESCRIPTION
## Summary
- add a regression test that exercises build_gateway_device_info when the coordinator exposes non-mapping data

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e439113abc8329a6afc4496b35fa27