### PR TITLE
Add heater boost sensor and binary sensor support

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -1,7 +1,8 @@
-"""Binary sensor entities for TermoWeb gateway connectivity."""
+"""Binary sensor entities for TermoWeb gateway connectivity and heaters."""
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
@@ -14,8 +15,16 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, signal_ws_status
 from .coordinator import StateCoordinator
-from .heater import DispatcherSubscriptionHelper
+from .heater import (
+    DispatcherSubscriptionHelper,
+    HeaterNodeBase,
+    iter_heater_nodes,
+    log_skipped_nodes,
+    prepare_heater_platform_data,
+)
 from .utils import build_gateway_device_info
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -23,8 +32,49 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coord: StateCoordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    ent = GatewayOnlineBinarySensor(coord, entry.entry_id, dev_id)
-    async_add_entities([ent])
+    gateway = GatewayOnlineBinarySensor(coord, entry.entry_id, dev_id)
+
+    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
+        data,
+        default_name_simple=lambda addr: f"Node {addr}",
+    )
+
+    boost_entities: list[BinarySensorEntity] = []
+    for node_type, node, addr_str, base_name in iter_heater_nodes(
+        nodes_by_type, resolve_name
+    ):
+        supports_boost = getattr(node, "supports_boost", None)
+        supported = False
+        if callable(supports_boost):
+            try:
+                supported = bool(supports_boost())
+            except Exception:  # pragma: no cover - defensive
+                supported = False
+        elif isinstance(supports_boost, bool):
+            supported = supports_boost
+        if not supported:
+            continue
+        unique_id = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:boost_active"
+        boost_entities.append(
+            HeaterBoostActiveBinarySensor(
+                coord,
+                entry.entry_id,
+                dev_id,
+                addr_str,
+                f"{base_name} Boost Active",
+                unique_id,
+                device_name=base_name,
+                node_type=node_type,
+            )
+        )
+
+    if boost_entities:
+        _LOGGER.debug(
+            "Adding %d TermoWeb heater boost binary sensors", len(boost_entities)
+        )
+
+    log_skipped_nodes("binary_sensor", nodes_by_type, logger=_LOGGER)
+    async_add_entities([gateway, *boost_entities])
 
 
 class GatewayOnlineBinarySensor(
@@ -97,3 +147,53 @@ class GatewayOnlineBinarySensor(
         if payload.get("dev_id") != self._dev_id:
             return
         self.schedule_update_ha_state()
+
+
+class HeaterBoostActiveBinarySensor(HeaterNodeBase, BinarySensorEntity):
+    """Binary sensor indicating whether a heater boost is active."""
+
+    _attr_device_class = getattr(BinarySensorDeviceClass, "HEAT", "heat")
+
+    def __init__(
+        self,
+        coordinator: StateCoordinator,
+        entry_id: str,
+        dev_id: str,
+        addr: str,
+        name: str,
+        unique_id: str,
+        *,
+        device_name: str | None = None,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise the boost activity binary sensor."""
+
+        super().__init__(
+            coordinator,
+            entry_id,
+            dev_id,
+            addr,
+            name,
+            unique_id,
+            device_name=device_name,
+            node_type=node_type,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the heater boost is active."""
+
+        state = self.boost_state()
+        return state.active
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return boost metadata exposed alongside the binary state."""
+
+        state = self.boost_state()
+        return {
+            "dev_id": self._dev_id,
+            "addr": self._addr,
+            "boost_minutes_remaining": state.minutes_remaining,
+            "boost_end": state.end_iso,
+        }

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -10,7 +11,13 @@ _install_stubs()
 
 from custom_components.termoweb import heater as heater_module
 from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb.binary_sensor import HeaterBoostActiveBinarySensor
+from custom_components.termoweb.sensor import (
+    HeaterBoostEndSensor,
+    HeaterBoostMinutesRemainingSensor,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 HeaterNodeBase = heater_module.HeaterNodeBase
 
@@ -100,3 +107,167 @@ def test_boost_runtime_storage_roundtrip() -> None:
         )
         == heater_module.DEFAULT_BOOST_DURATION
     )
+
+
+def test_derive_boost_state_uses_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify boost metadata derivation favours the coordinator resolver."""
+
+    base_now = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_now)
+
+    expected_end = base_now + timedelta(hours=1)
+
+    class _Coordinator(SimpleNamespace):
+        def resolve_boost_end(self, day, minute, *, now=None):
+            return expected_end, 60
+
+    settings = {"mode": "boost", "boost_end_day": 1, "boost_end_min": 60}
+    state = heater_module.derive_boost_state(settings, _Coordinator())
+
+    assert state.active is True
+    assert state.minutes_remaining == 60
+    assert state.end_datetime == expected_end
+    assert state.end_iso == expected_end.isoformat()
+
+
+def test_derive_boost_state_from_remaining(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure boost metadata uses remaining minutes when resolver unavailable."""
+
+    base_now = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_now)
+
+    settings = {"boost_remaining": "15"}
+    state = heater_module.derive_boost_state(settings, SimpleNamespace())
+
+    assert state.active is False
+    assert state.minutes_remaining == 15
+    assert state.end_iso == (base_now + timedelta(minutes=15)).isoformat()
+    assert state.end_datetime == base_now + timedelta(minutes=15)
+
+
+def test_derive_boost_state_parses_string_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boost metadata should parse ISO formatted end timestamps."""
+
+    base_now = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_now)
+
+    iso = "2024-01-01T00:30:00+00:00"
+    settings = {"boost_active": True, "boost_end": iso}
+    state = heater_module.derive_boost_state(settings, SimpleNamespace())
+
+    assert state.active is True
+    assert state.minutes_remaining is None
+    assert state.end_iso == iso
+    assert state.end_datetime == datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc)
+
+
+def test_boost_entities_expose_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure boost binary and sensor entities expose derived metadata."""
+
+    base_now = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_now)
+
+    expected_end = base_now + timedelta(minutes=30)
+    settings = {"mode": "boost", "boost_end_day": 1, "boost_end_min": 30}
+    coordinator = SimpleNamespace(
+        data={
+            "dev": {
+                "nodes_by_type": {
+                    "acm": {"settings": {"1": settings}},
+                }
+            }
+        },
+        resolve_boost_end=lambda day, minute, *, now=None: (expected_end, 30),
+    )
+
+    boost_binary = HeaterBoostActiveBinarySensor(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        "Accumulator Boost Active",
+        f"{DOMAIN}:dev:acm:1:boost_active",
+        device_name="Accumulator",
+        node_type="acm",
+    )
+    minutes_sensor = HeaterBoostMinutesRemainingSensor(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        "Accumulator Boost Minutes Remaining",
+        f"{DOMAIN}:dev:acm:1:boost:minutes_remaining",
+        device_name="Accumulator",
+        node_type="acm",
+    )
+    end_sensor = HeaterBoostEndSensor(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        "Accumulator Boost End",
+        f"{DOMAIN}:dev:acm:1:boost:end",
+        device_name="Accumulator",
+        node_type="acm",
+    )
+
+    assert boost_binary.is_on is True
+    assert minutes_sensor.native_value == 30
+    assert end_sensor.native_value == expected_end
+
+    assert boost_binary.extra_state_attributes["boost_minutes_remaining"] == 30
+    assert boost_binary.extra_state_attributes["boost_end"] == expected_end.isoformat()
+    assert minutes_sensor.extra_state_attributes["boost_end"] == expected_end.isoformat()
+    assert end_sensor.extra_state_attributes["boost_minutes_remaining"] == 30
+
+
+def test_boost_entities_handle_missing_data() -> None:
+    """Boost entities should gracefully handle missing settings."""
+
+    coordinator = SimpleNamespace(
+        data={
+            "dev": {
+                "nodes_by_type": {
+                    "acm": {"settings": {"1": {}}},
+                }
+            }
+        }
+    )
+
+    boost_binary = HeaterBoostActiveBinarySensor(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        "Accumulator Boost Active",
+        f"{DOMAIN}:dev:acm:1:boost_active",
+        device_name="Accumulator",
+        node_type="acm",
+    )
+    minutes_sensor = HeaterBoostMinutesRemainingSensor(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        "Accumulator Boost Minutes Remaining",
+        f"{DOMAIN}:dev:acm:1:boost:minutes_remaining",
+        device_name="Accumulator",
+        node_type="acm",
+    )
+    end_sensor = HeaterBoostEndSensor(
+        coordinator,
+        "entry",
+        "dev",
+        "1",
+        "Accumulator Boost End",
+        f"{DOMAIN}:dev:acm:1:boost:end",
+        device_name="Accumulator",
+        node_type="acm",
+    )
+
+    assert boost_binary.is_on is False
+    assert minutes_sensor.native_value is None
+    assert end_sensor.native_value is None
+    assert boost_binary.extra_state_attributes["boost_end"] is None
+    assert minutes_sensor.extra_state_attributes["boost_end"] is None
+    assert end_sensor.extra_state_attributes["boost_minutes_remaining"] is None


### PR DESCRIPTION
## Summary
- add a derive_boost_state helper on heaters and reuse it from the climate entity
- expose heater boost status via a binary sensor and countdown/timestamp sensors that plug into the coordinator cache
- extend binary sensor and sensor setup tests to cover boost-supporting accumulators

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e436853884832985a0b459684e93a0