### PR TITLE
Add number platform support and helper translations

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -85,7 +85,7 @@ from .backend.ws_client import TermoWebWSClient  # noqa: F401,E402
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["button", "binary_sensor", "climate", "select", "sensor"]
+PLATFORMS = ["button", "binary_sensor", "climate", "number", "select", "sensor"]
 
 reset_samples_rate_limit_state()
 
@@ -215,7 +215,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if node_inventory:
         type_counts = Counter(node.type for node in node_inventory)
-        summary = ", ".join(f"{node_type}:{count}" for node_type, count in sorted(type_counts.items()))
+        summary = ", ".join(
+            f"{node_type}:{count}" for node_type, count in sorted(type_counts.items())
+        )
     else:
         summary = "none"
     _LOGGER.info("%s: discovered node types: %s", dev_id, summary)
@@ -228,7 +230,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dev,
         nodes,
         node_inventory,
-
     )
 
     debug_enabled = bool(entry.options.get("debug", entry.data.get("debug", False)))
@@ -493,9 +494,7 @@ async def _async_shutdown_entry(rec: MutableMapping[str, Any]) -> None:
                 try:
                     cancel()
                 except Exception:  # pragma: no cover - defensive logging
-                    _LOGGER.exception(
-                        "WS task for %s raised during cancel", dev_id
-                    )
+                    _LOGGER.exception("WS task for %s raised during cancel", dev_id)
                     continue
             if hasattr(task, "__await__"):
                 try:
@@ -503,9 +502,7 @@ async def _async_shutdown_entry(rec: MutableMapping[str, Any]) -> None:
                 except asyncio.CancelledError:
                     pass
                 except Exception:  # pragma: no cover - defensive logging
-                    _LOGGER.exception(
-                        "WS task for %s failed to cancel cleanly", dev_id
-                    )
+                    _LOGGER.exception("WS task for %s failed to cancel cleanly", dev_id)
 
     ws_clients = rec.get("ws_clients")
     if isinstance(ws_clients, Mapping):

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -16,6 +16,8 @@ except ImportError:  # pragma: no cover - executed in unit test stubs
 
     class ServiceNotFound(HomeAssistantError):
         """Fallback service lookup error used in unit tests."""
+
+
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -117,6 +119,7 @@ class StateRefreshButton(CoordinatorEntity, ButtonEntity):
 
     _attr_name = "Force refresh"
     _attr_has_entity_name = True
+    _attr_translation_key = "force_refresh"
 
     def __init__(self, coordinator, entry_id: str, dev_id: str) -> None:
         """Initialise the force-refresh button entity."""
@@ -223,6 +226,7 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
     """Button that starts an accumulator boost for a fixed duration."""
 
     _attr_icon = "mdi:timer-play"
+    _attr_translation_key = "accumulator_boost_minutes"
 
     def __init__(
         self,
@@ -256,11 +260,18 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
 
         return self._minutes
 
+    @property
+    def translation_placeholders(self) -> dict[str, str]:
+        """Expose the configured boost duration for translations."""
+
+        return {"minutes": str(self._minutes)}
+
 
 class AccumulatorBoostCancelButton(AccumulatorBoostButtonBase):
     """Button that stops the active accumulator boost session."""
 
     _attr_icon = "mdi:timer-off"
+    _attr_translation_key = "accumulator_boost_cancel"
 
     def __init__(
         self,
@@ -285,4 +296,3 @@ class AccumulatorBoostCancelButton(AccumulatorBoostButtonBase):
             label="Cancel boost",
             node_type=node_type,
         )
-

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -208,7 +208,7 @@ def _coerce_boost_bool(value: Any) -> bool | None:
 
 
 def _coerce_boost_minutes(value: Any) -> int | None:
-    """Return ``value`` as non-negative minutes when possible."""
+    """Return ``value`` as positive minutes when possible."""
 
     if value is None or isinstance(value, bool):
         return None
@@ -222,7 +222,9 @@ def _coerce_boost_minutes(value: Any) -> int | None:
             minutes = int(float(text))
     except (TypeError, ValueError):  # pragma: no cover - defensive
         return None
-    return minutes if minutes >= 0 else None
+    if minutes <= 0:
+        return None
+    return minutes
 
 
 @dataclass(slots=True)
@@ -264,11 +266,7 @@ def derive_boost_state(
     boost_end_dt: datetime | None = None
     boost_minutes: int | None = None
     resolver = getattr(coordinator, "resolve_boost_end", None)
-    if (
-        callable(resolver)
-        and boost_day is not None
-        and boost_minute is not None
-    ):
+    if callable(resolver) and boost_day is not None and boost_minute is not None:
         try:
             boost_end_dt, boost_minutes = resolver(boost_day, boost_minute)
         except Exception:  # noqa: BLE001 - defensive

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -72,6 +72,7 @@ class AccumulatorBoostDurationSelect(RestoreEntity, HeaterNodeBase, SelectEntity
     _attr_entity_category = EntityCategory.CONFIG
     _attr_has_entity_name = True
     _attr_icon = "mdi:timer-cog-outline"
+    _attr_translation_key = "accumulator_boost_duration"
 
     _OPTION_MAP = {str(option): option for option in BOOST_DURATION_OPTIONS}
     _REVERSE_OPTION_MAP = {value: key for key, value in _OPTION_MAP.items()}

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -26,5 +26,94 @@
         }
       }
     }
+  },
+  "entity": {
+    "button": {
+      "force_refresh": {
+        "name": "Force refresh"
+      },
+      "accumulator_boost_minutes": {
+        "name": "Boost {minutes} minutes"
+      },
+      "accumulator_boost_cancel": {
+        "name": "Cancel boost"
+      }
+    },
+    "select": {
+      "accumulator_boost_duration": {
+        "name": "Boost duration"
+      }
+    }
+  },
+  "services": {
+    "set_schedule": {
+      "name": "Set weekly schedule",
+      "description": "Set the 7×24 weekly program for a TermoWeb heater. The program is a list of 168 integers, where each value corresponds to one hour of the week starting Monday 00:00. Use 0 for the cold preset, 1 for the night preset and 2 for the day preset.",
+      "fields": {
+        "prog": {
+          "name": "Program",
+          "description": "A list of 168 integers (0, 1 or 2) representing the heater’s weekly schedule. Index 0 is Monday 00:00, index 1 is Monday 01:00, and so on.",
+          "example": "[0,0,0,1,1,2,2,0,1,2,0,...]"
+        }
+      }
+    },
+    "set_preset_temperatures": {
+      "name": "Set preset temperatures",
+      "description": "Set the cold, night and day preset temperatures for a TermoWeb heater. You can either provide all three temperatures as a single list (``ptemp``) or specify each one separately (``cold``, ``night`` and ``day``).",
+      "fields": {
+        "ptemp": {
+          "name": "Preset temperatures",
+          "description": "A list of three temperatures [cold, night, day] in the same units as the heater (°C or °F). If provided, this will override individual cold, night and day values.",
+          "example": "[10.0, 16.0, 20.0]"
+        },
+        "cold": {
+          "name": "Cold preset",
+          "description": "Temperature for the cold preset (°C or °F).",
+          "example": "10.0"
+        },
+        "night": {
+          "name": "Night preset",
+          "description": "Temperature for the night preset (°C or °F).",
+          "example": "16.0"
+        },
+        "day": {
+          "name": "Day preset",
+          "description": "Temperature for the day preset (°C or °F).",
+          "example": "20.0"
+        }
+      }
+    },
+    "import_energy_history": {
+      "name": "Import energy history",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics.",
+      "fields": {
+        "reset_progress": {
+          "name": "Reset progress",
+          "description": "Clear stored progress and re-import history from scratch.",
+          "default": "false"
+        },
+        "max_history_retrieval": {
+          "name": "Max history days",
+          "description": "Number of days of history to retrieve. Overrides the configured default for this import only.",
+          "default": "7"
+        }
+      }
+    },
+    "ws_debug_probe": {
+      "name": "Emit websocket debug probe",
+      "description": "Request an immediate ``dev_data`` refresh from the websocket client and log the next ``dev_handshake`` and ``update`` frame sizes. Enable the debug option in the integration settings before using this helper.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry ID",
+          "description": "Restrict the probe to a single TermoWeb config entry.",
+          "example": "abcd1234deadbeef"
+        },
+        "dev_id": {
+          "name": "Device ID",
+          "description": "Restrict the probe to a single gateway device.",
+          "example": "0000abcd"
+        }
+      }
+    }
   }
 }

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -89,13 +89,11 @@
       "fields": {
         "reset_progress": {
           "name": "Reset progress",
-          "description": "Clear stored progress and re-import history from scratch.",
-          "default": "false"
+          "description": "Clear stored progress and re-import history from scratch."
         },
         "max_history_retrieval": {
           "name": "Max history days",
-          "description": "Number of days of history to retrieve. Overrides the configured default for this import only.",
-          "default": "7"
+          "description": "Number of days of history to retrieve. Overrides the configured default for this import only."
         }
       }
     },

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -30,5 +30,94 @@
         }
       }
     }
+  },
+  "entity": {
+    "button": {
+      "force_refresh": {
+        "name": "Force refresh"
+      },
+      "accumulator_boost_minutes": {
+        "name": "Boost {minutes} minutes"
+      },
+      "accumulator_boost_cancel": {
+        "name": "Cancel boost"
+      }
+    },
+    "select": {
+      "accumulator_boost_duration": {
+        "name": "Boost duration"
+      }
+    }
+  },
+  "services": {
+    "set_schedule": {
+      "name": "Set weekly schedule",
+      "description": "Set the 7×24 weekly program for a TermoWeb heater. The program is a list of 168 integers, where each value corresponds to one hour of the week starting Monday 00:00. Use 0 for the cold preset, 1 for the night preset and 2 for the day preset.",
+      "fields": {
+        "prog": {
+          "name": "Program",
+          "description": "A list of 168 integers (0, 1 or 2) representing the heater’s weekly schedule. Index 0 is Monday 00:00, index 1 is Monday 01:00, and so on.",
+          "example": "[0,0,0,1,1,2,2,0,1,2,0,...]"
+        }
+      }
+    },
+    "set_preset_temperatures": {
+      "name": "Set preset temperatures",
+      "description": "Set the cold, night and day preset temperatures for a TermoWeb heater. You can either provide all three temperatures as a single list (``ptemp``) or specify each one separately (``cold``, ``night`` and ``day``).",
+      "fields": {
+        "ptemp": {
+          "name": "Preset temperatures",
+          "description": "A list of three temperatures [cold, night, day] in the same units as the heater (°C or °F). If provided, this will override individual cold, night and day values.",
+          "example": "[10.0, 16.0, 20.0]"
+        },
+        "cold": {
+          "name": "Cold preset",
+          "description": "Temperature for the cold preset (°C or °F).",
+          "example": "10.0"
+        },
+        "night": {
+          "name": "Night preset",
+          "description": "Temperature for the night preset (°C or °F).",
+          "example": "16.0"
+        },
+        "day": {
+          "name": "Day preset",
+          "description": "Temperature for the day preset (°C or °F).",
+          "example": "20.0"
+        }
+      }
+    },
+    "import_energy_history": {
+      "name": "Import energy history",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics.",
+      "fields": {
+        "reset_progress": {
+          "name": "Reset progress",
+          "description": "Clear stored progress and re-import history from scratch.",
+          "default": "false"
+        },
+        "max_history_retrieval": {
+          "name": "Max history days",
+          "description": "Number of days of history to retrieve. Overrides the configured default for this import only.",
+          "default": "7"
+        }
+      }
+    },
+    "ws_debug_probe": {
+      "name": "Emit websocket debug probe",
+      "description": "Request an immediate ``dev_data`` refresh from the websocket client and log the next ``dev_handshake`` and ``update`` frame sizes. Enable the debug option in the integration settings before using this helper.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry ID",
+          "description": "Restrict the probe to a single TermoWeb config entry.",
+          "example": "abcd1234deadbeef"
+        },
+        "dev_id": {
+          "name": "Device ID",
+          "description": "Restrict the probe to a single gateway device.",
+          "example": "0000abcd"
+        }
+      }
+    }
   }
 }

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -93,13 +93,11 @@
       "fields": {
         "reset_progress": {
           "name": "Reset progress",
-          "description": "Clear stored progress and re-import history from scratch.",
-          "default": "false"
+          "description": "Clear stored progress and re-import history from scratch."
         },
         "max_history_retrieval": {
           "name": "Max history days",
-          "description": "Number of days of history to retrieve. Overrides the configured default for this import only.",
-          "default": "7"
+          "description": "Number of days of history to retrieve. Overrides the configured default for this import only."
         }
       }
     },

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -17,9 +17,7 @@ import custom_components.termoweb.button as button_module
 from custom_components.termoweb.const import DOMAIN, signal_ws_status
 from custom_components.termoweb.utils import build_gateway_device_info
 
-GatewayOnlineBinarySensor = (
-    binary_sensor_module.GatewayOnlineBinarySensor
-)
+GatewayOnlineBinarySensor = binary_sensor_module.GatewayOnlineBinarySensor
 async_setup_binary_sensor_entry = binary_sensor_module.async_setup_entry
 StateRefreshButton = button_module.StateRefreshButton
 async_setup_button_entry = button_module.async_setup_entry
@@ -103,9 +101,13 @@ def test_binary_sensor_setup_and_dispatch() -> None:
         }
 
         entity.schedule_update_ha_state = MagicMock()
-        async_dispatcher_send(hass, signal_ws_status(entry.entry_id), {"dev_id": "other"})
+        async_dispatcher_send(
+            hass, signal_ws_status(entry.entry_id), {"dev_id": "other"}
+        )
         entity.schedule_update_ha_state.assert_not_called()
-        async_dispatcher_send(hass, signal_ws_status(entry.entry_id), {"dev_id": dev_id})
+        async_dispatcher_send(
+            hass, signal_ws_status(entry.entry_id), {"dev_id": dev_id}
+        )
         entity.schedule_update_ha_state.assert_called_once_with()
 
         await entity.async_will_remove_from_hass()
@@ -124,7 +126,9 @@ def test_refresh_button_device_info_and_press() -> None:
             async_request_refresh=AsyncMock(),
         )
 
-        hass.data = {DOMAIN: {entry.entry_id: {"coordinator": coordinator, "dev_id": dev_id}}}
+        hass.data = {
+            DOMAIN: {entry.entry_id: {"coordinator": coordinator, "dev_id": dev_id}}
+        }
 
         added: list = []
         seen_ids: set[str] = set()
@@ -166,7 +170,9 @@ def test_refresh_button_device_info_and_press() -> None:
         coordinator.async_request_refresh.assert_awaited_once()
 
 
-def test_button_setup_adds_accumulator_entities(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_button_setup_adds_accumulator_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _run() -> None:
         hass = HomeAssistant()
         entry = types.SimpleNamespace(entry_id="entry-boost")
@@ -217,7 +223,10 @@ def test_button_setup_adds_accumulator_entities(monkeypatch: pytest.MonkeyPatch)
             "Boost 120 minutes",
             "Cancel boost",
         ]
-        icons = [getattr(entity, "icon", getattr(entity, "_attr_icon", None)) for entity in boost_entities]
+        icons = [
+            getattr(entity, "icon", getattr(entity, "_attr_icon", None))
+            for entity in boost_entities
+        ]
         assert icons == [
             "mdi:timer-play",
             "mdi:timer-play",
@@ -247,6 +256,8 @@ def test_accumulator_boost_button_triggers_service() -> None:
             node_type="acm",
         )
         button.hass = hass
+
+        assert button.translation_placeholders == {"minutes": "60"}
 
         await button.async_press()
 
@@ -327,7 +338,9 @@ def test_accumulator_boost_button_handles_missing_hass() -> None:
     asyncio.run(_run())
 
 
-def test_accumulator_boost_button_logs_service_errors(caplog: pytest.LogCaptureFixture) -> None:
+def test_accumulator_boost_button_logs_service_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     async def _run() -> None:
         caplog.set_level(logging.ERROR)
         hass = HomeAssistant()
@@ -348,7 +361,9 @@ def test_accumulator_boost_button_logs_service_errors(caplog: pytest.LogCaptureF
         )
         button.hass = hass
 
-        hass.services.async_call.side_effect = button_module.ServiceNotFound("termoweb", "boost")
+        hass.services.async_call.side_effect = button_module.ServiceNotFound(
+            "termoweb", "boost"
+        )
         await button.async_press()
         assert "Boost helper service unavailable" in caplog.text
 
@@ -380,14 +395,19 @@ def test_state_refresh_button_direct_press_and_info() -> None:
 
     asyncio.run(_run())
 
-def test_binary_sensor_setup_adds_boost_entities(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def test_binary_sensor_setup_adds_boost_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _run() -> None:
         hass = HomeAssistant()
         entry = types.SimpleNamespace(entry_id="entry-boost-binary")
         dev_id = "device-boost"
         coordinator = types.SimpleNamespace(hass=hass, data={})
 
-        hass.data = {DOMAIN: {entry.entry_id: {"coordinator": coordinator, "dev_id": dev_id}}}
+        hass.data = {
+            DOMAIN: {entry.entry_id: {"coordinator": coordinator, "dev_id": dev_id}}
+        }
 
         boost_node = types.SimpleNamespace(addr="4", supports_boost=lambda: True)
         skip_node = types.SimpleNamespace(addr="5", supports_boost=False)


### PR DESCRIPTION
## Summary
- ensure the TermoWeb config entry forwards and unloads the new number platform alongside existing helpers
- provide translation strings for helper entity names and each TermoWeb service in both strings.json and the English locale
- tighten boost duration coercion and extend tests covering helper entities and defensive boost state handling

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e4baa5c9648329bdaf0b6477f0fc1d