### PR TITLE
Remove number platform from setup

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -85,7 +85,7 @@ from .backend.ws_client import TermoWebWSClient  # noqa: F401,E402
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["button", "binary_sensor", "climate", "number", "select", "sensor"]
+PLATFORMS = ["button", "binary_sensor", "climate", "select", "sensor"]
 
 reset_samples_rate_limit_state()
 


### PR DESCRIPTION
## Summary
- remove the unused number platform from the PLATFORMS list so Home Assistant no longer imports a missing module

## Testing
- pytest tests/test_init_setup.py::test_async_setup_entry_happy_path
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e4c46eb33883298791c04ec9143f18