### PR TITLE
Add accumulator boost service support

### DIFF
--- a/custom_components/termoweb/services.yaml
+++ b/custom_components/termoweb/services.yaml
@@ -49,6 +49,60 @@ set_preset_temperatures:
       description: Temperature for the day preset (°C or °F).
       example: 20.0
 
+set_acm_preset:
+  name: Configure accumulator boost preset
+  description: >-
+    Update the default boost duration and/or temperature for a TermoWeb
+    accumulator. Minutes are capped at 120; omit a field to keep the existing
+    value.
+  target:
+    entity:
+      domain: climate
+      integration: termoweb
+  fields:
+    minutes:
+      name: Default boost duration
+      description: Number of minutes the boost should run when no override is provided.
+      example: 90
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: minutes
+    temperature:
+      name: Boost temperature
+      description: Optional boost setpoint to apply during the boost session (°C or °F).
+      example: 22.5
+
+start_boost:
+  name: Start accumulator boost
+  description: >-
+    Trigger an immediate boost on a TermoWeb accumulator. Provide a duration to
+    override the default (maximum 120 minutes), or omit it to use the stored
+    preset.
+  target:
+    entity:
+      domain: climate
+      integration: termoweb
+  fields:
+    minutes:
+      name: Boost duration
+      description: Duration of the boost session in minutes (1–120). Optional.
+      example: 60
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: minutes
+
+cancel_boost:
+  name: Cancel accumulator boost
+  description: Cancel the active boost session on a TermoWeb accumulator.
+  target:
+    entity:
+      domain: climate
+      integration: termoweb
+
 import_energy_history:
   name: Import energy history
   description: >-


### PR DESCRIPTION
## Summary
- document accumulator boost helper services in `services.yaml`
- add REST helpers to update boost presets and trigger boost sessions
- register new climate entity services and implement accumulator handlers with validation and tests

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check --fix custom_components/termoweb/api.py custom_components/termoweb/backend/ducaheat.py custom_components/termoweb/climate.py tests/test_api.py tests/test_climate.py`


------
https://chatgpt.com/codex/tasks/task_e_68e4c212bb80832989fa36e6be374421