### PR TITLE
Handle boost metadata when normalising Ducaheat payloads

### DIFF
--- a/tests/test_ducaheat_nodes.py
+++ b/tests/test_ducaheat_nodes.py
@@ -62,3 +62,23 @@ def test_ducaheat_rest_normalise_ws_nodes_mixed_settings_types() -> None:
     # Original payload should remain unchanged for mapping coercions.
     assert len(payload["htr"]["settings"]["01"]["prog"]["prog"]["1"]) == 48
     assert len(payload["acm"]["settings"]["03"]["prog"]["days"]["1"]) == 24
+
+
+def test_ducaheat_rest_normalise_ws_settings_boost_fields() -> None:
+    """Websocket settings should expose boost end metadata consistently."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    payload = {
+        "boost": False,
+        "boost_end": {"day": 6, "minute": 15},
+        "boost_end_day": 3,
+    }
+
+    result = client._normalise_ws_settings(payload)
+
+    assert result["boost"] is False
+    assert result["boost_end"] == {"day": 6, "minute": 15}
+    # Direct fields should take precedence over derived values.
+    assert result["boost_end_day"] == 3
+    assert result["boost_end_min"] == 15


### PR DESCRIPTION
## Summary
- ensure Ducaheat REST and websocket normalisation preserves boost and boost_end metadata
- add a helper to merge boost fields defensively across status and setup payloads
- extend API and node tests to cover boost metadata handling while keeping coverage at 100%

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e4c83d16c88329a67ff41b4784e5e9