### PR TITLE
Add boost duration support and metadata for Ducaheat accumulators

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -480,6 +480,7 @@ class RESTClient:
         ptemp: list[float]
         | None = None,  # preset temperatures [cold, night, day] (in current units)
         units: str = "C",
+        boost_time: int | None = None,
     ) -> Any:
         """Update heater settings.
 
@@ -500,6 +501,9 @@ class RESTClient:
         The payload will only include keys for the parameters passed by the caller, to avoid
         overwriting unrelated settings on the device.
         """
+
+        if boost_time is not None:
+            raise ValueError("boost_time is not supported for this node type")
 
         node_type, addr = self._resolve_node_descriptor(node)
 

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -30,6 +30,7 @@ class HttpClientProto(Protocol):
         prog: list[int] | None = None,
         ptemp: list[float] | None = None,
         units: str = "C",
+        boost_time: int | None = None,
     ) -> Any:
         """Update node settings for the specified node."""
 

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -1094,7 +1094,10 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
 
             await self._commit_write(
                 log_context="Preset mode write",
-                write_kwargs={"mode": "boost"},
+                write_kwargs={
+                    "mode": "boost",
+                    "boost_time": self._preferred_boost_minutes(),
+                },
                 apply_fn=_apply,
                 success_details={"preset_mode": "boost"},
             )

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -705,7 +705,11 @@ def test_accumulator_async_set_hvac_mode_paths(
 
         settings_map["mode"] = "auto"
         await entity.async_set_preset_mode("boost")
-        assert commit_calls and commit_calls[0]["write_kwargs"] == {"mode": "boost"}
+        assert commit_calls
+        assert commit_calls[0]["write_kwargs"] == {
+            "mode": "boost",
+            "boost_time": 60,
+        }
         assert settings_map["mode"] == "boost"
         assert entity._boost_resume_mode == HVACMode.AUTO
 

--- a/tests/test_ducaheat_acm_writes.py
+++ b/tests/test_ducaheat_acm_writes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from aiohttp import ClientResponseError
@@ -19,12 +20,17 @@ def _setup_client(
     monkeypatch: pytest.MonkeyPatch,
     *,
     responses: list[dict[str, Any] | None] | None = None,
-) -> tuple[DucaheatRESTClient, list[tuple[str, str, dict[str, Any]]]]:
+) -> tuple[
+    DucaheatRESTClient,
+    list[tuple[str, str, dict[str, Any]]],
+    list[str],
+]:
     """Create a REST client with fake request handling."""
 
     client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
     responses = list(responses or [])
     calls: list[tuple[str, str, dict[str, Any]]] = []
+    rtc_calls: list[str] = []
 
     headers = {
         "Authorization": "Bearer token",
@@ -48,27 +54,24 @@ def _setup_client(
             return responses.pop(0) or {}
         return {}
 
+    async def fake_rtc(dev_id: str) -> dict[str, Any]:
+        rtc_calls.append(dev_id)
+        return {"y": 2024, "n": 1, "d": 1, "h": 0, "m": 0, "s": 0}
     monkeypatch.setattr(client, "_authed_headers", fake_headers)
     monkeypatch.setattr(client, "_request", fake_request)
-    return client, calls
+    monkeypatch.setattr(client, "get_rtc_time", fake_rtc)
+    return client, calls, rtc_calls
 
 
-@pytest.mark.parametrize(
-    "input_mode,expected",
-    [
-        (HVACMode.AUTO, "auto"),
-        (HVACMode.OFF, "off"),
-        ("boost", "boost"),
-        ("manual", "manual"),
-    ],
-)
-def test_ducaheat_acm_mode_requests(
-    monkeypatch: pytest.MonkeyPatch, input_mode: HVACMode | str, expected: str
+def test_ducaheat_acm_mode_boost_includes_duration_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def _run() -> None:
-        client, calls = _setup_client(monkeypatch, responses=[{"ok": True}])
+        client, calls, rtc_calls = _setup_client(monkeypatch, responses=[{"ok": True}])
 
-        await client.set_node_settings("dev", ("acm", "9"), mode=input_mode)
+        result = await client.set_node_settings(
+            "dev", ("acm", "9"), mode="boost", boost_time=45
+        )
 
         assert calls == [
             (
@@ -80,17 +83,66 @@ def test_ducaheat_acm_mode_requests(
                         "X-SerialId": "15",
                         "User-Agent": get_brand_user_agent(BRAND_DUCAHEAT),
                     },
-                    "json": {"mode": expected},
+                    "json": {"mode": "boost", "boost_time": 45},
                 },
             )
         ]
+        assert rtc_calls == ["dev"]
+        boost_state = result.get("boost_state")
+        assert boost_state["boost_active"] is True
+        assert boost_state["boost_minutes_delta"] == 45
+        assert boost_state["boost_end_day"] == 1
+        assert boost_state["boost_end_min"] == 45
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_acm_mode_cancel_posts_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        client, calls, rtc_calls = _setup_client(monkeypatch, responses=[{"ok": True}])
+
+        result = await client.set_node_settings("dev", ("acm", "9"), mode=HVACMode.AUTO)
+
+        assert calls == [
+            (
+                "POST",
+                "/api/v2/devs/dev/acm/9/status",
+                {
+                    "headers": {
+                        "Authorization": "Bearer token",
+                        "X-SerialId": "15",
+                        "User-Agent": get_brand_user_agent(BRAND_DUCAHEAT),
+                    },
+                    "json": {"boost": False},
+                },
+            ),
+            (
+                "POST",
+                "/api/v2/devs/dev/acm/9/mode",
+                {
+                    "headers": {
+                        "Authorization": "Bearer token",
+                        "X-SerialId": "15",
+                        "User-Agent": get_brand_user_agent(BRAND_DUCAHEAT),
+                    },
+                    "json": {"mode": "auto"},
+                },
+            ),
+        ]
+        assert rtc_calls == ["dev"]
+        boost_state = result.get("boost_state")
+        assert boost_state["boost_active"] is False
+        assert boost_state["boost_end"] is None
+        assert boost_state["boost_minutes_delta"] == 0
 
     asyncio.run(_run())
 
 
 def test_ducaheat_acm_set_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
-        client, calls = _setup_client(monkeypatch, responses=[{"status": "ok"}])
+        client, calls, rtc_calls = _setup_client(
+            monkeypatch, responses=[{"status": "ok"}]
+        )
 
         await client.set_node_settings("dev", ("acm", "2"), stemp=19.5, units="c")
 
@@ -108,13 +160,16 @@ def test_ducaheat_acm_set_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
                 },
             )
         ]
+        assert rtc_calls == []
 
     asyncio.run(_run())
 
 
 def test_ducaheat_acm_program_write(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
-        client, calls = _setup_client(monkeypatch, responses=[{"saved": True}])
+        client, calls, rtc_calls = _setup_client(
+            monkeypatch, responses=[{"saved": True}]
+        )
         prog = [0, 1, 2] * 56
 
         await client.set_node_settings("dev", ("acm", "4"), prog=list(prog))
@@ -133,6 +188,7 @@ def test_ducaheat_acm_program_write(monkeypatch: pytest.MonkeyPatch) -> None:
                 },
             )
         ]
+        assert rtc_calls == []
 
         with pytest.raises(ValueError):
             await client.set_node_settings("dev", ("acm", "4"), prog=[0] * 24)
@@ -142,7 +198,9 @@ def test_ducaheat_acm_program_write(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_ducaheat_acm_program_temps(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _run() -> None:
-        client, calls = _setup_client(monkeypatch, responses=[{"saved": True}])
+        client, calls, rtc_calls = _setup_client(
+            monkeypatch, responses=[{"saved": True}]
+        )
 
         await client.set_node_settings(
             "dev", ("acm", "8"), ptemp=[18.0, 20.0, 22.0]
@@ -162,6 +220,7 @@ def test_ducaheat_acm_program_temps(monkeypatch: pytest.MonkeyPatch) -> None:
                 },
             )
         ]
+        assert rtc_calls == []
 
     asyncio.run(_run())
 
@@ -187,10 +246,231 @@ def test_ducaheat_acm_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
         monkeypatch.setattr(client, "_authed_headers", fake_headers)
         monkeypatch.setattr(client, "_request", fake_request)
+        mock_rtc = AsyncMock(return_value={})
+        monkeypatch.setattr(client, "get_rtc_time", mock_rtc)
 
         with pytest.raises(DucaheatRequestError) as exc:
             await client.set_node_settings("dev", ("acm", "1"), mode="boost")
 
         assert "malformed" in str(exc.value)
+        mock_rtc.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_acm_mode_invalid_boost_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        client, _, _ = _setup_client(monkeypatch)
+
+        with pytest.raises(ValueError):
+            await client.set_node_settings(
+                "dev", ("acm", "2"), mode="auto", boost_time=15
+            )
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_acm_mode_boost_invalid_minutes(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        client, _, _ = _setup_client(monkeypatch)
+
+        with pytest.raises(ValueError):
+            await client.set_node_settings(
+                "dev", ("acm", "2"), mode="boost", boost_time=0
+            )
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_acm_mode_boost_invalid_minutes_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        client, _, _ = _setup_client(monkeypatch)
+
+        with pytest.raises(ValueError):
+            await client.set_node_settings(
+                "dev", ("acm", "2"), mode="boost", boost_time="abc"
+            )
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_collect_boost_metadata_rtc_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        client, calls, _ = _setup_client(
+            monkeypatch, responses=[{"ok": True}, {"ok": True}]
+        )
+
+        async def failing_rtc(dev_id: str) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(client, "get_rtc_time", failing_rtc)
+
+        result = await client.set_node_settings("dev", ("acm", "9"), mode="auto")
+        assert len(calls) == 2
+        metadata = result["boost_state"]
+        assert metadata["boost_active"] is False
+        assert metadata["boost_end"] is None
+        assert metadata["boost_minutes_delta"] == 0
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_collect_boost_metadata_invalid_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        client, calls, _ = _setup_client(
+            monkeypatch, responses=[{"ok": True}, {"ok": True}]
+        )
+
+        async def bad_rtc(dev_id: str) -> dict[str, Any]:
+            return {"y": "bad"}
+
+        monkeypatch.setattr(client, "get_rtc_time", bad_rtc)
+
+        result = await client.set_node_settings("dev", ("acm", "9"), mode="auto")
+        assert len(calls) == 2
+        metadata = result["boost_state"]
+        assert metadata["boost_end"] is None
+        assert metadata["boost_minutes_delta"] == 0
+
+    asyncio.run(_run())
+
+
+@pytest.mark.asyncio
+async def test_ducaheat_set_acm_boost_state_non_dict_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    async def fake_headers() -> dict[str, str]:
+        return {"Authorization": "Bearer"}
+
+    async def fake_post(*args: Any, **kwargs: Any) -> Any:
+        return "ok"
+
+    rtc_mock = AsyncMock(return_value={"y": 2024, "n": 1, "d": 1, "h": 0, "m": 0, "s": 0})
+
+    monkeypatch.setattr(client, "_authed_headers", fake_headers)
+    monkeypatch.setattr(client, "_post_acm_endpoint", fake_post)
+    monkeypatch.setattr(client, "get_rtc_time", rtc_mock)
+
+    result = await client.set_acm_boost_state("dev", "5", boost=False)
+    assert result["response"] == "ok"
+    assert result["boost_state"]["boost_active"] is False
+    rtc_mock.assert_awaited_once_with("dev")
+
+
+def test_ducaheat_collect_boost_metadata_rtc_failure_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        client, calls, _ = _setup_client(
+            monkeypatch, responses=[{"ok": True}]
+        )
+
+        async def failing_rtc(dev_id: str) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(client, "get_rtc_time", failing_rtc)
+
+        result = await client.set_node_settings(
+            "dev", ("acm", "9"), mode="boost", boost_time=30
+        )
+        assert calls == [
+            (
+                "POST",
+                "/api/v2/devs/dev/acm/9/mode",
+                {
+                    "headers": {
+                        "Authorization": "Bearer token",
+                        "X-SerialId": "15",
+                        "User-Agent": get_brand_user_agent(BRAND_DUCAHEAT),
+                    },
+                    "json": {"mode": "boost", "boost_time": 30},
+                },
+            )
+        ]
+        metadata = result["boost_state"]
+        assert metadata["boost_end"] is None
+        assert metadata["boost_minutes_delta"] == 30
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_collect_boost_metadata_invalid_payload_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        client, calls, _ = _setup_client(
+            monkeypatch, responses=[{"ok": True}]
+        )
+
+        async def bad_rtc(dev_id: str) -> Any:
+            return "bad"
+
+        monkeypatch.setattr(client, "get_rtc_time", bad_rtc)
+
+        result = await client.set_node_settings(
+            "dev", ("acm", "9"), mode="boost", boost_time=30
+        )
+        assert calls == [
+            (
+                "POST",
+                "/api/v2/devs/dev/acm/9/mode",
+                {
+                    "headers": {
+                        "Authorization": "Bearer token",
+                        "X-SerialId": "15",
+                        "User-Agent": get_brand_user_agent(BRAND_DUCAHEAT),
+                    },
+                    "json": {"mode": "boost", "boost_time": 30},
+                },
+            )
+        ]
+        metadata = result["boost_state"]
+        assert metadata["boost_end"] is None
+        assert metadata["boost_minutes_delta"] == 30
+
+    asyncio.run(_run())
+
+
+def test_ducaheat_collect_boost_metadata_invalid_datetime_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        client, calls, _ = _setup_client(
+            monkeypatch, responses=[{"ok": True}]
+        )
+
+        async def bad_rtc(dev_id: str) -> dict[str, Any]:
+            return {"y": 2024, "n": 13, "d": 1, "h": 0, "m": 0, "s": 0}
+
+        monkeypatch.setattr(client, "get_rtc_time", bad_rtc)
+
+        result = await client.set_node_settings(
+            "dev", ("acm", "9"), mode="boost", boost_time=30
+        )
+        assert calls == [
+            (
+                "POST",
+                "/api/v2/devs/dev/acm/9/mode",
+                {
+                    "headers": {
+                        "Authorization": "Bearer token",
+                        "X-SerialId": "15",
+                        "User-Agent": get_brand_user_agent(BRAND_DUCAHEAT),
+                    },
+                    "json": {"mode": "boost", "boost_time": 30},
+                },
+            )
+        ]
+        metadata = result["boost_state"]
+        assert metadata["boost_end"] is None
+        assert metadata["boost_minutes_delta"] == 30
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow REST clients to surface unsupported boost duration errors on generic endpoints
- extend the Ducaheat accumulator writer to send boost duration payloads, cancel boost explicitly, and capture RTC metadata after writes
- propagate preferred boost minutes from the climate preset workflow and add extensive unit coverage for the new behaviours

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e4d9348af083299cd28bceac14881c