### PR TITLE
Refine accumulator boost preset handling

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -1088,23 +1088,14 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
 
         if value == "boost":
             self._boost_resume_mode = self.hvac_mode
-
-            def _apply(cur: dict[str, Any]) -> None:
-                cur["mode"] = "boost"
-
-            await self._commit_write(
-                log_context="Preset mode write",
-                write_kwargs={
-                    "mode": "boost",
-                    "boost_time": self._preferred_boost_minutes(),
-                },
-                apply_fn=_apply,
-                success_details={"preset_mode": "boost"},
+            await self.async_start_boost(
+                minutes=self._preferred_boost_minutes()
             )
             return
 
         resume_mode = self._boost_resume_mode or self.hvac_mode
         self._boost_resume_mode = None
+        await self.async_cancel_boost()
         await super().async_set_hvac_mode(resume_mode)
 
     @property  # type: ignore[override]


### PR DESCRIPTION
## Summary
- delegate accumulator boost preset toggles to the dedicated boost helpers so the optimistic cache update and fallback refresh are reused
- update the accumulator preset tests to assert helper invocation instead of direct writes

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e4fca4c8f08329b55a6ed7d7135865