### PR TITLE
Fix tests workflow to use uv virtualenv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,13 @@ jobs:
           enable-cache: true
 
       - name: Install Python requirement
-        run: uv python install
+        run: uv python install 3.13.2
+
+      - name: Create virtual environment
+        run: uv venv
 
       - name: Install project dependencies
-        run: uv pip install --system -e .[test]
+        run: uv pip install -e .[test]
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,18 @@ test = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["custom_components/termoweb"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "custom_components/termoweb",
+    "tests",
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+]
+
 
 [tool.ruff]
 required-version = ">=0.12.0"


### PR DESCRIPTION
## Summary
- install Python 3.13.2 for the tests workflow and install dependencies inside a uv-managed virtual environment
- configure hatch build targets so editable installs include the integration package

## Testing
- `timeout 30s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e4fec59f508329a2701e9aabd658ad