### PR TITLE
Document Ducaheat boost helper workflow

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -17,3 +17,29 @@ Key observations from traffic captures:
 - Boost (accumulators only), lock, and similar toggles are literal booleans; do not send quoted values.
 
 These semantics apply to both heater (`htr`) and accumulator (`acm`) nodes within the Ducaheat API.
+
+### Boost presets, helper services, and duration rules
+
+Accumulator boost defaults are stored under the `/setup` namespace as `extra_options.boost_time`
+and `extra_options.boost_temp`. The integration keeps an in-memory cache of these values so
+entity services can honour user-defined presets even when the REST payload omits a duration. When
+`termoweb.start_boost` is invoked without an explicit runtime the coordinator falls back to the
+cached preset, which in turn synchronises with the `select.termoweb_…_boost_duration` entity.
+
+Three Home Assistant services wrap the Ducaheat boost workflow:
+
+- `termoweb.configure_boost_preset` updates the default runtime and/or boost setpoint via
+  `/setup`. This service validates the payload and refuses to write unless at least one field is
+  present.
+- `termoweb.start_boost` issues a `/status` write with `boost: true` (and an optional
+  `boost_time`) and immediately applies optimistic state updates so Lovelace feedback remains
+  responsive while the REST call is in flight.
+- `termoweb.cancel_boost` performs the inverse `/status` write (`boost: false`) and clears cached
+  runtime metadata.
+
+Ducaheat limits boost sessions to **1–120 minutes**. Validation is enforced centrally:
+
+- The public services reject values outside this range and log `ERROR` messages for developer
+  diagnostics.
+- Button helpers and select entities derive their choices from the same validation logic so UI
+  affordances never generate invalid durations.


### PR DESCRIPTION
## Summary
- document how Ducaheat boost presets are cached, validated, and exposed through helper services
- expand the architecture guide with boost helper entities, flow diagrams, and a Lovelace usage example

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e5028edff88329b546c17699a81d1b