### PR TITLE
Limit ws_client __all__ exports to public API

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -211,51 +211,7 @@ class WebSocketClient(_WsLeaseMixin):
         return ""
 
 
-__all__ = [
-    "ACCEPT_LANGUAGE",
-    "API_BASE",
-    "BRAND_DUCAHEAT",
-    "BRAND_TERMOWEB",
-    "DOMAIN",
-    "DUCAHEAT_NAMESPACE",
-    "DucaheatWSClient",
-    "HandshakeError",
-    "HomeAssistant",
-    "RESTClient",
-    "USER_AGENT",
-    "WS_NAMESPACE",
-    "WSStats",
-    "WebSocketClient",
-    "_WSCommon",
-    "_WsLeaseMixin",
-    "addresses_by_node_type",
-    "aiohttp",
-    "async_dispatcher_send",
-    "asyncio",
-    "collect_heater_sample_addresses",
-    "ensure_node_inventory",
-    "get_brand_api_base",
-    "get_brand_requested_with",
-    "get_brand_user_agent",
-    "gzip",
-    "heater_sample_subscription_targets",
-    "json",
-    "logging",
-    "normalize_heater_addresses",
-    "normalize_node_addr",
-    "normalize_node_type",
-    "random",
-    "signal_ws_data",
-    "signal_ws_status",
-    "socketio",
-    "string",
-    "time",
-    "time_mod",
-    "TermoWebWSClient",
-    "urlencode",
-    "urlsplit",
-    "urlunsplit",
-]
+__all__ = ["DUCAHEAT_NAMESPACE", "HandshakeError", "WSStats", "WebSocketClient"]
 
 time_mod = time.monotonic
 


### PR DESCRIPTION
## Summary
- trim the ws_client __all__ definition to only expose the intended websocket client API symbols

## Testing
- pytest tests/test_ws_client.py tests/test_termoweb_ws_protocol.py tests/test_ducaheat_ws_protocol.py tests/test_backend_factory.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e514b51910832984d1aa448a7a1e56