### PR TITLE
Remove ws_impl argument from backend factory

### DIFF
--- a/custom_components/termoweb/backend/factory.py
+++ b/custom_components/termoweb/backend/factory.py
@@ -8,12 +8,9 @@ from .ducaheat import DucaheatBackend
 from .termoweb import TermoWebBackend
 
 
-def create_backend(
-    *, brand: str, client: HttpClientProto, ws_impl: str | None = None
-) -> Backend:
+def create_backend(*, brand: str, client: HttpClientProto) -> Backend:
     """Create a backend for the given brand."""
 
-    _ = ws_impl  # reserved for future websocket selection overrides
     if brand == BRAND_DUCAHEAT:
         return DucaheatBackend(brand=brand, client=client)
     return TermoWebBackend(brand=brand, client=client)

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -1,5 +1,12 @@
 # Developer notes
 
+## Backend factory API change
+
+The `create_backend` helper in `custom_components.termoweb.backend.factory` no longer accepts a
+`ws_impl` keyword argument. Custom tooling that previously passed this placeholder parameter must
+drop it and rely on the default websocket implementation that ships with the integration. Future
+overrides, if needed, will be exposed through a different configuration surface.
+
 ## Ducaheat accumulator write semantics
 
 Ducaheat accumulators (and heaters served by the same backend) do not expose a monolithic


### PR DESCRIPTION
## Summary
- drop the unused ws_impl keyword from the backend factory helper
- document the breaking change for any external tooling that depended on the placeholder argument

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e521451f248329a251fef20aa61c54