### PR TITLE
Simplify TermoWeb backend websocket resolution

### DIFF
--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -269,6 +269,12 @@ async def _load_module(
 
     monkeypatch.setattr(ws_module, "TermoWebWSClient", _FakeWSClient)
     monkeypatch.setattr(termoweb_ws_module, "TermoWebWSClient", _FakeWSClient)
+    backend_module = importlib.import_module(
+        "custom_components.termoweb.backend.termoweb"
+    )
+    monkeypatch.setattr(
+        backend_module, "TermoWebWSClient", _FakeWSClient, raising=False
+    )
 
     energy_module = importlib.reload(
         importlib.import_module("custom_components.termoweb.energy")

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -144,6 +144,12 @@ def termoweb_init(monkeypatch: pytest.MonkeyPatch) -> Any:
     )
     monkeypatch.setattr(ws_module, "TermoWebWSClient", FakeWSClient)
     monkeypatch.setattr(ws_client_module, "TermoWebWSClient", FakeWSClient, raising=False)
+    backend_module = importlib.import_module(
+        "custom_components.termoweb.backend.termoweb"
+    )
+    monkeypatch.setattr(
+        backend_module, "TermoWebWSClient", FakeWSClient, raising=False
+    )
     module._test_helpers = SimpleNamespace(
         fake_coordinator=FakeCoordinator,
         get_record=lambda hass, entry: hass.data[module.DOMAIN][entry.entry_id],
@@ -892,6 +898,12 @@ def test_coordinator_listener_starts_new_ws(
     )
     monkeypatch.setattr(ws_module, "TermoWebWSClient", SlowWSClient)
     monkeypatch.setattr(ws_client_module, "TermoWebWSClient", SlowWSClient, raising=False)
+    backend_module = importlib.import_module(
+        "custom_components.termoweb.backend.termoweb"
+    )
+    monkeypatch.setattr(
+        backend_module, "TermoWebWSClient", SlowWSClient, raising=False
+    )
     entry = ConfigEntry("listener", data={"username": "user", "password": "pw"})
     stub_hass.config_entries.add(entry)
 


### PR DESCRIPTION
## Summary
- load the TermoWeb websocket client directly with a fallback to the legacy WebSocketClient when the module is unavailable
- refresh backend factory coverage to exercise the direct import, ImportError fallback, and non-type guard
- update higher-level backend tests to patch the new TermoWeb client hook when swapping in fake websocket implementations

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e5246b2e988329889eab83b2a53cd7