### PR TITLE
Refactor boost helper metadata for TermoWeb platforms

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -21,6 +21,7 @@ from .heater import (
     iter_heater_nodes,
     log_skipped_nodes,
     prepare_heater_platform_data,
+    supports_boost,
 )
 from .utils import build_gateway_device_info
 
@@ -43,16 +44,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for node_type, node, addr_str, base_name in iter_heater_nodes(
         nodes_by_type, resolve_name
     ):
-        supports_boost = getattr(node, "supports_boost", None)
-        supported = False
-        if callable(supports_boost):
-            try:
-                supported = bool(supports_boost())
-            except Exception:  # pragma: no cover - defensive
-                supported = False
-        elif isinstance(supports_boost, bool):
-            supported = supports_boost
-        if not supported:
+        if not supports_boost(node):
             continue
         unique_id = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:boost_active"
         boost_entities.append(

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -32,8 +32,28 @@ _LOGGER = logging.getLogger(__name__)
 
 
 _BOOST_RUNTIME_KEY: Final = "boost_runtime"
-BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = (30, 60, 120)
 DEFAULT_BOOST_DURATION: Final = 60
+
+
+@dataclass(frozen=True, slots=True)
+class BoostButtonMetadata:
+    """Metadata describing an accumulator boost helper button."""
+
+    minutes: int | None
+    unique_suffix: str
+    label: str
+    icon: str
+
+
+BOOST_BUTTON_METADATA: Final[tuple[BoostButtonMetadata, ...]] = (
+    BoostButtonMetadata(30, "30", "Boost 30 minutes", "mdi:timer-play"),
+    BoostButtonMetadata(60, "60", "Boost 60 minutes", "mdi:timer-play"),
+    BoostButtonMetadata(120, "120", "Boost 120 minutes", "mdi:timer-play"),
+    BoostButtonMetadata(None, "cancel", "Cancel boost", "mdi:timer-off"),
+)
+BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = tuple(
+    option.minutes for option in BOOST_BUTTON_METADATA if option.minutes is not None
+)
 
 
 def _coerce_boost_remaining_minutes(value: Any) -> int | None:
@@ -182,6 +202,12 @@ def resolve_boost_runtime_minutes(
     if stored is not None:
         return stored
     return default
+
+
+def iter_boost_button_metadata() -> Iterator[BoostButtonMetadata]:
+    """Yield the metadata describing boost helper buttons."""
+
+    yield from BOOST_BUTTON_METADATA
 
 
 def supports_boost(node: Any) -> bool:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -15,6 +15,7 @@ from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.heater import (
     DEFAULT_BOOST_DURATION,
     get_boost_runtime_minutes,
+    iter_boost_button_metadata,
     set_boost_runtime_minutes,
 )
 from homeassistant.core import HomeAssistant
@@ -82,6 +83,13 @@ def test_select_setup_and_selection(monkeypatch: pytest.MonkeyPatch) -> None:
         entity = added[0]
         assert isinstance(entity, AccumulatorBoostDurationSelect)
         assert entity.unique_id == f"{DOMAIN}:{dev_id}:acm:{node.addr}:boost_duration"
+        expected_options = [
+            str(item.minutes)
+            for item in iter_boost_button_metadata()
+            if item.minutes is not None
+        ]
+        options = getattr(entity, "options", getattr(entity, "_attr_options", []))
+        assert options == expected_options
 
         await entity.async_added_to_hass()
         assert entity.async_write_ha_state.called


### PR DESCRIPTION
## Summary
- add shared `BoostButtonMetadata` definitions and iterator helpers so boost controls expose a single source of truth
- refactor button and binary_sensor platforms to build boost helpers from the shared metadata and helper logic
- update select and platform tests to validate behaviour through the common metadata and `supports_boost` helper

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/heater.py custom_components/termoweb/button.py custom_components/termoweb/binary_sensor.py tests/test_binary_sensor_button.py tests/test_select.py *(reports pre-existing warnings in heater helpers)*


------
https://chatgpt.com/codex/tasks/task_e_68e53e6030cc8329b9a37906f45bf33e