### PR TITLE
Refactor boost parsing and heater inventory helpers

### DIFF
--- a/custom_components/termoweb/boost.py
+++ b/custom_components/termoweb/boost.py
@@ -1,0 +1,158 @@
+"""Helpers for parsing boost metadata shared across TermoWeb modules."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import math
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+
+def coerce_int(value: Any) -> int | None:
+    """Return ``value`` as ``int`` when possible, else ``None``."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            return None
+        return int(value)
+    try:
+        candidate = str(value).strip()
+    except Exception:  # noqa: BLE001 - defensive
+        return None
+    if not candidate:
+        return None
+    try:
+        return int(float(candidate))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+def coerce_boost_bool(value: Any) -> bool | None:
+    """Return ``value`` as a boolean when possible."""
+
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    try:
+        text = str(value).strip().lower()
+    except Exception:  # noqa: BLE001 - defensive
+        return None
+    if text in {"true", "1", "yes", "on"}:
+        return True
+    if text in {"false", "0", "no", "off"}:
+        return False
+    return None
+
+
+def coerce_boost_minutes(value: Any) -> int | None:
+    """Return ``value`` as positive minutes when possible."""
+
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        if isinstance(value, (int, float)):
+            minutes = int(value)
+        else:
+            text = str(value).strip()
+            if not text:
+                return None
+            minutes = int(float(text))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+    return minutes if minutes > 0 else None
+
+
+def coerce_boost_remaining_minutes(value: Any) -> int | None:
+    """Return ``value`` as a positive integer minute count when possible."""
+
+    if value is None or isinstance(value, bool):
+        return None
+
+    candidate: int | None
+    try:
+        if isinstance(value, (int, float)):
+            candidate = int(value)
+        else:
+            text = str(value).strip()
+            if not text:
+                return None
+            candidate = int(float(text))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+    if candidate is None or candidate <= 0:
+        return None
+
+    return candidate
+
+
+def resolve_boost_end_from_fields(
+    boost_end_day: Any,
+    boost_end_min: Any,
+    *,
+    now: datetime | None = None,
+) -> tuple[datetime | None, int | None]:
+    """Translate boost end ``day``/``minute`` fields into a timestamp."""
+
+    day = coerce_int(boost_end_day)
+    minute = coerce_int(boost_end_min)
+    if day is None or minute is None or minute < 0:
+        return None, None
+
+    now_dt = now or dt_util.now()
+    tzinfo = now_dt.tzinfo or getattr(dt_util, "UTC", UTC)
+
+    candidates: list[datetime] = []
+
+    if 0 < day <= 400:
+        for year_offset in (-1, 0, 1):
+            year = now_dt.year + year_offset
+            try:
+                start = datetime(year, 1, 1, tzinfo=tzinfo)
+            except ValueError:  # pragma: no cover - defensive
+                continue
+            candidate = start + timedelta(days=day - 1, minutes=minute)
+            candidates.append(candidate)
+
+    if day >= 0:
+        epoch_timezone = getattr(dt_util, "UTC", UTC)
+        epoch_candidate = datetime(1970, 1, 1, tzinfo=epoch_timezone) + timedelta(
+            days=day,
+            minutes=minute,
+        )
+        candidates.append(epoch_candidate.astimezone(tzinfo))
+
+    if not candidates:
+        return None, None
+
+    window = 7 * 24 * 3600
+    filtered = [
+        candidate
+        for candidate in candidates
+        if abs((candidate - now_dt).total_seconds()) <= window
+    ]
+    if filtered:
+        candidates = filtered
+
+    def _candidate_key(candidate: datetime) -> tuple[int, float]:
+        delta_seconds = (candidate - now_dt).total_seconds()
+        is_future = 0 if delta_seconds >= 0 else 1
+        return is_future, abs(delta_seconds)
+
+    selected = min(candidates, key=_candidate_key)
+    delta_seconds = (selected - now_dt).total_seconds()
+    minutes_remaining = int(max(0.0, delta_seconds) // 60)
+
+    return selected, minutes_remaining
+

--- a/custom_components/termoweb/heater_inventory.py
+++ b/custom_components/termoweb/heater_inventory.py
@@ -1,0 +1,67 @@
+"""Shared helpers for deriving heater inventory metadata."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .nodes import (
+    HEATER_NODE_TYPES,
+    Node,
+    build_heater_address_map,
+    normalize_node_addr,
+    normalize_node_type,
+)
+
+
+@dataclass(slots=True)
+class HeaterInventoryDetails:
+    """Describe cached metadata derived from heater nodes."""
+
+    nodes_by_type: dict[str, list[Node]]
+    explicit_name_pairs: set[tuple[str, str]]
+    address_map: dict[str, list[str]]
+    reverse_address_map: dict[str, set[str]]
+
+
+def build_heater_inventory_details(
+    nodes: Iterable[Node],
+) -> HeaterInventoryDetails:
+    """Return derived heater metadata for ``nodes``."""
+
+    inventory = list(nodes)
+
+    nodes_by_type: dict[str, list[Node]] = defaultdict(list)
+    explicit_names: set[tuple[str, str]] = set()
+
+    for node in inventory:
+        node_type = normalize_node_type(getattr(node, "type", ""))
+        if not node_type:
+            continue
+        nodes_by_type[node_type].append(node)
+        addr = normalize_node_addr(getattr(node, "addr", ""))
+        if addr and getattr(node, "name", "").strip():
+            explicit_names.add((node_type, addr))
+
+    forward, reverse = build_heater_address_map(inventory)
+
+    filtered_forward = {
+        node_type: list(addresses)
+        for node_type, addresses in forward.items()
+        if node_type in HEATER_NODE_TYPES and addresses
+    }
+
+    filtered_reverse = {
+        addr: set(node_types)
+        for addr, node_types in reverse.items()
+        if node_types
+    }
+
+    return HeaterInventoryDetails(
+        nodes_by_type={k: list(v) for k, v in nodes_by_type.items()},
+        explicit_name_pairs=explicit_names,
+        address_map=filtered_forward,
+        reverse_address_map=filtered_reverse,
+    )
+

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -2,18 +2,15 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
+from .heater_inventory import HeaterInventoryDetails, build_heater_inventory_details
 from .nodes import (
     Node,
-    build_heater_address_map,
     build_node_inventory,
     heater_sample_subscription_targets,
     normalize_heater_addresses,
-    normalize_node_addr,
-    normalize_node_type,
 )
 
 
@@ -23,13 +20,10 @@ class InstallationSnapshot:
     __slots__ = (
         "_compat_aliases",
         "_dev_id",
-        "_explicit_name_pairs",
-        "_heater_address_map",
-        "_heater_address_reverse",
+        "_heater_details",
         "_inventory",
         "_name_map_cache",
         "_name_map_factories",
-        "_nodes_by_type",
         "_raw_nodes",
         "_sample_address_map",
         "_sample_targets",
@@ -47,10 +41,7 @@ class InstallationSnapshot:
         self._dev_id = str(dev_id)
         self._raw_nodes = raw_nodes
         self._inventory = list(node_inventory) if node_inventory is not None else None
-        self._nodes_by_type: dict[str, list[Node]] | None = None
-        self._explicit_name_pairs: set[tuple[str, str]] | None = None
-        self._heater_address_map: dict[str, list[str]] | None = None
-        self._heater_address_reverse: dict[str, set[str]] | None = None
+        self._heater_details: HeaterInventoryDetails | None = None
         self._sample_address_map: dict[str, list[str]] | None = None
         self._compat_aliases: dict[str, str] | None = None
         self._sample_targets: list[tuple[str, str]] | None = None
@@ -81,10 +72,7 @@ class InstallationSnapshot:
     def _invalidate_caches(self) -> None:
         """Reset derived cache state so it can be lazily recomputed."""
 
-        self._nodes_by_type = None
-        self._explicit_name_pairs = None
-        self._heater_address_map = None
-        self._heater_address_reverse = None
+        self._heater_details = None
         self._sample_address_map = None
         self._compat_aliases = None
         self._sample_targets = None
@@ -104,62 +92,34 @@ class InstallationSnapshot:
 
         return self._ensure_inventory()
 
-    def _ensure_nodes_by_type(self) -> None:
-        """Populate caches describing heater nodes by type."""
+    def _ensure_heater_details(self) -> HeaterInventoryDetails:
+        """Return cached heater metadata derived from the inventory."""
 
-        if self._nodes_by_type is not None:
-            return
-
-        nodes_by_type: dict[str, list[Node]] = defaultdict(list)
-        explicit_names: set[tuple[str, str]] = set()
-        for node in self._ensure_inventory():
-            node_type = normalize_node_type(getattr(node, "type", ""))
-            if not node_type:
-                continue
-            nodes_by_type[node_type].append(node)
-            addr = normalize_node_addr(getattr(node, "addr", ""))
-            if addr and getattr(node, "name", "").strip():
-                explicit_names.add((node_type, addr))
-
-        self._nodes_by_type = {k: list(v) for k, v in nodes_by_type.items()}
-        self._explicit_name_pairs = explicit_names
+        if self._heater_details is None:
+            self._heater_details = build_heater_inventory_details(self._ensure_inventory())
+        return self._heater_details
 
     @property
     def nodes_by_type(self) -> dict[str, list[Node]]:
         """Return a mapping of node type to ``Node`` instances."""
 
-        self._ensure_nodes_by_type()
-        return dict(self._nodes_by_type or {})
+        details = self._ensure_heater_details()
+        return {k: list(v) for k, v in details.nodes_by_type.items()}
 
     @property
     def explicit_heater_names(self) -> set[tuple[str, str]]:
         """Return node type/address pairs with explicit names."""
 
-        self._ensure_nodes_by_type()
-        return set(self._explicit_name_pairs or set())
-
-    def _ensure_address_maps(self) -> None:
-        """Populate cached heater address maps from the inventory."""
-
-        if self._heater_address_map is not None:
-            return
-
-        forward, reverse = build_heater_address_map(self._ensure_inventory())
-        self._heater_address_map = {k: list(v) for k, v in forward.items()}
-        self._heater_address_reverse = {
-            addr: set(node_types) for addr, node_types in reverse.items()
-        }
+        details = self._ensure_heater_details()
+        return set(details.explicit_name_pairs)
 
     @property
     def heater_address_map(self) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
         """Return forward and reverse heater address maps."""
 
-        self._ensure_address_maps()
-        forward = {k: list(v) for k, v in (self._heater_address_map or {}).items()}
-        reverse = {
-            addr: set(types)
-            for addr, types in (self._heater_address_reverse or {}).items()
-        }
+        details = self._ensure_heater_details()
+        forward = {k: list(v) for k, v in details.address_map.items()}
+        reverse = {addr: set(types) for addr, types in details.reverse_address_map.items()}
         return forward, reverse
 
     def _ensure_sample_addresses(self) -> None:
@@ -168,8 +128,8 @@ class InstallationSnapshot:
         if self._sample_address_map is not None:
             return
 
-        forward, _ = self.heater_address_map
-        normalized_map, compat = normalize_heater_addresses(forward)
+        forward_map, _ = self.heater_address_map
+        normalized_map, compat = normalize_heater_addresses(forward_map)
         self._sample_address_map = {
             node_type: list(addrs) for node_type, addrs in normalized_map.items()
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1216,9 +1216,7 @@ class FakeCoordinator:
     ) -> tuple[dt.datetime | None, int | None]:
         """Mirror coordinator helper for translating boost end fields."""
 
-        from custom_components.termoweb.coordinator import (
-            resolve_boost_end_from_fields,
-        )
+        from custom_components.termoweb.boost import resolve_boost_end_from_fields
 
         return resolve_boost_end_from_fields(
             boost_end_day,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,25 +11,25 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.termoweb import coordinator as coord_module
+from custom_components.termoweb import boost as boost_module, coordinator as coord_module
 from custom_components.termoweb.nodes import AccumulatorNode, HeaterNode
 
 
 def test_coerce_int_variants() -> None:
-    """_coerce_int should normalise primitives and guard against errors."""
+    """``coerce_int`` should normalise primitives and guard against errors."""
 
     class BadString:
         def __str__(self) -> str:
             raise RuntimeError("boom")
 
-    assert coord_module._coerce_int(None) is None
-    assert coord_module._coerce_int(True) == 1
-    assert coord_module._coerce_int(False) == 0
-    assert coord_module._coerce_int(5.7) == 5
-    assert coord_module._coerce_int(float("inf")) is None
-    assert coord_module._coerce_int(BadString()) is None
-    assert coord_module._coerce_int("   ") is None
-    assert coord_module._coerce_int(" 7.2 ") == 7
+    assert boost_module.coerce_int(None) is None
+    assert boost_module.coerce_int(True) == 1
+    assert boost_module.coerce_int(False) == 0
+    assert boost_module.coerce_int(5.7) == 5
+    assert boost_module.coerce_int(float("inf")) is None
+    assert boost_module.coerce_int(BadString()) is None
+    assert boost_module.coerce_int("   ") is None
+    assert boost_module.coerce_int(" 7.2 ") == 7
 
 
 def test_resolve_boost_end_from_fields_variants() -> None:
@@ -37,13 +37,13 @@ def test_resolve_boost_end_from_fields_variants() -> None:
 
     base_now = dt.datetime(2024, 1, 1, 0, 0, tzinfo=dt.timezone.utc)
 
-    dt_value, minutes = coord_module.resolve_boost_end_from_fields(None, 10)
+    dt_value, minutes = boost_module.resolve_boost_end_from_fields(None, 10)
     assert dt_value is None and minutes is None
 
-    dt_value, minutes = coord_module.resolve_boost_end_from_fields(-5, 10, now=base_now)
+    dt_value, minutes = boost_module.resolve_boost_end_from_fields(-5, 10, now=base_now)
     assert dt_value is None and minutes is None
 
-    dt_value, minutes = coord_module.resolve_boost_end_from_fields(2, 60, now=base_now)
+    dt_value, minutes = boost_module.resolve_boost_end_from_fields(2, 60, now=base_now)
     assert isinstance(dt_value, dt.datetime)
     assert minutes == 1500
 

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -14,9 +14,9 @@ _install_stubs()
 from custom_components.termoweb import heater as heater_module
 from custom_components.termoweb import installation as installation_module
 from custom_components.termoweb.installation import InstallationSnapshot
+from custom_components.termoweb.heater_inventory import build_heater_inventory_details
 from custom_components.termoweb.nodes import (
     HeaterNode,
-    build_heater_address_map,
     build_node_inventory,
 )
 from homeassistant.core import HomeAssistant
@@ -67,7 +67,9 @@ def test_prepare_heater_platform_data_groups_nodes() -> None:
     assert [node.addr for node in acm_nodes] == ["2", "2"]
     assert addrs_by_type["acm"] == ["2"]
     assert len(addrs_by_type["acm"]) == len(set(addrs_by_type["acm"]))
-    helper_map, helper_reverse = build_heater_address_map(inventory)
+    details = build_heater_inventory_details(inventory)
+    helper_map = details.address_map
+    helper_reverse = details.reverse_address_map
     assert addrs_by_type == {
         node_type: helper_map.get(node_type, [])
         for node_type in heater_module.HEATER_NODE_TYPES
@@ -122,7 +124,8 @@ def test_prepare_heater_platform_data_skips_blank_types(
 
     assert [node.addr for node in nodes_by_type.get("htr", [])] == ["6"]
     assert addrs_by_type["htr"] == ["6"]
-    helper_map, _ = build_heater_address_map(inventory)
+    details = build_heater_inventory_details(inventory)
+    helper_map = details.address_map
     assert helper_map == {"htr": ["6"]}
 
 

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -11,7 +11,7 @@ from conftest import _install_stubs, make_ws_payload
 
 _install_stubs()
 
-from custom_components.termoweb import heater as heater_module
+from custom_components.termoweb import boost as boost_module, heater as heater_module
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.binary_sensor import HeaterBoostActiveBinarySensor
 from custom_components.termoweb.sensor import (
@@ -334,7 +334,7 @@ def test_boost_entities_handle_missing_data() -> None:
 def test_coerce_boost_minutes_edge_cases() -> None:
     """Exercise defensive conversions for boost duration inputs."""
 
-    coerce = heater_module._coerce_boost_minutes
+    coerce = boost_module.coerce_boost_minutes
     assert coerce(None) is None
     assert coerce(True) is None
     assert coerce(0) is None
@@ -344,14 +344,14 @@ def test_coerce_boost_minutes_edge_cases() -> None:
     assert coerce("90") == 90
     assert coerce(120.7) == 120
 
-    remaining = heater_module._coerce_boost_remaining_minutes
+    remaining = boost_module.coerce_boost_remaining_minutes
     assert remaining(0) is None
 
 
 def test_coerce_boost_remaining_minutes_filters_non_positive() -> None:
     """Ensure remaining minute coercion rejects falsey and negative values."""
 
-    coerce = heater_module._coerce_boost_remaining_minutes
+    coerce = boost_module.coerce_boost_remaining_minutes
     assert coerce(None) is None
     assert coerce(False) is None
     assert coerce(0) is None
@@ -363,7 +363,7 @@ def test_coerce_boost_remaining_minutes_filters_non_positive() -> None:
 def test_coerce_boost_remaining_minutes_non_positive() -> None:
     """Ensure boost remaining coercion rejects non-positive values."""
 
-    coerce = heater_module._coerce_boost_remaining_minutes
+    coerce = boost_module.coerce_boost_remaining_minutes
     assert coerce(None) is None
     assert coerce(False) is None
     assert coerce(0) is None

--- a/tests/test_installation_snapshot.py
+++ b/tests/test_installation_snapshot.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from custom_components.termoweb.installation import InstallationSnapshot, ensure_snapshot
+from custom_components.termoweb.heater_inventory import build_heater_inventory_details
 from custom_components.termoweb.nodes import (
     build_node_inventory,
     heater_sample_subscription_targets,
@@ -36,6 +37,14 @@ def test_snapshot_properties_and_inventory_cache() -> None:
     assert snapshot.dev_id == "dev"
     assert snapshot.raw_nodes == {"nodes": nodes}
     assert [node.addr for node in snapshot.inventory] == ["1"]
+
+    details = build_heater_inventory_details(snapshot.inventory)
+    assert snapshot.nodes_by_type == details.nodes_by_type
+    assert snapshot.explicit_heater_names == details.explicit_name_pairs
+    assert snapshot.heater_address_map == (
+        details.address_map,
+        details.reverse_address_map,
+    )
 
 
 def test_snapshot_sample_targets_and_name_map_caching() -> None:


### PR DESCRIPTION
## Summary
- extract shared boost parsing helpers into a new `boost` module consumed by the coordinator and heater logic
- add a reusable heater inventory helper to feed both `prepare_heater_platform_data` and `InstallationSnapshot`
- update coordinator, heater, and installation tests to validate the shared helpers rather than duplicating cases

## Testing
- `ruff check custom_components/termoweb/boost.py custom_components/termoweb/heater.py custom_components/termoweb/coordinator.py custom_components/termoweb/heater_inventory.py custom_components/termoweb/installation.py tests/test_coordinator.py tests/test_heater_entities.py tests/test_heater_base.py tests/test_installation_snapshot.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` *(fails: existing import errors in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e5425ea8bc83298d9157f33f361e41