### PR TITLE
refactor: share heater test fixtures

### DIFF
--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-
 from typing import Any
 
 import pytest
@@ -66,12 +65,18 @@ def test_heater_node_base_payload_matching_normalizes_address(
     assert calls == [(" 01 ", {}), (" 01 ", {}), ("02", {}), ("  ", {})]
 
 
-def test_boost_runtime_storage_roundtrip() -> None:
+def test_boost_runtime_storage_roundtrip(heater_hass_data) -> None:
     """Ensure boost runtime helpers normalise addresses and defaults."""
 
     hass = HomeAssistant()
     entry_id = "entry-store"
-    hass.data = {DOMAIN: {entry_id: {}}}
+    heater_hass_data(
+        hass,
+        entry_id,
+        "dev-store",
+        SimpleNamespace(),
+        boost_runtime={},
+    )
 
     assert heater_module.get_boost_runtime_minutes(hass, entry_id, "acm", "01") is None
 


### PR DESCRIPTION
## Summary
- add reusable heater node, runtime store, and hass data fixtures to tests/conftest.py
- update binary sensor button, select, and heater entity tests to use the shared helpers and clean assertions

## Testing
- pytest tests/test_binary_sensor_button.py tests/test_select.py tests/test_heater_entities.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: upstream suite requires Home Assistant helpers not available in stub environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e554d1dc3c832991929b5b06be7b14