### PR TITLE
Handle Ducaheat boost cancellation in ACM settings

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -475,6 +475,7 @@ class RESTClient:
         | None = None,  # preset temperatures [cold, night, day] (in current units)
         units: str = "C",
         boost_time: int | None = None,
+        cancel_boost: bool = False,
     ) -> Any:
         """Update heater settings.
 
@@ -491,6 +492,9 @@ class RESTClient:
           [cold, night, day]. These values are formatted to one decimal and sent as strings.
         * ``units`` – either ``"C"`` or ``"F"``. This field is always included and indicates
           whether the numeric temperature values are in Celsius or Fahrenheit.
+        * ``cancel_boost`` – When ``True`` the Ducaheat accumulator adapter will cancel any
+          active boost session before applying the update. The base REST client does not
+          implement this behaviour and therefore rejects ``True``.
 
         The payload will only include keys for the parameters passed by the caller, to avoid
         overwriting unrelated settings on the device.
@@ -498,6 +502,8 @@ class RESTClient:
 
         if boost_time is not None:
             raise ValueError("boost_time is not supported for this node type")
+        if cancel_boost:
+            raise ValueError("cancel_boost is not supported for this node type")
 
         node_type, addr = self._resolve_node_descriptor(node)
 

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -31,6 +31,7 @@ class HttpClientProto(Protocol):
         ptemp: list[float] | None = None,
         units: str = "C",
         boost_time: int | None = None,
+        cancel_boost: bool = False,
     ) -> Any:
         """Update node settings for the specified node."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1919,6 +1919,7 @@ def test_ducaheat_set_acm_settings_segmented(monkeypatch) -> None:
             prog=prog_list,
             ptemp=ptemp_list,
             units="f",
+            cancel_boost=True,
         )
 
         assert set(result) == {"status", "prog", "prog_temps", "boost_state"}
@@ -2116,7 +2117,9 @@ def test_ducaheat_set_acm_settings_mode_only(monkeypatch) -> None:
         )
         monkeypatch.setattr(client, "get_rtc_time", rtc_mock)
 
-        result = await client.set_node_settings("dev", ("acm", "3"), mode="auto")
+        result = await client.set_node_settings(
+            "dev", ("acm", "3"), mode="auto", cancel_boost=True
+        )
         assert set(result) == {"status", "mode", "boost_state"}
         status_call, mode_call = session.request_calls
         assert status_call[1] == "https://api.termoweb.fake/api/v2/devs/dev/acm/3/status"

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -176,7 +176,14 @@ async def test_ducaheat_rest_set_node_settings_routes_non_special(
     assert captured["args"] == (
         "dev",
         ("pmo", "4"),
-        {"mode": "auto", "stemp": 20.5, "prog": None, "ptemp": None, "units": "C"},
+        {
+            "mode": "auto",
+            "stemp": 20.5,
+            "prog": None,
+            "ptemp": None,
+            "units": "C",
+            "cancel_boost": False,
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- propagate the boost-active flag from the accumulator climate entity to Ducaheat writes so cancellation requests are only sent when needed
- extend the Ducaheat REST client surface with an optional `cancel_boost` switch and gate the `/status` write inside `_set_acm_settings`
- update the ACM write tests to cover both boost cancellation and no-boost scenarios

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` *(fails: ImportError: cannot import name 'default_samples_rate_limit_state' from 'custom_components.termoweb.energy')*

------
https://chatgpt.com/codex/tasks/task_e_68e55b00d1708329aab0913fdf2996a2