### PR TITLE
Align HomeAssistant test stubs with frame setup

### DIFF
--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -13,6 +13,7 @@ import aiohttp
 import pytest
 
 from custom_components.termoweb.backend import ducaheat_ws
+from homeassistant.core import HomeAssistant
 
 
 class DummyREST:
@@ -113,13 +114,10 @@ class StubSession:
 def _make_client(monkeypatch: pytest.MonkeyPatch) -> ducaheat_ws.DucaheatWSClient:
     """Create a websocket client with deterministic helpers."""
 
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
     ws = StubWebSocket()
     session = StubSession(ws)
-    hass = SimpleNamespace(loop=loop, data={ducaheat_ws.DOMAIN: {"entry": {}}})
+    hass = HomeAssistant()
+    hass.data.setdefault(ducaheat_ws.DOMAIN, {})["entry"] = {}
     client = ducaheat_ws.DucaheatWSClient(
         hass,
         entry_id="entry",


### PR DESCRIPTION
## Summary
- load the homeassistant.helpers.frame module during stub installation and initialise it for each HomeAssistant test instance
- extend the HomeAssistant stub with loop bookkeeping, integration storage, and verify_event_loop_thread compatibility
- update websocket protocol tests to rely on the richer HomeAssistant stub so production code can access loop helpers

## Testing
- pytest tests/test_ducaheat_ws_protocol.py tests/test_termoweb_ws_protocol.py

------
https://chatgpt.com/codex/tasks/task_e_68e5617901488329b7addcd3c812c6c5