### PR TITLE
Fix coordinator refresh errors and stub compatibility

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -37,6 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _BOOST_RUNTIME_KEY: Final = "boost_runtime"
 DEFAULT_BOOST_DURATION: Final = 60
+_HASS_UNSET = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -870,19 +871,19 @@ class HeaterNodeBase(CoordinatorEntity):
     def _hass_for_runtime(self) -> Any:
         """Return the best-effort Home Assistant instance for runtime access."""
 
-        hass = self.hass
-        if hass is not None:
-            return hass
+        hass_attr = getattr(self, "_hass", _HASS_UNSET)
+        if hass_attr is not _HASS_UNSET:
+            return hass_attr
         return getattr(self.coordinator, "hass", None)
 
     @property  # type: ignore[override]
     def hass(self) -> Any:
         """Return the Home Assistant instance, falling back to the coordinator."""
 
-        hass = getattr(self, "_hass", None)
-        if hass is not None:
-            return hass
-        return getattr(self.coordinator, "hass", None)
+        hass_attr = getattr(self, "_hass", _HASS_UNSET)
+        if hass_attr is _HASS_UNSET:
+            return getattr(self.coordinator, "hass", None)
+        return hass_attr
 
     @hass.setter  # type: ignore[override]
     def hass(self, value: Any) -> None:

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -8,9 +8,16 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.loader import async_get_integration
 
 from .const import DOMAIN
+
+
+async def async_get_integration(*args, **kwargs):
+    """Proxy ``homeassistant.loader.async_get_integration`` for monkeypatching."""
+
+    from homeassistant.loader import async_get_integration as loader_async_get_integration
+
+    return await loader_async_get_integration(*args, **kwargs)
 
 
 async def async_get_integration_version(hass: HomeAssistant) -> str:


### PR DESCRIPTION
## Summary
- propagate UpdateFailed exceptions during manual refreshes and guard coordinator loggers for stubbed environments
- ensure heater entities respect explicit hass removal flags
- provide dynamic integration lookup and fuller HomeAssistant stubs for executor jobs, hass jobs, and data caches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e56dcee1d48329ad39adc67f9e93d1