### PR TITLE
Add diagnostics helper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ logger:
     custom_components.termoweb: debug
 ```
 
+### Diagnostics export
+
+You can now download an anonymised diagnostics bundle from **Settings → Devices & Services → TermoWeb → ⋮ → Download diagnostics**. Share this file with the maintainers when you open a support issue so we can understand your setup without exposing passwords or device identifiers.
+
 ---
 
 ## Tips

--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -1,0 +1,96 @@
+"""Diagnostics support for the TermoWeb integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import platform
+from typing import Any, Final
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_BRAND, DEFAULT_BRAND, DOMAIN, get_brand_label
+from .installation import ensure_snapshot
+from .nodes import Node, ensure_node_inventory
+from .utils import async_get_integration_version
+
+SENSITIVE_FIELDS: Final = {
+    "access_token",
+    "authorization",
+    "client_secret",
+    "dev_id",
+    "password",
+    "refresh_token",
+    "token",
+    "username",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Mapping[str, Any]:
+    """Return a diagnostics payload for ``entry``."""
+
+    domain_data = hass.data.get(DOMAIN)
+    record: Mapping[str, Any] | None = None
+    if isinstance(domain_data, Mapping):
+        candidate = domain_data.get(entry.entry_id)
+        if isinstance(candidate, Mapping):
+            record = candidate
+
+    snapshot = ensure_snapshot(record or {})
+    if snapshot is not None:
+        inventory_source = list(snapshot.inventory)
+    elif record is not None:
+        inventory_source = ensure_node_inventory(record)
+    else:
+        inventory_source = []
+
+    node_inventory: list[dict[str, Any]] = [
+        node.as_dict() for node in inventory_source if isinstance(node, Node)
+    ]
+    node_inventory.sort(key=lambda item: (str(item.get("addr", "")), str(item.get("type", ""))))
+
+    version = record.get("version") if isinstance(record, Mapping) else None
+    if version is None:
+        version = await async_get_integration_version(hass)
+    version_str = str(version)
+
+    brand_value: str | None = None
+    if isinstance(record, Mapping):
+        candidate_brand = record.get("brand")
+        if isinstance(candidate_brand, str) and candidate_brand.strip():
+            brand_value = candidate_brand.strip()
+    if not brand_value:
+        entry_brand = entry.data.get(CONF_BRAND)
+        if isinstance(entry_brand, str) and entry_brand.strip():
+            brand_value = entry_brand.strip()
+    brand_label = get_brand_label(brand_value or DEFAULT_BRAND)
+
+    ha_version = getattr(hass, "version", None)
+    ha_version_str = str(ha_version) if ha_version is not None else "unknown"
+
+    hass_config = getattr(hass, "config", None)
+    time_zone = getattr(hass_config, "time_zone", None)
+    time_zone_str = str(time_zone) if time_zone not in (None, "") else None
+
+    diagnostics: dict[str, Any] = {
+        "integration": {
+            "domain": DOMAIN,
+            "version": version_str,
+            "brand": brand_label,
+        },
+        "home_assistant": {
+            "version": ha_version_str,
+            "python_version": platform.python_version(),
+        },
+        "installation": {
+            "node_inventory": node_inventory,
+        },
+    }
+
+    if time_zone_str is not None:
+        diagnostics["home_assistant"]["time_zone"] = time_zone_str
+
+    return await async_redact_data(diagnostics, SENSITIVE_FIELDS)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,137 @@
+"""Tests for the TermoWeb diagnostics helper."""
+
+from __future__ import annotations
+
+import asyncio
+import platform
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from conftest import _install_stubs
+
+_install_stubs()
+
+diagnostics_stub = types.ModuleType("diagnostics")
+
+
+async def _async_passthrough(data: Any, _keys: set[str]) -> Any:
+    return data
+
+
+diagnostics_stub.async_redact_data = _async_passthrough
+components_pkg = sys.modules.setdefault(
+    "homeassistant.components", types.ModuleType("homeassistant.components")
+)
+setattr(components_pkg, "diagnostics", diagnostics_stub)
+sys.modules["homeassistant.components.diagnostics"] = diagnostics_stub
+
+from custom_components.termoweb.const import BRAND_DUCAHEAT, CONF_BRAND, DOMAIN
+from custom_components.termoweb.diagnostics import async_get_config_entry_diagnostics
+from custom_components.termoweb.installation import InstallationSnapshot
+from custom_components.termoweb.nodes import Node
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+def _flatten(data: Any) -> list[str]:
+    if isinstance(data, dict):
+        keys: list[str] = list(data)
+        for value in data.values():
+            keys.extend(_flatten(value))
+        return keys
+    if isinstance(data, list):
+        keys: list[str] = []
+        for item in data:
+            keys.extend(_flatten(item))
+        return keys
+    return []
+
+
+def test_diagnostics_with_cached_inventory() -> None:
+    """Diagnostics return cached inventory and redact sensitive keys."""
+
+    hass = HomeAssistant()
+    hass.version = "2025.5.0"
+    hass.config.time_zone = "Europe/London"
+
+    entry = ConfigEntry(
+        "entry-one",
+        data={CONF_BRAND: BRAND_DUCAHEAT},
+    )
+
+    nodes = [
+        Node(name="Heater One", addr="1", node_type="htr"),
+        Node(name="Monitor", addr="2", node_type="pmo"),
+    ]
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {
+        "version": "1.2.3",
+        "brand": BRAND_DUCAHEAT,
+        "node_inventory": list(nodes),
+        "dev_id": "secret-dev",
+        "username": "user@example.com",
+    }
+
+    diagnostics = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+
+    assert diagnostics["integration"]["version"] == "1.2.3"
+    assert diagnostics["integration"]["brand"] == "Ducaheat"
+    assert diagnostics["home_assistant"]["version"] == "2025.5.0"
+    assert diagnostics["home_assistant"]["python_version"] == platform.python_version()
+    assert diagnostics["home_assistant"]["time_zone"] == "Europe/London"
+    assert diagnostics["installation"]["node_inventory"] == [
+        {"name": "Heater One", "addr": "1", "type": "htr"},
+        {"name": "Monitor", "addr": "2", "type": "pmo"},
+    ]
+
+    flattened = _flatten(diagnostics)
+    assert "dev_id" not in flattened
+    assert "username" not in flattened
+
+
+def test_diagnostics_uses_snapshot_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Diagnostics fall back to snapshot inventory and helper version."""
+
+    hass = HomeAssistant()
+    hass.version = "2025.5.1"
+
+    entry = ConfigEntry(
+        "entry-two",
+        data={CONF_BRAND: "termoweb"},
+    )
+
+    raw_nodes = [
+        {"name": "Heater Two", "addr": "5", "type": "htr"},
+    ]
+    snapshot = InstallationSnapshot(dev_id="dev-123", raw_nodes=raw_nodes)
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {
+        "snapshot": snapshot,
+    }
+
+    recorded: dict[str, Any] = {}
+
+    async def fake_version(_hass: HomeAssistant) -> str:
+        recorded["called"] = True
+        return "9.9.9"
+
+    monkeypatch.setattr(
+        "custom_components.termoweb.diagnostics.async_get_integration_version",
+        fake_version,
+    )
+
+    diagnostics = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+
+    assert recorded["called"] is True
+    assert diagnostics["integration"]["version"] == "9.9.9"
+    assert diagnostics["integration"]["brand"] == "TermoWeb"
+    assert diagnostics["installation"]["node_inventory"] == [
+        {"name": "Heater Two", "addr": "5", "type": "htr"},
+    ]
+    assert "dev_id" not in _flatten(diagnostics)
+    assert "time_zone" not in diagnostics["home_assistant"]


### PR DESCRIPTION
## Summary
- add an async diagnostics helper that reports integration metadata, environment details, and node inventory while redacting sensitive fields
- cover the diagnostics helper with unit tests for cached inventory and snapshot fallback scenarios
- document how to download the new diagnostics export from the integration page

## Testing
- pytest tests/test_diagnostics.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e61742ee5c8329b67155332217b600