### PR TITLE
Fix Accumulator overrides typing

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -1040,8 +1040,8 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
             self._addr,
         )
 
-    @property  # type: ignore[override]
-    def hvac_mode(self) -> HVACMode:
+    @property
+    def hvac_mode(self) -> HVACMode | None:
         """Return the current accumulator HVAC mode."""
 
         s = self.heater_settings() or {}
@@ -1052,7 +1052,8 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
             return HVACMode.AUTO
         if mode == "boost":
             return HVACMode.AUTO
-        return super().hvac_mode
+        fallback = super().hvac_mode
+        return fallback if fallback is not None else None
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode | str) -> None:
         """Handle accumulator HVAC modes, delegating boost to presets."""
@@ -1105,11 +1106,12 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
         await self.async_cancel_boost()
         await super().async_set_hvac_mode(resume_mode)
 
-    @property  # type: ignore[override]
-    def extra_state_attributes(self) -> dict[str, Any]:
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return accumulator attributes including boost metadata."""
 
-        attrs = super().extra_state_attributes
+        base_attrs = super().extra_state_attributes
+        attrs: dict[str, Any] = dict(base_attrs) if base_attrs is not None else {}
         settings = self.heater_settings() or {}
         boost_state = derive_boost_state(settings, self.coordinator)
 


### PR DESCRIPTION
## Summary
- update `AccumulatorClimateEntity.hvac_mode` to return an optional HVAC mode and remove the type ignore
- align `extra_state_attributes` with the base mapping signature while preserving boost metadata

## Testing
- `uvx ty check custom_components/termoweb/climate.py` *(fails: missing Home Assistant and voluptuous type stubs in the environment)*
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e6368e8f908329a8e96174c12847e9