### PR TITLE
Fix typing of TermoWeb set_schedule entity service

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # Explicit callables ensure dispatch and let us add clear logs when invoked.
     async def _svc_set_schedule(entity: HeaterClimateEntity, call: ServiceCall) -> None:
         """Handle the set_schedule entity service."""
-        prog = call.data.get("prog")
+        prog = cast(list[int], call.data["prog"])
         _LOGGER.info(
             "entity-service termoweb.set_schedule -> %s prog_len=%s",
             getattr(entity, "entity_id", "<no-entity-id>"),


### PR DESCRIPTION
## Summary
- cast the service payload for termoweb.set_schedule to the expected list[int]

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e637656b7483299be143b32db652f5