### PR TITLE
Handle async diagnostics redaction helpers

### DIFF
--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import inspect
 import platform
 from typing import Any, Final
 
@@ -93,4 +94,7 @@ async def async_get_config_entry_diagnostics(
     if time_zone_str is not None:
         diagnostics["home_assistant"]["time_zone"] = time_zone_str
 
-    return await async_redact_data(diagnostics, SENSITIVE_FIELDS)
+    redacted = async_redact_data(diagnostics, SENSITIVE_FIELDS)
+    if inspect.isawaitable(redacted):
+        redacted = await redacted
+    return redacted


### PR DESCRIPTION
## Summary
- drop the invalid await when redacting diagnostics data
- handle both awaitable and direct return values from `async_redact_data`

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e63779afe8832987bf18f3c47b6cbd