### PR TITLE
Refactor websocket node dispatch preparation logic

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -866,7 +866,7 @@ class HeaterNodeBase(CoordinatorEntity):
     def _hass_for_runtime(self) -> HomeAssistant | None:
         """Return the best-effort Home Assistant instance for runtime access."""
 
-        hass_attr = self._hass
+        hass_attr = getattr(self, "_hass", _HASS_UNSET)
         if hass_attr is not _HASS_UNSET:
             return hass_attr
         coordinator_hass = getattr(self.coordinator, "hass", None)
@@ -876,7 +876,7 @@ class HeaterNodeBase(CoordinatorEntity):
     def hass(self) -> HomeAssistant | None:
         """Return the Home Assistant instance, falling back to the coordinator."""
 
-        hass_attr = self._hass
+        hass_attr = getattr(self, "_hass", _HASS_UNSET)
         if hass_attr is not _HASS_UNSET:
             return hass_attr
         coordinator_hass = getattr(self.coordinator, "hass", None)


### PR DESCRIPTION
## Summary
- extract a reusable helper to prepare node dispatch metadata for websocket clients
- update the TermoWeb node dispatcher to call the helper while keeping compatibility hooks
- harden the heater hass fallback when the cached attribute is missing

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e65a43bbb08329b12dc2d04b426479