### PR TITLE
Export websocket helper utilities

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -389,7 +389,14 @@ class WebSocketClient(_WsLeaseMixin, _WSStatusMixin):
         return ""
 
 
-__all__ = ["DUCAHEAT_NAMESPACE", "HandshakeError", "WSStats", "WebSocketClient"]
+__all__ = [
+    "DUCAHEAT_NAMESPACE",
+    "HandshakeError",
+    "WSStats",
+    "forward_ws_sample_updates",
+    "resolve_ws_update_section",
+    "WebSocketClient",
+]
 
 time_mod = time.monotonic
 


### PR DESCRIPTION
## Summary
- export the shared websocket helper functions from `backend.ws_client`

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e65f2dc4108329980ec5b1f53928b0