### PR TITLE
Use boost helper for accumulator validation

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -19,6 +19,7 @@ from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
 from .backend.ducaheat import DucaheatRESTClient
+from .boost import coerce_boost_minutes
 from .const import BRAND_DUCAHEAT, DOMAIN
 from .heater import (
     DEFAULT_BOOST_DURATION,
@@ -1128,9 +1129,8 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
 
         if minutes is None:
             return None
-        try:
-            value = int(minutes)
-        except (TypeError, ValueError):
+        value = coerce_boost_minutes(minutes)
+        if value is None:
             _LOGGER.error(
                 "Invalid boost minutes for type=%s addr=%s: %s",
                 self._node_type,
@@ -1138,7 +1138,7 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
                 minutes,
             )
             return None
-        if value <= 0 or value > 120:
+        if value > 120:
             _LOGGER.error(
                 "Boost duration must be between 1 and 120 minutes for type=%s addr=%s: %s",
                 self._node_type,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1211,6 +1211,91 @@ def test_accumulator_service_error_paths(monkeypatch: pytest.MonkeyPatch) -> Non
     asyncio.run(_run())
 
 
+def _make_accumulator_for_validation() -> climate_module.AccumulatorClimateEntity:
+    hass = HomeAssistant()
+    entry_id = "entry-acm-validate"
+    dev_id = "dev-acm-validate"
+    addr = "9"
+    record = {
+        "nodes": {},
+        "nodes_by_type": {"acm": {"settings": {addr: {"mode": "auto"}}}},
+        "htr": {"settings": {}},
+    }
+    coordinator = _make_coordinator(hass, dev_id, record)
+    entity = climate_module.AccumulatorClimateEntity(
+        coordinator,
+        entry_id,
+        dev_id,
+        addr,
+        "Accumulator",
+        node_type="acm",
+    )
+    entity.hass = hass
+    return entity
+
+
+def test_validate_boost_minutes_uses_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_environment()
+    entity = _make_accumulator_for_validation()
+
+    calls: list[Any] = []
+
+    def _fake(value: Any) -> int:
+        calls.append(value)
+        return 45
+
+    monkeypatch.setattr(climate_module, "coerce_boost_minutes", _fake)
+
+    result = entity._validate_boost_minutes(60)
+
+    assert result == 45
+    assert calls == [60]
+
+
+def test_validate_boost_minutes_invalid_logs_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _reset_environment()
+    entity = _make_accumulator_for_validation()
+
+    calls: list[Any] = []
+
+    def _fake(value: Any) -> int | None:
+        calls.append(value)
+        return None
+
+    monkeypatch.setattr(climate_module, "coerce_boost_minutes", _fake)
+    caplog.set_level(logging.ERROR)
+
+    result = entity._validate_boost_minutes("bad")
+
+    assert result is None
+    assert calls == ["bad"]
+    assert any("Invalid boost minutes" in record.message for record in caplog.records)
+
+
+def test_validate_boost_minutes_enforces_upper_limit(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _reset_environment()
+    entity = _make_accumulator_for_validation()
+
+    calls: list[Any] = []
+
+    def _fake(value: Any) -> int:
+        calls.append(value)
+        return 130
+
+    monkeypatch.setattr(climate_module, "coerce_boost_minutes", _fake)
+    caplog.set_level(logging.ERROR)
+
+    result = entity._validate_boost_minutes(130)
+
+    assert result is None
+    assert calls == [130]
+    assert any("Boost duration must be between 1 and 120" in record.message for record in caplog.records)
+
+
 def test_accumulator_extra_state_attributes_handles_resolver_fallbacks() -> None:
     """Edge cases in boost metadata should handle resolver failures gracefully."""
 


### PR DESCRIPTION
## Summary
- use the shared `coerce_boost_minutes` helper when validating accumulator boost durations
- retain the integration-specific 120 minute guard on boost requests
- add unit tests confirming `_validate_boost_minutes` delegates to the helper and logs invalid values

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e69eac76688329bde1d95f03aeb292