### PR TITLE
Add helper for heater entity unique IDs

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -18,6 +18,7 @@ from .coordinator import StateCoordinator
 from .heater import (
     DispatcherSubscriptionHelper,
     HeaterNodeBase,
+    build_heater_entity_unique_id,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
     prepare_heater_platform_data,
@@ -43,7 +44,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
         nodes_by_type, resolve_name
     ):
-        unique_id = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:boost_active"
+        unique_id = build_heater_entity_unique_id(
+            dev_id,
+            node_type,
+            addr_str,
+            ":boost_active",
+        )
         boost_entities.append(
             HeaterBoostActiveBinarySensor(
                 coord,

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -25,6 +25,7 @@ from .const import DOMAIN
 from .heater import (
     BoostButtonMetadata,
     HeaterNodeBase,
+    build_heater_entity_unique_id,
     iter_boost_button_metadata,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
@@ -280,7 +281,12 @@ def _create_boost_button_entities(
 ) -> list[ButtonEntity]:
     """Return boost helper buttons described by shared metadata."""
 
-    unique_prefix = f"{DOMAIN}:{dev_id}:{node_type}:{addr}:boost"
+    unique_prefix = build_heater_entity_unique_id(
+        dev_id,
+        node_type,
+        addr,
+        ":boost",
+    )
     return [
         _build_boost_button(
             metadata,

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -24,6 +24,7 @@ from .const import BRAND_DUCAHEAT, DOMAIN
 from .heater import (
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
+    build_heater_entity_unique_id,
     derive_boost_state,
     iter_heater_maps,
     iter_heater_nodes,
@@ -56,7 +57,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for node_type, _node, addr_str, resolved_name in iter_heater_nodes(
         nodes_by_type, resolve_name
     ):
-        unique_id = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:climate"
+        unique_id = build_heater_entity_unique_id(
+            dev_id,
+            node_type,
+            addr_str,
+            ":climate",
+        )
         entity_cls: type[HeaterClimateEntity]
         if node_type == "acm":
             entity_cls = AccumulatorClimateEntity

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -61,6 +61,28 @@ BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = tuple(
 )
 
 
+def build_heater_entity_unique_id(
+    dev_id: Any,
+    node_type: Any,
+    addr: Any,
+    suffix: str | None = None,
+) -> str:
+    """Return the canonical unique ID for a heater entity."""
+
+    dev = normalize_node_addr(dev_id)
+    node = normalize_node_type(node_type)
+    address = normalize_node_addr(addr)
+    if not dev or not node or not address:
+        raise ValueError("dev_id, node_type and addr must be provided")
+
+    suffix_str = ""
+    if suffix:
+        suffix_clean = str(suffix)
+        suffix_str = suffix_clean if suffix_clean.startswith(":") else f":{suffix_clean}"
+
+    return f"{DOMAIN}:{dev}:{node}:{address}{suffix_str}"
+
+
 def _boost_runtime_store(
     entry_data: MutableMapping[str, Any] | None,
     *,

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -14,6 +14,7 @@ from .heater import (
     BOOST_DURATION_OPTIONS,
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
+    build_heater_entity_unique_id,
     get_boost_runtime_minutes,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
@@ -42,7 +43,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
         resolve_name,
         accumulators_only=True,
     ):
-        unique_id = f"{DOMAIN}:{dev_id}:{node_type}:{addr_str}:boost_duration"
+        unique_id = build_heater_entity_unique_id(
+            dev_id,
+            node_type,
+            addr_str,
+            ":boost_duration",
+        )
         new_entities.append(
             AccumulatorBoostDurationSelect(
                 coordinator,

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -283,7 +283,15 @@ def test_button_setup_adds_accumulator_entities(
         expected_names = [item.label for item in custom_metadata]
         expected_icons = [item.icon for item in custom_metadata]
         expected_unique_ids = [
-            f"{DOMAIN}:{dev_id}:acm:{acm_node.addr}:boost_{item.unique_suffix}"
+            "{}_{}".format(
+                heater_module.build_heater_entity_unique_id(
+                    dev_id,
+                    "acm",
+                    acm_node.addr,
+                    ":boost",
+                ),
+                item.unique_suffix,
+            )
             for item in custom_metadata
         ]
         assert names == expected_names

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -28,6 +28,29 @@ iter_boostable_heater_nodes = heater_module.iter_boostable_heater_nodes
 prepare_heater_platform_data = heater_module.prepare_heater_platform_data
 
 
+def test_build_heater_entity_unique_id_normalises_inputs() -> None:
+    """Helper should normalise identifiers and enforce required fields."""
+
+    uid = heater_module.build_heater_entity_unique_id(
+        " 0A1B ",
+        " ACM ",
+        " 07 ",
+        "boost",
+    )
+    assert uid == "termoweb:0A1B:acm:07:boost"
+
+    uid_with_colon = heater_module.build_heater_entity_unique_id(
+        "0a1b",
+        "acm",
+        "07",
+        ":boost",
+    )
+    assert uid_with_colon == "termoweb:0a1b:acm:07:boost"
+
+    with pytest.raises(ValueError):
+        heater_module.build_heater_entity_unique_id("", "acm", "07")
+
+
 def _make_heater(coordinator: SimpleNamespace) -> HeaterNodeBase:
     return HeaterNodeBase(coordinator, "entry", "dev", "A", "Heater A")
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -17,6 +17,7 @@ from custom_components.termoweb.heater import (
     get_boost_runtime_minutes,
     iter_boost_button_metadata,
     set_boost_runtime_minutes,
+    build_heater_entity_unique_id,
 )
 from homeassistant.core import HomeAssistant
 
@@ -75,7 +76,12 @@ def test_select_setup_and_selection(
         assert len(added) == 1
         entity = added[0]
         assert isinstance(entity, AccumulatorBoostDurationSelect)
-        assert entity.unique_id == f"{DOMAIN}:{dev_id}:acm:{node.addr}:boost_duration"
+        assert entity.unique_id == build_heater_entity_unique_id(
+            dev_id,
+            "acm",
+            node.addr,
+            ":boost_duration",
+        )
         expected_options = [
             str(item.minutes)
             for item in iter_boost_button_metadata()
@@ -173,7 +179,12 @@ def test_select_restores_last_state(
             dev_id,
             node.addr,
             "Accumulator 9",
-            f"{DOMAIN}:{dev_id}:acm:{node.addr}:boost_duration",
+            build_heater_entity_unique_id(
+                dev_id,
+                "acm",
+                node.addr,
+                ":boost_duration",
+            ),
             node_type="acm",
         )
         entity2.hass = hass


### PR DESCRIPTION
## Summary
- add a `build_heater_entity_unique_id` helper for constructing canonical heater entity IDs
- refactor heater-related platforms to use the helper and update button prefix handling
- adjust unit tests to assert against helper output and cover validation

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6a9a549d08329904c150a9e4a75c0