### PR TITLE
Refactor heater unique ID builders

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -18,11 +18,11 @@ from .coordinator import StateCoordinator
 from .entity import GatewayDispatcherEntity
 from .heater import (
     HeaterNodeBase,
-    build_heater_entity_unique_id,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
     prepare_heater_platform_data,
 )
+from .identifiers import build_heater_entity_unique_id
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -25,12 +25,12 @@ from .const import DOMAIN
 from .heater import (
     BoostButtonMetadata,
     HeaterNodeBase,
-    build_heater_entity_unique_id,
     iter_boost_button_metadata,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
     prepare_heater_platform_data,
 )
+from .identifiers import build_heater_entity_unique_id
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -24,7 +24,6 @@ from .const import BRAND_DUCAHEAT, DOMAIN
 from .heater import (
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
-    build_heater_entity_unique_id,
     derive_boost_state,
     iter_heater_maps,
     iter_heater_nodes,
@@ -32,6 +31,7 @@ from .heater import (
     prepare_heater_platform_data,
     resolve_boost_runtime_minutes,
 )
+from .identifiers import build_heater_entity_unique_id
 from .nodes import HeaterNode, normalize_node_addr, normalize_node_type
 from .utils import float_or_none
 

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -16,10 +16,10 @@ from homeassistant.helpers import entity_registry as er
 
 from .api import RESTClient
 from .const import DOMAIN
+from .identifiers import build_heater_energy_unique_id
 from .installation import ensure_snapshot
 from .nodes import (
     build_heater_address_map,
-    build_heater_energy_unique_id,
     ensure_node_inventory,
     normalize_heater_addresses,
     parse_heater_energy_unique_id,

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -59,30 +59,6 @@ BOOST_BUTTON_METADATA: Final[tuple[BoostButtonMetadata, ...]] = (
 BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = tuple(
     option.minutes for option in BOOST_BUTTON_METADATA if option.minutes is not None
 )
-
-
-def build_heater_entity_unique_id(
-    dev_id: Any,
-    node_type: Any,
-    addr: Any,
-    suffix: str | None = None,
-) -> str:
-    """Return the canonical unique ID for a heater entity."""
-
-    dev = normalize_node_addr(dev_id)
-    node = normalize_node_type(node_type)
-    address = normalize_node_addr(addr)
-    if not dev or not node or not address:
-        raise ValueError("dev_id, node_type and addr must be provided")
-
-    suffix_str = ""
-    if suffix:
-        suffix_clean = str(suffix)
-        suffix_str = suffix_clean if suffix_clean.startswith(":") else f":{suffix_clean}"
-
-    return f"{DOMAIN}:{dev}:{node}:{address}{suffix_str}"
-
-
 def _boost_runtime_store(
     entry_data: MutableMapping[str, Any] | None,
     *,

--- a/custom_components/termoweb/identifiers.py
+++ b/custom_components/termoweb/identifiers.py
@@ -1,0 +1,48 @@
+"""Identifier builders for TermoWeb entities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import nodes as nodes_module
+from .const import DOMAIN
+
+
+def build_heater_unique_id(
+    dev_id: Any,
+    node_type: Any,
+    addr: Any,
+    *,
+    suffix: str | None = None,
+) -> str:
+    """Return the canonical unique ID for a heater node."""
+
+    dev = nodes_module.normalize_node_addr(dev_id)
+    node = nodes_module.normalize_node_type(node_type)
+    address = nodes_module.normalize_node_addr(addr)
+    if not dev or not node or not address:
+        raise ValueError("dev_id, node_type and addr must be provided")
+
+    suffix_str = ""
+    if suffix:
+        suffix_clean = str(suffix)
+        suffix_str = suffix_clean if suffix_clean.startswith(":") else f":{suffix_clean}"
+
+    return f"{DOMAIN}:{dev}:{node}:{address}{suffix_str}"
+
+
+def build_heater_entity_unique_id(
+    dev_id: Any,
+    node_type: Any,
+    addr: Any,
+    suffix: str | None = None,
+) -> str:
+    """Return the canonical unique ID for a heater entity."""
+
+    return build_heater_unique_id(dev_id, node_type, addr, suffix=suffix)
+
+
+def build_heater_energy_unique_id(dev_id: Any, node_type: Any, addr: Any) -> str:
+    """Return the canonical unique ID for a heater energy sensor."""
+
+    return build_heater_unique_id(dev_id, node_type, addr, suffix=":energy")

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -498,19 +498,6 @@ def ensure_node_inventory(
         mutable_record["node_inventory"] = []
 
     return []
-
-
-def build_heater_energy_unique_id(dev_id: Any, node_type: Any, addr: Any) -> str:
-    """Return the canonical unique ID for a heater energy sensor."""
-
-    dev = normalize_node_addr(dev_id)
-    node = normalize_node_type(node_type)
-    address = normalize_node_addr(addr)
-    if not dev or not node or not address:
-        raise ValueError("dev_id, node_type and addr must be provided")
-    return f"{DOMAIN}:{dev}:{node}:{address}:energy"
-
-
 def parse_heater_energy_unique_id(unique_id: str) -> tuple[str, str, str] | None:
     """Parse a heater energy sensor unique ID into its components."""
 

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -14,7 +14,6 @@ from .heater import (
     BOOST_DURATION_OPTIONS,
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
-    build_heater_entity_unique_id,
     get_boost_runtime_minutes,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
@@ -22,6 +21,7 @@ from .heater import (
     resolve_boost_runtime_minutes,
     set_boost_runtime_minutes,
 )
+from .identifiers import build_heater_entity_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -37,7 +37,7 @@ from .heater import (
     log_skipped_nodes,
     prepare_heater_platform_data,
 )
-from .nodes import build_heater_energy_unique_id
+from .identifiers import build_heater_energy_unique_id
 from .utils import build_gateway_device_info, float_or_none
 
 _WH_TO_KWH = 1 / 1000.0

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 import custom_components.termoweb.binary_sensor as binary_sensor_module
 import custom_components.termoweb.button as button_module
 import custom_components.termoweb.heater as heater_module
+from custom_components.termoweb import identifiers as identifiers_module
 from custom_components.termoweb.const import DOMAIN, signal_ws_status
 from custom_components.termoweb.utils import build_gateway_device_info
 
@@ -301,7 +302,7 @@ def test_button_setup_adds_accumulator_entities(
         expected_icons = [item.icon for item in custom_metadata]
         expected_unique_ids = [
             "{}_{}".format(
-                heater_module.build_heater_entity_unique_id(
+                identifiers_module.build_heater_entity_unique_id(
                     dev_id,
                     "acm",
                     acm_node.addr,

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -12,6 +12,7 @@ from conftest import _install_stubs, make_ws_payload
 _install_stubs()
 
 from custom_components.termoweb import heater as heater_module
+from custom_components.termoweb import identifiers as identifiers_module
 from custom_components.termoweb import installation as installation_module
 from custom_components.termoweb.installation import InstallationSnapshot
 from custom_components.termoweb.heater_inventory import build_heater_inventory_details
@@ -31,7 +32,7 @@ prepare_heater_platform_data = heater_module.prepare_heater_platform_data
 def test_build_heater_entity_unique_id_normalises_inputs() -> None:
     """Helper should normalise identifiers and enforce required fields."""
 
-    uid = heater_module.build_heater_entity_unique_id(
+    uid = identifiers_module.build_heater_entity_unique_id(
         " 0A1B ",
         " ACM ",
         " 07 ",
@@ -39,7 +40,7 @@ def test_build_heater_entity_unique_id_normalises_inputs() -> None:
     )
     assert uid == "termoweb:0A1B:acm:07:boost"
 
-    uid_with_colon = heater_module.build_heater_entity_unique_id(
+    uid_with_colon = identifiers_module.build_heater_entity_unique_id(
         "0a1b",
         "acm",
         "07",
@@ -48,7 +49,7 @@ def test_build_heater_entity_unique_id_normalises_inputs() -> None:
     assert uid_with_colon == "termoweb:0a1b:acm:07:boost"
 
     with pytest.raises(ValueError):
-        heater_module.build_heater_entity_unique_id("", "acm", "07")
+        identifiers_module.build_heater_entity_unique_id("", "acm", "07")
 
 
 def _make_heater(coordinator: SimpleNamespace) -> HeaterNodeBase:

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -17,10 +17,8 @@ from aiohttp import ClientError
 from custom_components.termoweb import coordinator as coordinator_module
 from custom_components.termoweb import sensor as sensor_module
 from custom_components.termoweb import const as const_module
-from custom_components.termoweb.nodes import (
-    build_heater_energy_unique_id,
-    build_node_inventory,
-)
+from custom_components.termoweb.identifiers import build_heater_energy_unique_id
+from custom_components.termoweb.nodes import build_node_inventory
 from custom_components.termoweb.utils import build_gateway_device_info
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfTemperature

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from custom_components.termoweb import identifiers as identifiers_module
 from custom_components.termoweb import nodes as nodes_module
 from custom_components.termoweb.installation import InstallationSnapshot
 
@@ -517,7 +518,7 @@ def test_register_import_service_uses_module_asyncio(
         entry = ConfigEntry("cache-test", options={})
         entries[entry.entry_id] = entry
 
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -869,9 +870,9 @@ def test_async_import_energy_history_skips_invalid_samples(
             }
         }
 
-        uid_c = nodes_module.build_heater_energy_unique_id("dev", "htr", "C")
+        uid_c = identifiers_module.build_heater_energy_unique_id("dev", "htr", "C")
         ent_reg.add("sensor.dev_C_energy", "sensor", const.DOMAIN, uid_c, "C energy")
-        uid_d = nodes_module.build_heater_energy_unique_id("dev", "htr", "D")
+        uid_d = identifiers_module.build_heater_energy_unique_id("dev", "htr", "D")
         ent_reg.add("sensor.dev_D_energy", "sensor", const.DOMAIN, uid_d, "D energy")
 
         store = Mock()
@@ -945,7 +946,7 @@ def test_import_energy_history(monkeypatch: pytest.MonkeyPatch) -> None:
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 4 * 86_400
@@ -1046,7 +1047,7 @@ def test_import_energy_history_with_existing_stats(
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 4 * 86_400
@@ -1144,7 +1145,7 @@ def test_import_energy_history_clears_overlap(monkeypatch: pytest.MonkeyPatch) -
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 4 * 86_400
@@ -1248,7 +1249,7 @@ def test_import_energy_history_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
             "node_inventory": _inventory_for(mod, ["A"]),
             "config_entry": entry,
         }
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 2 * 86_400
@@ -1329,7 +1330,7 @@ def test_import_history_uses_last_stats_and_clears_overlap(
             "config_entry": entry,
         }
 
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 5 * 86_400
@@ -1436,7 +1437,7 @@ def test_import_history_uses_sync_recorder_helpers(
             "config_entry": entry,
         }
 
-        uid = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uid, "A energy")
 
         fake_now = 5 * 86_400
@@ -1540,8 +1541,8 @@ def test_import_energy_history_reset_and_subset(
             "node_inventory": _inventory_for(mod, ["A", "B"]),
             "config_entry": entry,
         }
-        uidA = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uidB = nodes_module.build_heater_energy_unique_id("dev", "htr", "B")
+        uidA = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uidB = identifiers_module.build_heater_energy_unique_id("dev", "htr", "B")
         ent_reg.add("sensor.dev_A_energy", "sensor", const.DOMAIN, uidA, "A energy")
         ent_reg.add("sensor.dev_B_energy", "sensor", const.DOMAIN, uidB, "B energy")
 
@@ -1645,8 +1646,8 @@ def test_import_energy_history_reset_all_progress(
             "config_entry": entry,
         }
 
-        uid_a = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uid_b = nodes_module.build_heater_energy_unique_id("dev", "htr", "B")
+        uid_a = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid_b = identifiers_module.build_heater_energy_unique_id("dev", "htr", "B")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -1809,8 +1810,8 @@ def test_import_energy_history_requested_map_filters(
             energy_mod, "normalize_heater_addresses", fake_normalize
         )
 
-        uid_a = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uid_b_legacy = nodes_module.build_heater_energy_unique_id("dev", "htr", "B")
+        uid_a = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid_b_legacy = identifiers_module.build_heater_energy_unique_id("dev", "htr", "B")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -2248,8 +2249,8 @@ def test_service_dispatches_import_tasks(monkeypatch: pytest.MonkeyPatch) -> Non
         rec = hass.data[const.DOMAIN][entry.entry_id]
         rec["node_inventory"] = _inventory_for(mod, {"htr": ["A"], "acm": ["B"]})
 
-        uid_a = nodes_module.build_heater_energy_unique_id("dev", "htr", "A")
-        uid_b = nodes_module.build_heater_energy_unique_id("dev", "acm", "B")
+        uid_a = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
+        uid_b = identifiers_module.build_heater_energy_unique_id("dev", "acm", "B")
         ent_reg.add(
             "sensor.dev_A_energy",
             "sensor",
@@ -2408,7 +2409,7 @@ def test_service_filters_invalid_entities(monkeypatch: pytest.MonkeyPatch) -> No
             "sensor.no_entry",
             "sensor",
             const.DOMAIN,
-            nodes_module.build_heater_energy_unique_id("dev", "htr", "D"),
+            identifiers_module.build_heater_energy_unique_id("dev", "htr", "D"),
             "Missing entry",
             config_entry_id="missing",
         )
@@ -2416,7 +2417,7 @@ def test_service_filters_invalid_entities(monkeypatch: pytest.MonkeyPatch) -> No
             "sensor.no_config",
             "sensor",
             const.DOMAIN,
-            nodes_module.build_heater_energy_unique_id("dev", "htr", "C"),
+            identifiers_module.build_heater_energy_unique_id("dev", "htr", "C"),
             "No config",
         )
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -22,10 +22,8 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as entity_registry_mod
 
-from custom_components.termoweb.nodes import (
-    build_heater_address_map,
-    build_heater_energy_unique_id,
-)
+from custom_components.termoweb.identifiers import build_heater_energy_unique_id
+from custom_components.termoweb.nodes import build_heater_address_map
 
 
 class FakeWSClient:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -17,8 +17,8 @@ from custom_components.termoweb.heater import (
     get_boost_runtime_minutes,
     iter_boost_button_metadata,
     set_boost_runtime_minutes,
-    build_heater_entity_unique_id,
 )
+from custom_components.termoweb.identifiers import build_heater_entity_unique_id
 from homeassistant.core import HomeAssistant
 
 AccumulatorBoostDurationSelect = select_module.AccumulatorBoostDurationSelect

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,10 +7,10 @@ import pytest
 
 from custom_components.termoweb import nodes as nodes_module
 from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb.identifiers import build_heater_energy_unique_id
 from custom_components.termoweb.nodes import (
     HEATER_NODE_TYPES,
     addresses_by_node_type,
-    build_heater_energy_unique_id,
     build_node_inventory,
     ensure_node_inventory,
     normalize_heater_addresses,


### PR DESCRIPTION
## Summary
- add a shared identifiers helper for heater unique IDs
- update entity and energy unique ID builders and adjust imports/tests

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6b227ddf483298c6ee0ed0bc89cf9