### PR TITLE
Fix Ducaheat websocket logging and cover diagnostics guards

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -593,7 +593,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 summary = f" path={args[0]}"
             elif args:
                 summary = f" args={args}"
-#            _LOGGER.debug("WS (ducaheat): -> 42 %s%s", event, summary)
+            _LOGGER.debug("WS (ducaheat): -> 42 %s%s", event, summary)
 
     def _normalise_nodes_payload(self, nodes: Mapping[str, Any]) -> Any:
         """Normalise websocket node payloads via the REST client helper."""

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -174,6 +174,52 @@ def test_async_ensure_diagnostics_platform_registers(
     assert diagnostics_calls == [
         ("sync", stub_hass, termoweb_init.DOMAIN, diagnostics_platform)
     ]
+
+
+def test_async_ensure_diagnostics_platform_guard_paths(
+    termoweb_init: Any,
+    stub_hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diagnostics_calls: list[tuple[str, HomeAssistant, str, types.ModuleType]] = []
+
+    diagnostics_module = types.ModuleType("diagnostics_guard_stub")
+    diagnostics_module.DOMAIN = "diagnostics"
+    diagnostics_module.async_redact_data = lambda data, fields: data
+
+    def _sync_register(
+        hass: HomeAssistant, domain: str, platform: types.ModuleType
+    ) -> None:
+        diagnostics_calls.append(("sync", hass, domain, platform))
+
+    diagnostics_module._register_diagnostics_platform = _sync_register
+    diagnostics_module._DIAGNOSTICS_DATA = "diag_key"
+
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.components.diagnostics", diagnostics_module
+    )
+
+    platform = importlib.import_module("custom_components.termoweb.diagnostics")
+
+    stub_hass.data = {}
+    asyncio.run(termoweb_init._async_ensure_diagnostics_platform(stub_hass))
+    assert diagnostics_calls == []
+
+    stub_hass.data = {
+        diagnostics_module._DIAGNOSTICS_DATA: SimpleNamespace(platforms=None)
+    }
+    asyncio.run(termoweb_init._async_ensure_diagnostics_platform(stub_hass))
+    assert diagnostics_calls == []
+
+    stub_hass.data = {
+        diagnostics_module._DIAGNOSTICS_DATA: SimpleNamespace(
+            platforms={termoweb_init.DOMAIN: platform}
+        )
+    }
+    asyncio.run(termoweb_init._async_ensure_diagnostics_platform(stub_hass))
+    assert diagnostics_calls == []
+
+
 async def _drain_tasks(hass: HomeAssistant) -> None:
     if hass.tasks:
         await asyncio.gather(*hass.tasks, return_exceptions=True)


### PR DESCRIPTION
## Summary
- restore the Ducaheat websocket debug emission log that describes outgoing frames
- exercise diagnostics platform guard paths with dedicated tests to reach full coverage

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6c9bdb28c83298c2c77527df21e7e