### PR TITLE
Add immutable inventory container with tests

### DIFF
--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -1,0 +1,50 @@
+"""Inventory helpers for TermoWeb nodes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Tuple
+
+RawNodePayload = Any
+PrebuiltNode = Any
+
+__all__ = ["Inventory"]
+
+
+@dataclass(frozen=True, slots=True)
+class Inventory:
+    """Represent immutable node inventory details."""
+
+    _dev_id: str
+    _payload: RawNodePayload
+    _nodes: Tuple[PrebuiltNode, ...]
+
+    def __init__(
+        self,
+        dev_id: str,
+        payload: RawNodePayload,
+        nodes: Iterable[PrebuiltNode],
+    ) -> None:
+        """Initialize the inventory container."""
+
+        object.__setattr__(self, "_dev_id", dev_id)
+        object.__setattr__(self, "_payload", payload)
+        object.__setattr__(self, "_nodes", tuple(nodes))
+
+    @property
+    def dev_id(self) -> str:
+        """Get the device identifier."""
+
+        return self._dev_id
+
+    @property
+    def payload(self) -> RawNodePayload:
+        """Get the raw node payload."""
+
+        return self._payload
+
+    @property
+    def nodes(self) -> Tuple[PrebuiltNode, ...]:
+        """Get the immutable tuple of node objects."""
+
+        return self._nodes

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,71 @@
+"""Tests for the inventory container."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from typing import Any, List
+
+import pytest
+
+from custom_components.termoweb.inventory import Inventory
+
+
+class DummyNode:
+    """Represent a lightweight node stub."""
+
+    def __init__(self, name: str, metadata: Any | None = None) -> None:
+        """Store identifying fields for the stub."""
+
+        self.name = name
+        self.metadata = metadata
+
+
+@pytest.fixture
+def sample_payload() -> dict[str, Any]:
+    """Return a representative payload mapping."""
+
+    return {"nodes": [{"addr": 1}, {"addr": 2}]}
+
+
+@pytest.fixture
+def sample_nodes() -> List[DummyNode]:
+    """Return a list of dummy node instances."""
+
+    return [DummyNode("alpha"), DummyNode("beta")]
+
+
+@pytest.fixture
+def inventory(sample_payload: dict[str, Any], sample_nodes: List[DummyNode]) -> Inventory:
+    """Build an inventory instance for tests."""
+
+    return Inventory("abc123", sample_payload, sample_nodes)
+
+
+def test_inventory_properties(
+    inventory: Inventory, sample_payload: dict[str, Any], sample_nodes: List[DummyNode]
+) -> None:
+    """Validate accessor properties and tuple conversion."""
+
+    assert inventory.dev_id == "abc123"
+    assert inventory.payload is sample_payload
+    assert inventory.nodes == tuple(sample_nodes)
+    assert isinstance(inventory.nodes, tuple)
+
+
+def test_inventory_rejects_mutation(inventory: Inventory) -> None:
+    """Ensure mutation attempts raise frozen instance errors."""
+
+    with pytest.raises((FrozenInstanceError, AttributeError, TypeError)):
+        inventory.dev_id = "xyz987"
+    with pytest.raises(TypeError):
+        inventory.nodes[0] = DummyNode("gamma")
+
+
+def test_inventory_nodes_are_independent(
+    sample_payload: dict[str, Any], sample_nodes: List[DummyNode]
+) -> None:
+    """Confirm node collections are copied into the tuple."""
+
+    inventory = Inventory("abc123", sample_payload, sample_nodes)
+    sample_nodes.append(DummyNode("gamma"))
+    assert len(inventory.nodes) == 2


### PR DESCRIPTION
## Summary
- introduce an immutable `Inventory` dataclass that stores device metadata and exposes read-only accessors
- add unit tests covering the new container and verifying immutability semantics

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6caf15e488329ae8405a064a86699