### PR TITLE
Refactor node models into inventory module

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -29,7 +29,7 @@ from .const import (
     get_brand_requested_with,
     get_brand_user_agent,
 )
-from .nodes import Node, NodeDescriptor, normalize_node_addr, normalize_node_type
+from .inventory import Node, NodeDescriptor, normalize_node_addr, normalize_node_type
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from asyncio import Task
 from typing import Any, Protocol
 
-from ..nodes import NodeDescriptor
+from ..inventory import NodeDescriptor
 
 
 class HttpClientProto(Protocol):

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -11,7 +11,7 @@ from aiohttp import ClientResponseError
 
 from ..api import RESTClient
 from ..const import BRAND_DUCAHEAT, WS_NAMESPACE
-from ..nodes import NodeDescriptor
+from ..inventory import NodeDescriptor
 from .base import Backend, WsClientProto
 from .ducaheat_ws import DucaheatWSClient
 from .sanitize import (

--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -27,12 +27,11 @@ from ..const import (
     get_brand_requested_with,
     get_brand_user_agent,
 )
+from ..inventory import normalize_node_addr, normalize_node_type
 from ..nodes import (
     collect_heater_sample_addresses,
     heater_sample_subscription_targets,
     normalize_heater_addresses,
-    normalize_node_addr,
-    normalize_node_type,
 )
 from .ws_client import (
     DUCAHEAT_NAMESPACE,

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -51,14 +51,13 @@ from custom_components.termoweb.installation import (
     InstallationSnapshot,
     ensure_snapshot,
 )
+from custom_components.termoweb.inventory import normalize_node_addr, normalize_node_type
 from custom_components.termoweb.nodes import (
     addresses_by_node_type as _addresses_by_node_type,
     build_node_inventory as _build_node_inventory,
     collect_heater_sample_addresses,
     heater_sample_subscription_targets,
     normalize_heater_addresses,
-    normalize_node_addr,
-    normalize_node_type,
 )
 from .ws_client import (
     WSStats,

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -36,15 +36,13 @@ from ..const import (
     signal_ws_status,
 )
 from ..installation import InstallationSnapshot, ensure_snapshot
+from ..inventory import NODE_CLASS_BY_TYPE, normalize_node_addr, normalize_node_type
 from ..nodes import (
-    NODE_CLASS_BY_TYPE,
     addresses_by_node_type,
     collect_heater_sample_addresses,
     ensure_node_inventory,
     heater_sample_subscription_targets,
     normalize_heater_addresses,
-    normalize_node_addr,
-    normalize_node_type,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -32,7 +32,7 @@ from .heater import (
     resolve_boost_runtime_minutes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .nodes import HeaterNode, normalize_node_addr, normalize_node_type
+from .inventory import HeaterNode, normalize_node_addr, normalize_node_type
 from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -18,14 +18,12 @@ from homeassistant.util import dt as dt_util
 from .api import BackendAuthError, BackendRateLimitError, RESTClient
 from .boost import coerce_int, resolve_boost_end_from_fields
 from .const import HTR_ENERGY_UPDATE_INTERVAL, MIN_POLL_INTERVAL
+from .inventory import Node, normalize_node_addr, normalize_node_type
 from .nodes import (
-    Node,
     _existing_nodes_map,
     build_heater_address_map,
     build_node_inventory,
     normalize_heater_addresses,
-    normalize_node_addr,
-    normalize_node_type,
 )
 from .utils import float_or_none
 

--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -13,7 +13,8 @@ from homeassistant.core import HomeAssistant
 
 from .const import CONF_BRAND, DEFAULT_BRAND, DOMAIN, get_brand_label
 from .installation import ensure_snapshot
-from .nodes import Node, ensure_node_inventory
+from .inventory import Node
+from .nodes import ensure_node_inventory
 from .utils import async_get_integration_version
 
 SENSITIVE_FIELDS: Final = {

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -23,13 +23,11 @@ from .boost import (
 from .const import DOMAIN, signal_ws_data
 from .heater_inventory import build_heater_inventory_details
 from .installation import InstallationSnapshot, ensure_snapshot
+from .inventory import Node, normalize_node_addr, normalize_node_type
 from .nodes import (
     HEATER_NODE_TYPES,
-    Node,
     build_node_inventory,
     ensure_node_inventory,
-    normalize_node_addr,
-    normalize_node_type,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/heater_inventory.py
+++ b/custom_components/termoweb/heater_inventory.py
@@ -6,13 +6,8 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from .nodes import (
-    HEATER_NODE_TYPES,
-    Node,
-    build_heater_address_map,
-    normalize_node_addr,
-    normalize_node_type,
-)
+from .inventory import Node, normalize_node_addr, normalize_node_type
+from .nodes import HEATER_NODE_TYPES, build_heater_address_map
 
 
 @dataclass(slots=True)

--- a/custom_components/termoweb/identifiers.py
+++ b/custom_components/termoweb/identifiers.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from . import nodes as nodes_module
 from .const import DOMAIN
+from .inventory import normalize_node_addr, normalize_node_type
 
 
 def build_heater_unique_id(
@@ -17,9 +17,9 @@ def build_heater_unique_id(
 ) -> str:
     """Return the canonical unique ID for a heater node."""
 
-    dev = nodes_module.normalize_node_addr(dev_id)
-    node = nodes_module.normalize_node_type(node_type)
-    address = nodes_module.normalize_node_addr(addr)
+    dev = normalize_node_addr(dev_id)
+    node = normalize_node_type(node_type)
+    address = normalize_node_addr(addr)
     if not dev or not node or not address:
         raise ValueError("dev_id, node_type and addr must be provided")
 

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -6,8 +6,8 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 from .heater_inventory import HeaterInventoryDetails, build_heater_inventory_details
+from .inventory import Node
 from .nodes import (
-    Node,
     build_node_inventory,
     heater_sample_subscription_targets,
     normalize_heater_addresses,

--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -1,4 +1,4 @@
-"""Inventory helpers for TermoWeb nodes."""
+"""Inventory helpers and node model abstractions for TermoWeb."""
 
 from __future__ import annotations
 
@@ -8,7 +8,19 @@ from typing import Any, Iterable, Tuple
 RawNodePayload = Any
 PrebuiltNode = Any
 
-__all__ = ["Inventory"]
+__all__ = [
+    "Inventory",
+    "_normalize_node_identifier",
+    "normalize_node_type",
+    "normalize_node_addr",
+    "Node",
+    "HeaterNode",
+    "AccumulatorNode",
+    "PowerMonitorNode",
+    "ThermostatNode",
+    "NODE_CLASS_BY_TYPE",
+    "NodeDescriptor",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,3 +60,206 @@ class Inventory:
         """Get the immutable tuple of node objects."""
 
         return self._nodes
+
+
+def _normalize_node_identifier(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+    lowercase: bool,
+) -> str:
+    """Return ``value`` as a normalised node identifier string."""
+
+    raw = value
+    if use_default_when_falsey and not raw:
+        raw = default
+
+    try:
+        normalized = str(raw).strip()
+    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+        normalized = ""
+    else:
+        if lowercase:
+            normalized = normalized.lower()
+
+    if normalized:
+        return normalized
+
+    if default and not use_default_when_falsey:
+        try:
+            normalized_default = str(default).strip()
+        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+            return ""
+        if lowercase:
+            normalized_default = normalized_default.lower()
+        return normalized_default
+
+    return ""
+
+
+def normalize_node_type(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+) -> str:
+    """Return ``value`` as a normalised node type string."""
+
+    return _normalize_node_identifier(
+        value,
+        default=default,
+        use_default_when_falsey=use_default_when_falsey,
+        lowercase=True,
+    )
+
+
+def normalize_node_addr(
+    value: Any,
+    *,
+    default: str = "",
+    use_default_when_falsey: bool = False,
+) -> str:
+    """Return ``value`` as a normalised node address string."""
+
+    return _normalize_node_identifier(
+        value,
+        default=default,
+        use_default_when_falsey=use_default_when_falsey,
+        lowercase=False,
+    )
+
+
+class Node:
+    """Base representation of a TermoWeb node."""
+
+    __slots__ = ("_node_name", "addr", "type")
+    NODE_TYPE = ""
+
+    def __init__(
+        self,
+        *,
+        name: str | None,
+        addr: str | int,
+        node_type: str | None = None,
+    ) -> None:
+        """Initialise a node with normalised metadata."""
+
+        resolved_type = normalize_node_type(
+            node_type,
+            default=self.NODE_TYPE,
+            use_default_when_falsey=True,
+        )
+        if not resolved_type:
+            msg = "node_type must be provided"
+            raise ValueError(msg)
+
+        addr_str = normalize_node_addr(addr)
+        if not addr_str:
+            msg = "addr must be provided"
+            raise ValueError(msg)
+
+        self.addr = addr_str
+        self.type = resolved_type
+        self._node_name = ""
+        self.name = name if name is not None else ""
+
+    @property
+    def name(self) -> str:
+        """Return the friendly name for the node."""
+
+        attr_name = getattr(self, "_attr_name", None)
+        if isinstance(attr_name, str) and attr_name.strip():
+            return attr_name
+        return self._node_name
+
+    @name.setter
+    def name(self, value: str | None) -> None:
+        """Update the stored friendly name for the node."""
+        cleaned = str(value or "").strip()
+        self._node_name = cleaned
+        if hasattr(self, "_attr_name"):
+            self._attr_name = cleaned
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of core node metadata."""
+
+        return {
+            "name": self.name,
+            "addr": self.addr,
+            "type": self.type,
+        }
+
+
+NodeDescriptor = Node | tuple[str, str | int]
+
+
+class HeaterNode(Node):
+    """Heater node (type ``htr``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "htr"
+
+    def __init__(self, *, name: str | None, addr: str | int) -> None:
+        """Initialise a heater node."""
+
+        super().__init__(name=name, addr=addr)
+
+    def supports_boost(self) -> bool:
+        """Return whether the node natively exposes boost/runback control."""
+
+        return False
+
+
+class AccumulatorNode(HeaterNode):
+    """Storage heater / accumulator node (type ``acm``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "acm"
+
+    def supports_boost(self) -> bool:
+        """Return whether the accumulator exposes boost/runback."""
+
+        return True
+
+
+class PowerMonitorNode(Node):
+    """Power monitor node (type ``pmo``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "pmo"
+
+    def __init__(self, *, name: str | None, addr: str | int) -> None:
+        """Initialise a power monitor node."""
+
+        super().__init__(name=name, addr=addr)
+
+    def power_level(self) -> float:
+        """Return the reported power level (stub)."""
+
+        raise NotImplementedError
+
+
+class ThermostatNode(Node):
+    """Thermostat node (type ``thm``)."""
+
+    __slots__ = ()
+    NODE_TYPE = "thm"
+
+    def __init__(self, *, name: str | None, addr: str | int) -> None:
+        """Initialise a thermostat node."""
+
+        super().__init__(name=name, addr=addr)
+
+    def capabilities(self) -> dict[str, Any]:
+        """Return thermostat capabilities (stub)."""
+
+        raise NotImplementedError
+
+
+NODE_CLASS_BY_TYPE: dict[str, type[Node]] = {
+    HeaterNode.NODE_TYPE: HeaterNode,
+    AccumulatorNode.NODE_TYPE: AccumulatorNode,
+    PowerMonitorNode.NODE_TYPE: PowerMonitorNode,
+    ThermostatNode.NODE_TYPE: ThermostatNode,
+}

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -1,4 +1,4 @@
-"""Node model abstractions and helpers for TermoWeb devices."""
+"""Node helpers for TermoWeb devices."""
 
 from __future__ import annotations
 
@@ -7,76 +7,18 @@ import logging
 from typing import Any, cast
 
 from .const import DOMAIN
+from .inventory import (
+    AccumulatorNode,
+    HeaterNode,
+    NODE_CLASS_BY_TYPE,
+    Node,
+    PowerMonitorNode,
+    ThermostatNode,
+    normalize_node_addr,
+    normalize_node_type,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _normalize_node_identifier(
-    value: Any,
-    *,
-    default: str = "",
-    use_default_when_falsey: bool = False,
-    lowercase: bool,
-) -> str:
-    """Return ``value`` as a normalised node identifier string."""
-
-    raw = value
-    if use_default_when_falsey and not raw:
-        raw = default
-
-    try:
-        normalized = str(raw).strip()
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-        normalized = ""
-    else:
-        if lowercase:
-            normalized = normalized.lower()
-
-    if normalized:
-        return normalized
-
-    if default and not use_default_when_falsey:
-        try:
-            normalized_default = str(default).strip()
-        except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-            return ""
-        if lowercase:
-            normalized_default = normalized_default.lower()
-        return normalized_default
-
-    return ""
-
-
-def normalize_node_type(
-    value: Any,
-    *,
-    default: str = "",
-    use_default_when_falsey: bool = False,
-) -> str:
-    """Return ``value`` as a normalised node type string."""
-
-    return _normalize_node_identifier(
-        value,
-        default=default,
-        use_default_when_falsey=use_default_when_falsey,
-        lowercase=True,
-    )
-
-
-def normalize_node_addr(
-    value: Any,
-    *,
-    default: str = "",
-    use_default_when_falsey: bool = False,
-) -> str:
-    """Return ``value`` as a normalised node address string."""
-
-    return _normalize_node_identifier(
-        value,
-        default=default,
-        use_default_when_falsey=use_default_when_falsey,
-        lowercase=False,
-    )
 
 
 HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
@@ -215,139 +157,6 @@ def _extract_snapshot_name(payloads: Iterable[Mapping[str, Any]]) -> str:
     return ""
 
 
-class Node:
-    """Base representation of a TermoWeb node."""
-
-    __slots__ = ("_node_name", "addr", "type")
-    NODE_TYPE = ""
-
-    def __init__(
-        self,
-        *,
-        name: str | None,
-        addr: str | int,
-        node_type: str | None = None,
-    ) -> None:
-        """Initialise a node with normalised metadata."""
-
-        resolved_type = normalize_node_type(
-            node_type,
-            default=self.NODE_TYPE,
-            use_default_when_falsey=True,
-        )
-        if not resolved_type:
-            msg = "node_type must be provided"
-            raise ValueError(msg)
-
-        addr_str = normalize_node_addr(addr)
-        if not addr_str:
-            msg = "addr must be provided"
-            raise ValueError(msg)
-
-        self.addr = addr_str
-        self.type = resolved_type
-        self._node_name = ""
-        self.name = name if name is not None else ""
-
-    @property
-    def name(self) -> str:
-        """Return the friendly name for the node."""
-
-        attr_name = getattr(self, "_attr_name", None)
-        if isinstance(attr_name, str) and attr_name.strip():
-            return attr_name
-        return self._node_name
-
-    @name.setter
-    def name(self, value: str | None) -> None:
-        """Update the stored friendly name for the node."""
-        cleaned = str(value or "").strip()
-        self._node_name = cleaned
-        if hasattr(self, "_attr_name"):
-            self._attr_name = cleaned
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a serialisable snapshot of core node metadata."""
-
-        return {
-            "name": self.name,
-            "addr": self.addr,
-            "type": self.type,
-        }
-
-
-NodeDescriptor = Node | tuple[str, str | int]
-
-
-class HeaterNode(Node):
-    """Heater node (type ``htr``)."""
-
-    __slots__ = ()
-    NODE_TYPE = "htr"
-
-    def __init__(self, *, name: str | None, addr: str | int) -> None:
-        """Initialise a heater node."""
-
-        super().__init__(name=name, addr=addr)
-
-    def supports_boost(self) -> bool:
-        """Return whether the node natively exposes boost/runback control."""
-
-        return False
-
-
-class AccumulatorNode(HeaterNode):
-    """Storage heater / accumulator node (type ``acm``)."""
-
-    __slots__ = ()
-    NODE_TYPE = "acm"
-
-    def supports_boost(self) -> bool:
-        """Return whether the accumulator exposes boost/runback."""
-
-        return True
-
-
-class PowerMonitorNode(Node):
-    """Power monitor node (type ``pmo``)."""
-
-    __slots__ = ()
-    NODE_TYPE = "pmo"
-
-    def __init__(self, *, name: str | None, addr: str | int) -> None:
-        """Initialise a power monitor node."""
-
-        super().__init__(name=name, addr=addr)
-
-    def power_level(self) -> float:
-        """Return the reported power level (stub)."""
-
-        raise NotImplementedError
-
-
-class ThermostatNode(Node):
-    """Thermostat node (type ``thm``)."""
-
-    __slots__ = ()
-    NODE_TYPE = "thm"
-
-    def __init__(self, *, name: str | None, addr: str | int) -> None:
-        """Initialise a thermostat node."""
-
-        super().__init__(name=name, addr=addr)
-
-    def capabilities(self) -> dict[str, Any]:
-        """Return thermostat capabilities (stub)."""
-
-        raise NotImplementedError
-
-
-NODE_CLASS_BY_TYPE: dict[str, type[Node]] = {
-    HeaterNode.NODE_TYPE: HeaterNode,
-    AccumulatorNode.NODE_TYPE: AccumulatorNode,
-    PowerMonitorNode.NODE_TYPE: PowerMonitorNode,
-    ThermostatNode.NODE_TYPE: ThermostatNode,
-}
 
 
 def _iter_node_payload(raw_nodes: Any) -> Iterable[dict[str, Any]]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ from custom_components.termoweb.const import (
     get_brand_requested_with,
     get_brand_user_agent,
 )
-from custom_components.termoweb.nodes import AccumulatorNode
+from custom_components.termoweb.inventory import AccumulatorNode
 
 RESTClient = api.RESTClient
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -24,7 +24,8 @@ from custom_components.termoweb.const import (
     DOMAIN,
     signal_ws_data,
 )
-from custom_components.termoweb.nodes import HeaterNode, build_node_inventory
+from custom_components.termoweb.inventory import HeaterNode
+from custom_components.termoweb.nodes import build_node_inventory
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,7 +12,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.termoweb import boost as boost_module, coordinator as coord_module
-from custom_components.termoweb.nodes import AccumulatorNode, HeaterNode
+from custom_components.termoweb.inventory import AccumulatorNode, HeaterNode
 
 
 def test_coerce_int_variants() -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -31,7 +31,7 @@ sys.modules["homeassistant.components.diagnostics"] = diagnostics_stub
 from custom_components.termoweb.const import BRAND_DUCAHEAT, CONF_BRAND, DOMAIN
 from custom_components.termoweb.diagnostics import async_get_config_entry_diagnostics
 from custom_components.termoweb.installation import InstallationSnapshot
-from custom_components.termoweb.nodes import Node
+from custom_components.termoweb.inventory import Node
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -16,10 +16,8 @@ from custom_components.termoweb import identifiers as identifiers_module
 from custom_components.termoweb import installation as installation_module
 from custom_components.termoweb.installation import InstallationSnapshot
 from custom_components.termoweb.heater_inventory import build_heater_inventory_details
-from custom_components.termoweb.nodes import (
-    HeaterNode,
-    build_node_inventory,
-)
+from custom_components.termoweb.inventory import HeaterNode
+from custom_components.termoweb.nodes import build_node_inventory
 from homeassistant.core import HomeAssistant
 
 HeaterNodeBase = heater_module.HeaterNodeBase

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -17,16 +17,18 @@ _install_stubs()
 import custom_components.termoweb.coordinator as coordinator_module
 import custom_components.termoweb.installation as installation_module
 import custom_components.termoweb.nodes as nodes_module
-from custom_components.termoweb.nodes import (
+from custom_components.termoweb.inventory import (
     AccumulatorNode,
     HeaterNode,
     Node,
     PowerMonitorNode,
     ThermostatNode,
-    build_node_inventory,
-    heater_sample_subscription_targets,
     normalize_node_addr,
     normalize_node_type,
+)
+from custom_components.termoweb.nodes import (
+    build_node_inventory,
+    heater_sample_subscription_targets,
     _existing_nodes_map,
 )
 from homeassistant.core import HomeAssistant

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,9 @@ from typing import Any
 
 import pytest
 
-from custom_components.termoweb import nodes as nodes_module
+from custom_components.termoweb import inventory as inventory_module, nodes as nodes_module
 from custom_components.termoweb.const import DOMAIN
+import custom_components.termoweb.identifiers as identifiers_module
 from custom_components.termoweb.identifiers import build_heater_energy_unique_id
 from custom_components.termoweb.nodes import (
     HEATER_NODE_TYPES,
@@ -14,9 +15,11 @@ from custom_components.termoweb.nodes import (
     build_node_inventory,
     ensure_node_inventory,
     normalize_heater_addresses,
+    parse_heater_energy_unique_id,
+)
+from custom_components.termoweb.inventory import (
     normalize_node_addr,
     normalize_node_type,
-    parse_heater_energy_unique_id,
 )
 from custom_components.termoweb.utils import (
     _entry_gateway_record,
@@ -283,8 +286,8 @@ def test_build_heater_energy_unique_id_round_trip(
 ) -> None:
     calls: list[tuple[str, object, dict[str, Any]]] = []
 
-    original_normalize_type = nodes_module.normalize_node_type
-    original_normalize_addr = nodes_module.normalize_node_addr
+    original_normalize_type = inventory_module.normalize_node_type
+    original_normalize_addr = inventory_module.normalize_node_addr
 
     def _record_type(value, **kwargs):
         calls.append(("type", value, kwargs))
@@ -294,6 +297,10 @@ def test_build_heater_energy_unique_id_round_trip(
         calls.append(("addr", value, kwargs))
         return original_normalize_addr(value, **kwargs)
 
+    monkeypatch.setattr(inventory_module, "normalize_node_type", _record_type)
+    monkeypatch.setattr(inventory_module, "normalize_node_addr", _record_addr)
+    monkeypatch.setattr(identifiers_module, "normalize_node_type", _record_type)
+    monkeypatch.setattr(identifiers_module, "normalize_node_addr", _record_addr)
     monkeypatch.setattr(nodes_module, "normalize_node_type", _record_type)
     monkeypatch.setattr(nodes_module, "normalize_node_addr", _record_addr)
 


### PR DESCRIPTION
## Summary
- move the node normalizers and model classes into `inventory.py` and re-export them for reuse
- update integration modules and identifiers to import from the new inventory location while keeping `nodes.py` focused on discovery helpers
- adjust unit tests to cover the relocated helpers and ensure the new import path is exercised

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6cc9024bc8329a5be6b77b5b72359