### PR TITLE
Refactor node inventory helpers into inventory module

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -41,7 +41,7 @@ from .energy import (
     reset_samples_rate_limit_state,
 )
 from .installation import InstallationSnapshot
-from .nodes import build_node_inventory
+from .inventory import build_node_inventory
 from .utils import async_get_integration_version as _async_get_integration_version
 
 try:  # pragma: no cover - fallback for test stubs

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -51,10 +51,13 @@ from custom_components.termoweb.installation import (
     InstallationSnapshot,
     ensure_snapshot,
 )
-from custom_components.termoweb.inventory import normalize_node_addr, normalize_node_type
+from custom_components.termoweb.inventory import (
+    build_node_inventory as _build_node_inventory,
+    normalize_node_addr,
+    normalize_node_type,
+)
 from custom_components.termoweb.nodes import (
     addresses_by_node_type as _addresses_by_node_type,
-    build_node_inventory as _build_node_inventory,
     collect_heater_sample_addresses,
     heater_sample_subscription_targets,
     normalize_heater_addresses,

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -18,13 +18,14 @@ from homeassistant.util import dt as dt_util
 from .api import BackendAuthError, BackendRateLimitError, RESTClient
 from .boost import coerce_int, resolve_boost_end_from_fields
 from .const import HTR_ENERGY_UPDATE_INTERVAL, MIN_POLL_INTERVAL
-from .inventory import Node, normalize_node_addr, normalize_node_type
-from .nodes import (
+from .inventory import (
+    Node,
     _existing_nodes_map,
-    build_heater_address_map,
     build_node_inventory,
-    normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
 )
+from .nodes import build_heater_address_map, normalize_heater_addresses
 from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -23,12 +23,13 @@ from .boost import (
 from .const import DOMAIN, signal_ws_data
 from .heater_inventory import build_heater_inventory_details
 from .installation import InstallationSnapshot, ensure_snapshot
-from .inventory import Node, normalize_node_addr, normalize_node_type
-from .nodes import (
-    HEATER_NODE_TYPES,
+from .inventory import (
+    Node,
     build_node_inventory,
-    ensure_node_inventory,
+    normalize_node_addr,
+    normalize_node_type,
 )
+from .nodes import HEATER_NODE_TYPES, ensure_node_inventory
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -6,12 +6,8 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 from .heater_inventory import HeaterInventoryDetails, build_heater_inventory_details
-from .inventory import Node
-from .nodes import (
-    build_node_inventory,
-    heater_sample_subscription_targets,
-    normalize_heater_addresses,
-)
+from .inventory import Node, build_node_inventory
+from .nodes import heater_sample_subscription_targets, normalize_heater_addresses
 
 
 class InstallationSnapshot:

--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -2,25 +2,48 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Iterable, Tuple
+import logging
+from typing import Any
 
 RawNodePayload = Any
 PrebuiltNode = Any
 
+_NODE_SECTION_IGNORE_KEYS = frozenset(
+    {"dev_id", "name", "raw", "connected", "nodes", "nodes_by_type"}
+)
+
+_SNAPSHOT_NAME_CANDIDATE_KEYS = (
+    "name",
+    "label",
+    "title",
+    "display_name",
+    "device_name",
+    "friendly_name",
+    "heater_name",
+    "alias",
+    "room",
+)
+
+
 __all__ = [
-    "Inventory",
-    "_normalize_node_identifier",
-    "normalize_node_type",
-    "normalize_node_addr",
-    "Node",
-    "HeaterNode",
+    "NODE_CLASS_BY_TYPE",
     "AccumulatorNode",
+    "HeaterNode",
+    "Inventory",
+    "Node",
+    "NodeDescriptor",
     "PowerMonitorNode",
     "ThermostatNode",
-    "NODE_CLASS_BY_TYPE",
-    "NodeDescriptor",
+    "_normalize_node_identifier",
+    "build_node_inventory",
+    "normalize_node_addr",
+    "normalize_node_type",
 ]
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,7 +52,7 @@ class Inventory:
 
     _dev_id: str
     _payload: RawNodePayload
-    _nodes: Tuple[PrebuiltNode, ...]
+    _nodes: tuple[PrebuiltNode, ...]
 
     def __init__(
         self,
@@ -56,7 +79,7 @@ class Inventory:
         return self._payload
 
     @property
-    def nodes(self) -> Tuple[PrebuiltNode, ...]:
+    def nodes(self) -> tuple[PrebuiltNode, ...]:
         """Get the immutable tuple of node objects."""
 
         return self._nodes
@@ -263,3 +286,215 @@ NODE_CLASS_BY_TYPE: dict[str, type[Node]] = {
     PowerMonitorNode.NODE_TYPE: PowerMonitorNode,
     ThermostatNode.NODE_TYPE: ThermostatNode,
 }
+
+
+def _existing_nodes_map(source: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """Return a mapping of node type sections extracted from ``source``."""
+
+    if not isinstance(source, Mapping):
+        return {}
+
+    sections: dict[str, dict[str, Any]] = {}
+
+    raw_existing = source.get("nodes_by_type")
+    if isinstance(raw_existing, Mapping):
+        for node_type, section in raw_existing.items():
+            if isinstance(section, Mapping):
+                sections[node_type] = dict(section)
+
+    for key, value in source.items():
+        if key in _NODE_SECTION_IGNORE_KEYS:
+            continue
+        if isinstance(value, Mapping):
+            sections.setdefault(key, dict(value))
+
+    return sections
+
+
+def _iter_snapshot_sections(
+    sections: Mapping[str, Any],
+    seen: set[tuple[str, str]],
+) -> Iterable[dict[str, Any]]:
+    """Yield node payloads derived from snapshot-style ``sections``."""
+
+    for node_type, payload in sections.items():
+        if not isinstance(node_type, str):
+            continue
+        normalized_type = node_type.strip()
+        if not normalized_type or not isinstance(payload, Mapping):
+            continue
+        for entry in _iter_snapshot_section(normalized_type, payload):
+            addr = entry.get("addr")
+            if not isinstance(addr, str):
+                continue
+            key = (normalized_type, addr)
+            if key in seen:
+                continue
+            seen.add(key)
+            yield entry
+
+
+def _iter_snapshot_section(
+    node_type: str, section: Mapping[str, Any]
+) -> Iterable[dict[str, Any]]:
+    """Yield node dictionaries for a single node type section."""
+
+    addresses = _collect_snapshot_addresses(section)
+    for addr in sorted(addresses):
+        entry: dict[str, Any] = {"type": node_type, "addr": addr}
+        name = _extract_snapshot_name(addresses[addr])
+        if name:
+            entry["name"] = name
+        yield entry
+
+
+def _collect_snapshot_addresses(
+    section: Mapping[str, Any]
+) -> dict[str, list[Mapping[str, Any]]]:
+    """Return mapping of addresses to candidate payloads from ``section``."""
+
+    addresses: dict[str, list[Mapping[str, Any]]] = {}
+
+    addrs = section.get("addrs")
+    if isinstance(addrs, (list, tuple, set)):
+        for candidate in addrs:
+            addr = normalize_node_addr(candidate)
+            if addr:
+                addresses.setdefault(addr, [])
+
+    for value in section.values():
+        if not isinstance(value, Mapping):
+            continue
+        for addr_key, payload in value.items():
+            addr = normalize_node_addr(addr_key)
+            if not addr:
+                continue
+            bucket = addresses.setdefault(addr, [])
+            if isinstance(payload, Mapping):
+                bucket.append(payload)
+            elif isinstance(payload, str):
+                bucket.append({"name": payload})
+
+    return addresses
+
+
+def _extract_snapshot_name(payloads: Iterable[Mapping[str, Any]]) -> str:
+    """Return best candidate name extracted from ``payloads``."""
+
+    queue = [payload for payload in payloads if isinstance(payload, Mapping)]
+    seen: set[int] = set()
+
+    while queue:
+        payload = queue.pop(0)
+        payload_id = id(payload)
+        if payload_id in seen:
+            continue
+        seen.add(payload_id)
+
+        for key in _SNAPSHOT_NAME_CANDIDATE_KEYS:
+            value = payload.get(key)
+            if isinstance(value, str):
+                candidate = value.strip()
+                if candidate:
+                    return candidate
+
+        queue.extend(
+            nested for nested in payload.values() if isinstance(nested, Mapping)
+        )
+
+    return ""
+
+
+def _iter_node_payload(raw_nodes: Any) -> Iterable[dict[str, Any]]:
+    """Yield node dictionaries from a payload returned by the API."""
+
+    if isinstance(raw_nodes, dict):
+        node_list = raw_nodes.get("nodes")
+        if isinstance(node_list, list):
+            for entry in node_list:
+                if isinstance(entry, dict):
+                    yield entry
+            return
+
+        seen: set[tuple[str, str]] = set()
+
+        if isinstance(node_list, dict):
+            yield from _iter_snapshot_sections(node_list, seen)
+
+        sections = _existing_nodes_map(raw_nodes)
+        if sections:
+            yield from _iter_snapshot_sections(sections, seen)
+            if seen:
+                return
+
+    if isinstance(raw_nodes, list):
+        for entry in raw_nodes:
+            if isinstance(entry, dict):
+                yield entry
+
+
+def _resolve_node_class(node_type: str) -> type[Node]:
+    """Return the most appropriate node class for ``node_type``."""
+
+    return NODE_CLASS_BY_TYPE.get(node_type, Node)
+
+
+def _normalise_with_fallback(
+    normalizer: Callable[..., str],
+    *candidates: Any,
+) -> str:
+    """Return the first non-empty normalised value from ``candidates``."""
+
+    for candidate in candidates:
+        normalized = normalizer(candidate, use_default_when_falsey=True)
+        if normalized:
+            return normalized
+    return ""
+
+
+def build_node_inventory(raw_nodes: Any) -> list[Node]:
+    """Return a list of :class:`Node` instances for the provided payload."""
+
+    inventory: list[Node] = []
+    for index, payload in enumerate(_iter_node_payload(raw_nodes)):
+        node_type = _normalise_with_fallback(
+            normalize_node_type,
+            payload.get("type"),
+            payload.get("node_type"),
+        )
+        if not node_type:
+            _LOGGER.debug(
+                "Skipping node with missing type at index %s: %s",
+                index,
+                payload,
+            )
+            continue
+
+        name = payload.get("name") or payload.get("title") or payload.get("label")
+        addr = _normalise_with_fallback(
+            normalize_node_addr,
+            payload.get("addr"),
+            payload.get("address"),
+        )
+
+        node_cls = _resolve_node_class(node_type)
+        if node_cls is Node:
+            _LOGGER.debug("Unsupported node type '%s' encountered", node_type)
+
+        try:
+            if node_cls is Node:
+                node = node_cls(name=name, addr=addr, node_type=node_type)
+            else:
+                node = node_cls(name=name, addr=addr)
+        except (TypeError, ValueError) as err:  # pragma: no cover - defensive
+            _LOGGER.debug(
+                "Failed to initialise node %s at index %s: %s",
+                payload,
+                index,
+                err,
+            )
+            continue
+
+        inventory.append(node)
+
+    return inventory

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -25,7 +25,7 @@ from custom_components.termoweb.const import (
     signal_ws_data,
 )
 from custom_components.termoweb.inventory import HeaterNode
-from custom_components.termoweb.nodes import build_node_inventory
+from custom_components.termoweb.inventory import build_node_inventory
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -17,7 +17,7 @@ from custom_components.termoweb import installation as installation_module
 from custom_components.termoweb.installation import InstallationSnapshot
 from custom_components.termoweb.heater_inventory import build_heater_inventory_details
 from custom_components.termoweb.inventory import HeaterNode
-from custom_components.termoweb.nodes import build_node_inventory
+from custom_components.termoweb.inventory import build_node_inventory
 from homeassistant.core import HomeAssistant
 
 HeaterNodeBase = heater_module.HeaterNodeBase

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -18,7 +18,7 @@ from custom_components.termoweb import coordinator as coordinator_module
 from custom_components.termoweb import sensor as sensor_module
 from custom_components.termoweb import const as const_module
 from custom_components.termoweb.identifiers import build_heater_energy_unique_id
-from custom_components.termoweb.nodes import build_node_inventory
+from custom_components.termoweb.inventory import build_node_inventory
 from custom_components.termoweb.utils import build_gateway_device_info
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfTemperature

--- a/tests/test_installation_snapshot.py
+++ b/tests/test_installation_snapshot.py
@@ -5,12 +5,10 @@ from typing import Any
 
 import pytest
 
-from custom_components.termoweb.installation import InstallationSnapshot, ensure_snapshot
 from custom_components.termoweb.heater_inventory import build_heater_inventory_details
-from custom_components.termoweb.nodes import (
-    build_node_inventory,
-    heater_sample_subscription_targets,
-)
+from custom_components.termoweb.installation import InstallationSnapshot, ensure_snapshot
+from custom_components.termoweb.inventory import build_node_inventory
+from custom_components.termoweb.nodes import heater_sample_subscription_targets
 
 
 def _make_snapshot(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -16,9 +16,12 @@ _install_stubs()
 
 import custom_components.termoweb.coordinator as coordinator_module
 import custom_components.termoweb.installation as installation_module
+import custom_components.termoweb.inventory as inventory_module
 import custom_components.termoweb.nodes as nodes_module
 from custom_components.termoweb.inventory import (
     AccumulatorNode,
+    _existing_nodes_map,
+    build_node_inventory,
     HeaterNode,
     Node,
     PowerMonitorNode,
@@ -26,11 +29,7 @@ from custom_components.termoweb.inventory import (
     normalize_node_addr,
     normalize_node_type,
 )
-from custom_components.termoweb.nodes import (
-    build_node_inventory,
-    heater_sample_subscription_targets,
-    _existing_nodes_map,
-)
+from custom_components.termoweb.nodes import heater_sample_subscription_targets
 from homeassistant.core import HomeAssistant
 
 
@@ -198,12 +197,12 @@ def test_iter_snapshot_sections_skips_invalid_entries(
     }
 
     monkeypatch.setattr(
-        nodes_module,
+        inventory_module,
         "_iter_snapshot_section",
         lambda node_type, section: ({"addr": 5}, {"addr": None}),
     )
 
-    assert list(nodes_module._iter_snapshot_sections(sections, seen)) == []
+    assert list(inventory_module._iter_snapshot_sections(sections, seen)) == []
 
 
 def test_collect_snapshot_addresses_handles_mixed_values() -> None:
@@ -213,7 +212,7 @@ def test_collect_snapshot_addresses_handles_mixed_values() -> None:
         "extra": {"2": {"label": "Garage"}, "3": "Loft"},
     }
 
-    addresses = nodes_module._collect_snapshot_addresses(section)
+    addresses = inventory_module._collect_snapshot_addresses(section)
 
     assert sorted(addresses) == ["1", "2", "3", "None"]
     assert addresses["1"][0]["name"] == "Living"
@@ -226,7 +225,7 @@ def test_extract_snapshot_name_handles_repeated_payloads() -> None:
     shared: dict[str, Any] = {}
     payloads = [shared, shared, {"title": "Kitchen"}]
 
-    result = nodes_module._extract_snapshot_name(payloads)
+    result = inventory_module._extract_snapshot_name(payloads)
 
     assert result == "Kitchen"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,12 +12,12 @@ from custom_components.termoweb.identifiers import build_heater_energy_unique_id
 from custom_components.termoweb.nodes import (
     HEATER_NODE_TYPES,
     addresses_by_node_type,
-    build_node_inventory,
     ensure_node_inventory,
     normalize_heater_addresses,
     parse_heater_energy_unique_id,
 )
 from custom_components.termoweb.inventory import (
+    build_node_inventory,
     normalize_node_addr,
     normalize_node_type,
 )


### PR DESCRIPTION
## Summary
- move the node inventory builder and snapshot helpers into `custom_components.termoweb.inventory`
- update integration code and websocket exports to consume the shared inventory helpers
- refresh unit tests to build inventories through the new module for success and failure paths

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e6d0d6cbb883299d23782b044c11fc