### PR TITLE
Set diagnostics support flag during TermoWeb setup

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -12,7 +12,12 @@ import logging
 from typing import Any
 
 from aiohttp import ClientError
-from homeassistant.config_entries import ConfigEntry
+try:  # pragma: no cover - compatibility shim for older Home Assistant cores
+    from homeassistant.config_entries import ConfigEntry, SupportsDiagnostics
+except ImportError:  # pragma: no cover - tests provide stubbed config entries
+    from homeassistant.config_entries import ConfigEntry  # type: ignore[misc]
+
+    SupportsDiagnostics = None  # type: ignore[assignment]
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
@@ -119,6 +124,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
     brand = entry.data.get(CONF_BRAND, DEFAULT_BRAND)
 
     await _async_ensure_diagnostics_platform(hass)
+
+    if SupportsDiagnostics is not None and hasattr(entry, "supports_diagnostics"):
+        entry.supports_diagnostics = SupportsDiagnostics.YES
 
     version = await _async_get_integration_version(hass)
 


### PR DESCRIPTION
## Summary
- set the config entry diagnostics support flag when the Home Assistant core exposes it
- add a diagnostics-aware config entry stub and test to verify the flag assignment during setup

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6d671592883298e34b6147c5d7c54