### PR TITLE
Move heater helpers into inventory module

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -27,12 +27,13 @@ from ..const import (
     get_brand_requested_with,
     get_brand_user_agent,
 )
-from ..inventory import normalize_node_addr, normalize_node_type
-from ..nodes import (
-    collect_heater_sample_addresses,
+from ..inventory import (
     heater_sample_subscription_targets,
     normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
 )
+from ..nodes import collect_heater_sample_addresses
 from .ws_client import (
     DUCAHEAT_NAMESPACE,
     HandshakeError,

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -52,16 +52,14 @@ from custom_components.termoweb.installation import (
     ensure_snapshot,
 )
 from custom_components.termoweb.inventory import (
+    addresses_by_node_type as _addresses_by_node_type,
     build_node_inventory as _build_node_inventory,
+    heater_sample_subscription_targets,
+    normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
 )
-from custom_components.termoweb.nodes import (
-    addresses_by_node_type as _addresses_by_node_type,
-    collect_heater_sample_addresses,
-    heater_sample_subscription_targets,
-    normalize_heater_addresses,
-)
+from custom_components.termoweb.nodes import collect_heater_sample_addresses
 from .ws_client import (
     WSStats,
     _WSStatusMixin,

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -36,14 +36,15 @@ from ..const import (
     signal_ws_status,
 )
 from ..installation import InstallationSnapshot, ensure_snapshot
-from ..inventory import NODE_CLASS_BY_TYPE, normalize_node_addr, normalize_node_type
-from ..nodes import (
+from ..inventory import (
+    NODE_CLASS_BY_TYPE,
     addresses_by_node_type,
-    collect_heater_sample_addresses,
-    ensure_node_inventory,
     heater_sample_subscription_targets,
     normalize_heater_addresses,
+    normalize_node_addr,
+    normalize_node_type,
 )
+from ..nodes import collect_heater_sample_addresses, ensure_node_inventory
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .ducaheat_ws import DucaheatWSClient

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -21,11 +21,12 @@ from .const import HTR_ENERGY_UPDATE_INTERVAL, MIN_POLL_INTERVAL
 from .inventory import (
     Node,
     _existing_nodes_map,
+    build_heater_address_map,
     build_node_inventory,
+    normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
 )
-from .nodes import build_heater_address_map, normalize_heater_addresses
 from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -18,12 +18,12 @@ from .api import RESTClient
 from .const import DOMAIN
 from .identifiers import build_heater_energy_unique_id
 from .installation import ensure_snapshot
-from .nodes import (
+from .inventory import (
     build_heater_address_map,
-    ensure_node_inventory,
     normalize_heater_addresses,
     parse_heater_energy_unique_id,
 )
+from .nodes import ensure_node_inventory
 from .throttle import (
     MonotonicRateLimiter,
     default_samples_rate_limit_state,

--- a/custom_components/termoweb/heater_inventory.py
+++ b/custom_components/termoweb/heater_inventory.py
@@ -6,8 +6,13 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from .inventory import Node, normalize_node_addr, normalize_node_type
-from .nodes import HEATER_NODE_TYPES, build_heater_address_map
+from .inventory import (
+    Node,
+    build_heater_address_map,
+    normalize_node_addr,
+    normalize_node_type,
+)
+from .nodes import HEATER_NODE_TYPES
 
 
 @dataclass(slots=True)

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -6,8 +6,12 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 from .heater_inventory import HeaterInventoryDetails, build_heater_inventory_details
-from .inventory import Node, build_node_inventory
-from .nodes import heater_sample_subscription_targets, normalize_heater_addresses
+from .inventory import (
+    Node,
+    build_node_inventory,
+    heater_sample_subscription_targets,
+    normalize_heater_addresses,
+)
 
 
 class InstallationSnapshot:

--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
+from .const import DOMAIN
+
 RawNodePayload = Any
 PrebuiltNode = Any
 
@@ -31,11 +33,17 @@ __all__ = [
     "NODE_CLASS_BY_TYPE",
     "AccumulatorNode",
     "HeaterNode",
+    "HEATER_NODE_TYPES",
     "Inventory",
     "Node",
     "NodeDescriptor",
     "PowerMonitorNode",
     "ThermostatNode",
+    "addresses_by_node_type",
+    "build_heater_address_map",
+    "heater_sample_subscription_targets",
+    "normalize_heater_addresses",
+    "parse_heater_energy_unique_id",
     "_normalize_node_identifier",
     "build_node_inventory",
     "normalize_node_addr",
@@ -44,6 +52,9 @@ __all__ = [
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,6 +162,171 @@ def normalize_node_addr(
         use_default_when_falsey=use_default_when_falsey,
         lowercase=False,
     )
+
+
+def parse_heater_energy_unique_id(unique_id: str) -> tuple[str, str, str] | None:
+    """Parse a heater energy sensor unique ID into its components."""
+
+    if not isinstance(unique_id, str):
+        return None
+    stripped = unique_id.strip()
+    if not stripped or not stripped.startswith(f"{DOMAIN}:"):
+        return None
+    try:
+        domain, dev, node, address, metric = stripped.split(":", 4)
+    except ValueError:
+        return None
+    if domain != DOMAIN or metric != "energy":
+        return None
+    if not dev or not node or not address:
+        return None
+    return dev, node, address
+
+
+def addresses_by_node_type(
+    nodes: Iterable[Node],
+    *,
+    known_types: Iterable[str] | None = None,
+) -> tuple[dict[str, list[str]], set[str]]:
+    """Return mapping of node type to address list, tracking unknown types."""
+
+    known: set[str] | None = None
+    if known_types is not None:
+        known = {normalize_node_type(node_type) for node_type in known_types if node_type}
+
+    result: dict[str, list[str]] = {}
+    seen: dict[str, set[str]] = {}
+    unknown: set[str] = set()
+
+    for node in nodes:
+        node_type = normalize_node_type(getattr(node, "type", ""))
+        if not node_type:
+            continue
+        addr = normalize_node_addr(getattr(node, "addr", ""))
+        if not addr:
+            continue
+        type_seen = seen.setdefault(node_type, set())
+        if addr in type_seen:
+            continue
+        type_seen.add(addr)
+        result.setdefault(node_type, []).append(addr)
+        if known is not None and node_type not in known:
+            unknown.add(node_type)
+
+    return result, unknown
+
+
+def build_heater_address_map(
+    nodes: Iterable[Any],
+    *,
+    heater_types: Iterable[str] | None = None,
+) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
+    """Return mapping of heater node types to addresses and reverse lookup."""
+
+    allowed_types: set[str]
+    if heater_types is None:
+        allowed_types = set(HEATER_NODE_TYPES)
+    else:
+        allowed_types = {
+            normalize_node_type(node_type, use_default_when_falsey=True)
+            for node_type in heater_types
+            if normalize_node_type(node_type, use_default_when_falsey=True)
+        }  # pragma: no cover - exercised indirectly in integration
+
+    if not allowed_types:
+        return {}, {}  # pragma: no cover - defensive
+
+    by_type_raw, _ = addresses_by_node_type(
+        nodes,
+        known_types=allowed_types,
+    )  # pragma: no cover - exercised via higher level integration tests
+
+    by_type: dict[str, list[str]] = {
+        node_type: list(addresses)
+        for node_type, addresses in by_type_raw.items()
+        if node_type in allowed_types and addresses
+    }
+
+    reverse: dict[str, set[str]] = {}
+    for node_type, addresses in by_type.items():
+        for address in addresses:
+            reverse.setdefault(address, set()).add(node_type)
+
+    return by_type, reverse
+
+
+def normalize_heater_addresses(
+    addrs: Iterable[Any] | Mapping[Any, Iterable[Any]] | None,
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    """Return canonical heater addresses and compatibility aliases."""
+
+    cleaned_map: dict[str, list[str]] = {}
+    compat_aliases: dict[str, str] = {}
+
+    if addrs is None:
+        sources: Iterable[tuple[Any, Iterable[Any] | Any]] = []
+    elif isinstance(addrs, Mapping):
+        sources = addrs.items()
+    else:
+        sources = [("htr", addrs)]
+
+    for raw_type, values in sources:
+        node_type = normalize_node_type(
+            raw_type,
+            use_default_when_falsey=True,
+        )
+        if not node_type:
+            continue
+
+        alias_target: str | None = None
+        if node_type in {"heater", "heaters", "htr"}:
+            alias_target = "htr"
+        if alias_target is not None and node_type != alias_target:
+            compat_aliases[node_type] = alias_target
+            node_type = alias_target
+
+        if node_type not in HEATER_NODE_TYPES:
+            continue
+
+        if isinstance(values, str) or not isinstance(values, Iterable):
+            candidates = [values]
+        else:
+            candidates = list(values)
+
+        bucket = cleaned_map.setdefault(node_type, [])
+        seen: set[str] = set(bucket)
+        for candidate in candidates:
+            addr = normalize_node_addr(
+                candidate,
+                use_default_when_falsey=True,
+            )
+            if not addr or addr in seen:
+                continue
+            seen.add(addr)
+            bucket.append(addr)
+
+    cleaned_map.setdefault("htr", [])
+    compat_aliases["htr"] = "htr"
+
+    return cleaned_map, compat_aliases
+
+
+def heater_sample_subscription_targets(
+    addrs: Mapping[Any, Iterable[Any]] | Iterable[Any] | None,
+) -> list[tuple[str, str]]:
+    """Return canonical heater sample subscription target pairs."""
+
+    normalized_map, _ = normalize_heater_addresses(addrs)
+    if not any(normalized_map.values()):
+        return []
+
+    other_types = sorted(node_type for node_type in normalized_map if node_type != "htr")
+    order = ["htr", *other_types]
+    return [
+        (node_type, addr)
+        for node_type in order
+        for addr in normalized_map.get(node_type, []) or []
+    ]
 
 
 class Node:

--- a/custom_components/termoweb/nodes.py
+++ b/custom_components/termoweb/nodes.py
@@ -6,18 +6,17 @@ from collections.abc import Iterable, Mapping, MutableMapping
 import logging
 from typing import Any, cast
 
-from .const import DOMAIN
 from .inventory import (
+    HEATER_NODE_TYPES,
     Node,
+    addresses_by_node_type,
     build_node_inventory,
+    normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
 
 
 def ensure_node_inventory(
@@ -78,153 +77,6 @@ def ensure_node_inventory(
     return []
 
 
-def parse_heater_energy_unique_id(unique_id: str) -> tuple[str, str, str] | None:
-    """Parse a heater energy sensor unique ID into its components."""
-
-    if not isinstance(unique_id, str):
-        return None
-    stripped = unique_id.strip()
-    if not stripped or not stripped.startswith(f"{DOMAIN}:"):
-        return None
-    try:
-        domain, dev, node, address, metric = stripped.split(":", 4)
-    except ValueError:
-        return None
-    if domain != DOMAIN or metric != "energy":
-        return None
-    if not dev or not node or not address:
-        return None
-    return dev, node, address
-
-
-def addresses_by_node_type(
-    nodes: Iterable[Node],
-    *,
-    known_types: Iterable[str] | None = None,
-) -> tuple[dict[str, list[str]], set[str]]:
-    """Return mapping of node type to address list, tracking unknown types."""
-
-    known: set[str] | None = None
-    if known_types is not None:
-        known = {normalize_node_type(node_type) for node_type in known_types if node_type}
-
-    result: dict[str, list[str]] = {}
-    seen: dict[str, set[str]] = {}
-    unknown: set[str] = set()
-
-    for node in nodes:
-        node_type = normalize_node_type(getattr(node, "type", ""))
-        if not node_type:
-            continue
-        addr = normalize_node_addr(getattr(node, "addr", ""))
-        if not addr:
-            continue
-        type_seen = seen.setdefault(node_type, set())
-        if addr in type_seen:
-            continue
-        type_seen.add(addr)
-        result.setdefault(node_type, []).append(addr)
-        if known is not None and node_type not in known:
-            unknown.add(node_type)
-
-    return result, unknown
-
-
-def build_heater_address_map(
-    nodes: Iterable[Any],
-    *,
-    heater_types: Iterable[str] | None = None,
-) -> tuple[dict[str, list[str]], dict[str, set[str]]]:
-    """Return mapping of heater node types to addresses and reverse lookup."""
-
-    allowed_types: set[str]
-    if heater_types is None:
-        allowed_types = set(HEATER_NODE_TYPES)
-    else:
-        allowed_types = {
-            normalize_node_type(node_type, use_default_when_falsey=True)
-            for node_type in heater_types
-            if normalize_node_type(node_type, use_default_when_falsey=True)
-        }  # pragma: no cover - exercised indirectly in integration
-
-    if not allowed_types:
-        return {}, {}  # pragma: no cover - defensive
-
-    by_type_raw, _ = addresses_by_node_type(
-        nodes,
-        known_types=allowed_types,
-    )  # pragma: no cover - exercised via higher level integration tests
-
-    by_type: dict[str, list[str]] = {
-        node_type: list(addresses)
-        for node_type, addresses in by_type_raw.items()
-        if node_type in allowed_types and addresses
-    }
-
-    reverse: dict[str, set[str]] = {}
-    for node_type, addresses in by_type.items():
-        for address in addresses:
-            reverse.setdefault(address, set()).add(node_type)
-
-    return by_type, reverse
-
-
-def normalize_heater_addresses(
-    addrs: Iterable[Any] | Mapping[Any, Iterable[Any]] | None,
-) -> tuple[dict[str, list[str]], dict[str, str]]:
-    """Return canonical heater addresses and compatibility aliases."""
-
-    cleaned_map: dict[str, list[str]] = {}
-    compat_aliases: dict[str, str] = {}
-
-    if addrs is None:
-        sources: Iterable[tuple[Any, Iterable[Any] | Any]] = []
-    elif isinstance(addrs, Mapping):
-        sources = addrs.items()
-    else:
-        sources = [("htr", addrs)]
-
-    for raw_type, values in sources:
-        node_type = normalize_node_type(
-            raw_type,
-            use_default_when_falsey=True,
-        )
-        if not node_type:
-            continue
-
-        alias_target: str | None = None
-        if node_type in {"heater", "heaters", "htr"}:
-            alias_target = "htr"
-        if alias_target is not None and node_type != alias_target:
-            compat_aliases[node_type] = alias_target
-            node_type = alias_target
-
-        if node_type not in HEATER_NODE_TYPES:
-            continue
-
-        if isinstance(values, str) or not isinstance(values, Iterable):
-            candidates = [values]
-        else:
-            candidates = list(values)
-
-        bucket = cleaned_map.setdefault(node_type, [])
-        seen: set[str] = set(bucket)
-        for candidate in candidates:
-            addr = normalize_node_addr(
-                candidate,
-                use_default_when_falsey=True,
-            )
-            if not addr or addr in seen:
-                continue
-            seen.add(addr)
-            bucket.append(addr)
-
-    cleaned_map.setdefault("htr", [])
-    compat_aliases["htr"] = "htr"
-
-    return cleaned_map, compat_aliases
-
-
 def collect_heater_sample_addresses(
     record: Mapping[str, Any] | None,
     *,
@@ -283,21 +135,3 @@ def collect_heater_sample_addresses(
                 normalized_map["htr"] = normalised
 
     return list(inventory), normalized_map, compat
-
-
-def heater_sample_subscription_targets(
-    addrs: Mapping[Any, Iterable[Any]] | Iterable[Any] | None,
-) -> list[tuple[str, str]]:
-    """Return canonical heater sample subscription target pairs."""
-
-    normalized_map, _ = normalize_heater_addresses(addrs)
-    if not any(normalized_map.values()):
-        return []
-
-    other_types = sorted(node_type for node_type in normalized_map if node_type != "htr")
-    order = ["htr", *other_types]
-    return [
-        (node_type, addr)
-        for node_type in order
-        for addr in normalized_map.get(node_type, []) or []
-    ]

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -20,7 +20,7 @@ from custom_components.termoweb.const import (
     HTR_ENERGY_UPDATE_INTERVAL,
     signal_ws_data,
 )
-from custom_components.termoweb.nodes import normalize_heater_addresses
+from custom_components.termoweb.inventory import normalize_heater_addresses
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.update_coordinator import UpdateFailed

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -16,8 +16,11 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from custom_components.termoweb import identifiers as identifiers_module
-from custom_components.termoweb import nodes as nodes_module
+from custom_components.termoweb import (
+    identifiers as identifiers_module,
+    inventory as inventory_module,
+    nodes as nodes_module,
+)
 from custom_components.termoweb.installation import InstallationSnapshot
 
 from conftest import _install_stubs
@@ -1797,7 +1800,7 @@ def test_import_energy_history_requested_map_filters(
             )
 
         monkeypatch.setattr(
-            nodes_module, "addresses_by_node_type", fake_addresses_by_node_type
+            inventory_module, "addresses_by_node_type", fake_addresses_by_node_type
         )
 
         original_normalize = energy_mod.normalize_heater_addresses
@@ -1983,7 +1986,7 @@ def test_import_energy_history_resets_requested_progress(
             return ({"pmo": ["X"]}, set())
 
         monkeypatch.setattr(
-            nodes_module, "addresses_by_node_type", fake_addresses_by_node_type
+            inventory_module, "addresses_by_node_type", fake_addresses_by_node_type
         )
 
         fake_now = 5 * 86_400

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -24,7 +24,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as entity_registry_mod
 
 from custom_components.termoweb.identifiers import build_heater_energy_unique_id
-from custom_components.termoweb.nodes import build_heater_address_map
+from custom_components.termoweb.inventory import build_heater_address_map
 
 
 class FakeWSClient:

--- a/tests/test_installation_snapshot.py
+++ b/tests/test_installation_snapshot.py
@@ -7,8 +7,10 @@ import pytest
 
 from custom_components.termoweb.heater_inventory import build_heater_inventory_details
 from custom_components.termoweb.installation import InstallationSnapshot, ensure_snapshot
-from custom_components.termoweb.inventory import build_node_inventory
-from custom_components.termoweb.nodes import heater_sample_subscription_targets
+from custom_components.termoweb.inventory import (
+    build_node_inventory,
+    heater_sample_subscription_targets,
+)
 
 
 def _make_snapshot(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -29,7 +29,7 @@ from custom_components.termoweb.inventory import (
     normalize_node_addr,
     normalize_node_type,
 )
-from custom_components.termoweb.nodes import heater_sample_subscription_targets
+from custom_components.termoweb.inventory import heater_sample_subscription_targets
 from homeassistant.core import HomeAssistant
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,17 +9,17 @@ from custom_components.termoweb import inventory as inventory_module, nodes as n
 from custom_components.termoweb.const import DOMAIN
 import custom_components.termoweb.identifiers as identifiers_module
 from custom_components.termoweb.identifiers import build_heater_energy_unique_id
-from custom_components.termoweb.nodes import (
-    HEATER_NODE_TYPES,
-    addresses_by_node_type,
-    ensure_node_inventory,
-    normalize_heater_addresses,
-    parse_heater_energy_unique_id,
-)
 from custom_components.termoweb.inventory import (
+    addresses_by_node_type,
     build_node_inventory,
+    normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
+    parse_heater_energy_unique_id,
+)
+from custom_components.termoweb.nodes import (
+    HEATER_NODE_TYPES,
+    ensure_node_inventory,
 )
 from custom_components.termoweb.utils import (
     _entry_gateway_record,


### PR DESCRIPTION
## Summary
- relocate heater address helpers and the energy unique ID parser into the inventory module alongside `HEATER_NODE_TYPES`
- update backend clients, coordinators, and tests to reference the new inventory helpers while keeping node inventory caching intact

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6d331cab08329ad9e0549d4186367