### PR TITLE
Add diagnostics logging for inventory source

### DIFF
--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import inspect
+import logging
 import platform
 from typing import Any, Final
 
@@ -16,6 +17,8 @@ from .installation import ensure_snapshot
 from .inventory import Node
 from .nodes import ensure_node_inventory
 from .utils import async_get_integration_version
+
+_LOGGER = logging.getLogger(__name__)
 
 SENSITIVE_FIELDS: Final = {
     "access_token",
@@ -42,10 +45,13 @@ async def async_get_config_entry_diagnostics(
             record = candidate
 
     snapshot = ensure_snapshot(record or {})
+    inventory_source_label = "fallback"
     if snapshot is not None:
         inventory_source = list(snapshot.inventory)
+        inventory_source_label = "snapshot"
     elif record is not None:
-        inventory_source = ensure_node_inventory(record)
+        inventory_source = list(ensure_node_inventory(record))
+        inventory_source_label = "cached inventory"
     else:
         inventory_source = []
 
@@ -95,7 +101,21 @@ async def async_get_config_entry_diagnostics(
     if time_zone_str is not None:
         diagnostics["home_assistant"]["time_zone"] = time_zone_str
 
-    redacted = async_redact_data(diagnostics, SENSITIVE_FIELDS)
-    if inspect.isawaitable(redacted):
-        redacted = await redacted
+    _LOGGER.debug(
+        "Diagnostics inventory source for %s: %s (raw=%d, filtered=%d)",
+        entry.entry_id,
+        inventory_source_label,
+        len(inventory_source),
+        len(node_inventory),
+    )
+
+    try:
+        redacted = async_redact_data(diagnostics, SENSITIVE_FIELDS)
+        if inspect.isawaitable(redacted):
+            redacted = await redacted
+    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+        _LOGGER.exception(
+            "Failed to redact diagnostics payload for %s", entry.entry_id
+        )
+        raise
     return redacted


### PR DESCRIPTION
## Summary
- add debug logging to diagnostics to record the inventory source and handle redaction errors
- update diagnostics tests to capture the new debug output for better failure visibility

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6d8a883b483298da407b01f70f7a8