### PR TITLE
Refactor heater metadata caching into Inventory

### DIFF
--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -17,7 +17,7 @@ from custom_components.termoweb import installation as installation_module
 from custom_components.termoweb.installation import InstallationSnapshot
 from custom_components.termoweb.inventory import (
     HeaterNode,
-    build_heater_inventory_details,
+    Inventory,
     build_node_inventory,
 )
 from homeassistant.core import HomeAssistant
@@ -112,9 +112,8 @@ def test_prepare_heater_platform_data_groups_nodes() -> None:
     assert [node.addr for node in acm_nodes] == ["2", "2"]
     assert addrs_by_type["acm"] == ["2"]
     assert len(addrs_by_type["acm"]) == len(set(addrs_by_type["acm"]))
-    details = build_heater_inventory_details(inventory)
-    helper_map = details.address_map
-    helper_reverse = details.reverse_address_map
+    reference = Inventory("dev", raw_nodes, inventory)
+    helper_map, helper_reverse = reference.heater_address_map
     assert addrs_by_type == {
         node_type: helper_map.get(node_type, [])
         for node_type in heater_module.HEATER_NODE_TYPES
@@ -128,7 +127,7 @@ def test_prepare_heater_platform_data_groups_nodes() -> None:
         {"node_inventory": list(inventory)},
         default_name_simple=lambda addr: f"Heater {addr}",
     )
-    assert cached_inventory == list(inventory)
+    assert cached_inventory == inventory
 
     legacy_entry = {
         "nodes": {"nodes": [{"type": "htr", "addr": "9", "name": " Kitchen "}]},
@@ -169,8 +168,8 @@ def test_prepare_heater_platform_data_skips_blank_types(
 
     assert [node.addr for node in nodes_by_type.get("htr", [])] == ["6"]
     assert addrs_by_type["htr"] == ["6"]
-    details = build_heater_inventory_details(inventory)
-    helper_map = details.address_map
+    reference = Inventory("dev", {"nodes": []}, inventory)
+    helper_map, _ = reference.heater_address_map
     assert helper_map == {"htr": ["6"]}
 
 

--- a/tests/test_installation_snapshot.py
+++ b/tests/test_installation_snapshot.py
@@ -7,7 +7,7 @@ import pytest
 
 from custom_components.termoweb.installation import InstallationSnapshot, ensure_snapshot
 from custom_components.termoweb.inventory import (
-    build_heater_inventory_details,
+    Inventory,
     build_node_inventory,
     heater_sample_subscription_targets,
 )
@@ -38,13 +38,10 @@ def test_snapshot_properties_and_inventory_cache() -> None:
     assert snapshot.raw_nodes == {"nodes": nodes}
     assert [node.addr for node in snapshot.inventory] == ["1"]
 
-    details = build_heater_inventory_details(snapshot.inventory)
-    assert snapshot.nodes_by_type == details.nodes_by_type
-    assert snapshot.explicit_heater_names == details.explicit_name_pairs
-    assert snapshot.heater_address_map == (
-        details.address_map,
-        details.reverse_address_map,
-    )
+    reference = Inventory(snapshot.dev_id, snapshot.raw_nodes, snapshot.inventory)
+    assert snapshot.nodes_by_type == reference.nodes_by_type
+    assert snapshot.explicit_heater_names == reference.explicit_heater_names
+    assert snapshot.heater_address_map == reference.heater_address_map
 
 
 def test_snapshot_sample_targets_and_name_map_caching() -> None:

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
 from typing import Any, List
 
 import pytest
 
-from custom_components.termoweb.inventory import Inventory
+from custom_components.termoweb.inventory import Inventory, Node
 
 
 class DummyNode:
@@ -41,6 +42,21 @@ def inventory(sample_payload: dict[str, Any], sample_nodes: List[DummyNode]) -> 
     return Inventory("abc123", sample_payload, sample_nodes)
 
 
+@pytest.fixture
+def heater_inventory(sample_payload: dict[str, Any]) -> Inventory:
+    """Return an inventory containing heater and ancillary nodes."""
+
+    nodes = [
+        Node(name=" Lounge ", addr="1", node_type="HTR"),
+        Node(name="", addr="2", node_type="htr"),
+        Node(name="Storage", addr="2", node_type="ACM"),
+        Node(name=None, addr=" 2 ", node_type="acm"),
+        SimpleNamespace(type="htr", addr="", name="Ignored"),
+        Node(name="Thermostat", addr="9", node_type="thm"),
+    ]
+    return Inventory("abc123", sample_payload, nodes)
+
+
 def test_inventory_properties(
     inventory: Inventory, sample_payload: dict[str, Any], sample_nodes: List[DummyNode]
 ) -> None:
@@ -69,3 +85,76 @@ def test_inventory_nodes_are_independent(
     inventory = Inventory("abc123", sample_payload, sample_nodes)
     sample_nodes.append(DummyNode("gamma"))
     assert len(inventory.nodes) == 2
+
+
+def test_inventory_nodes_by_type_caches_results(heater_inventory: Inventory) -> None:
+    """Nodes by type should be cached and immune to caller mutation."""
+
+    assert heater_inventory._nodes_by_type_cache is None
+    first = heater_inventory.nodes_by_type
+    assert heater_inventory._nodes_by_type_cache is not None
+    first.setdefault("htr", []).append("sentinel")
+
+    second = heater_inventory.nodes_by_type
+
+    assert "sentinel" not in second["htr"]
+    assert len(second["htr"]) == 3
+
+
+def test_inventory_heater_metadata_properties(heater_inventory: Inventory) -> None:
+    """Heater-specific properties should expose canonical metadata."""
+
+    nodes = heater_inventory.nodes
+    expected_nodes = tuple(
+        node
+        for node in nodes
+        if getattr(node, "type", "").strip().lower() in {"htr", "acm"}
+    )
+    actual_pairs = {
+        (
+            getattr(node, "type", "").strip().lower(),
+            str(getattr(node, "addr", "")).strip(),
+        )
+        for node in heater_inventory.heater_nodes
+    }
+    expected_pairs = {
+        (
+            getattr(node, "type", "").strip().lower(),
+            str(getattr(node, "addr", "")).strip(),
+        )
+        for node in expected_nodes
+    }
+    assert actual_pairs == expected_pairs
+
+    assert heater_inventory.explicit_heater_names == {("htr", "1"), ("acm", "2")}
+
+    forward, reverse = heater_inventory.heater_address_map
+
+    assert forward == {"htr": ["1", "2"], "acm": ["2"]}
+    assert reverse == {"1": {"htr"}, "2": {"htr", "acm"}}
+
+    # Mutating the returned maps must not corrupt cached state.
+    forward["htr"].append("bogus")
+    reverse.setdefault("3", set()).add("htr")
+
+    cached_forward, cached_reverse = heater_inventory.heater_address_map
+    assert cached_forward == {"htr": ["1", "2"], "acm": ["2"]}
+    assert cached_reverse == {"1": {"htr"}, "2": {"htr", "acm"}}
+
+
+def test_build_heater_inventory_details_wraps_inventory(
+    heater_inventory: Inventory,
+) -> None:
+    """Legacy helper should return data derived from the ``Inventory`` wrapper."""
+
+    from custom_components.termoweb.inventory import (  # noqa: PLC0415
+        build_heater_inventory_details,
+    )
+
+    details = build_heater_inventory_details(heater_inventory.nodes)
+    forward, reverse = heater_inventory.heater_address_map
+
+    assert details.nodes_by_type == heater_inventory.nodes_by_type
+    assert details.explicit_name_pairs == heater_inventory.explicit_heater_names
+    assert details.address_map == forward
+    assert details.reverse_address_map == reverse


### PR DESCRIPTION
## Summary
- add cached heater metadata properties to `Inventory` and expose heater node helpers for reuse
- update `InstallationSnapshot` and heater platform setup to use the new cached properties
- extend inventory-related tests to exercise cache reuse and keep legacy helper coverage

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e6da3d03b883298666de55723892e8