### PR TITLE
Handle recorder API signature variations

### DIFF
--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -249,13 +249,23 @@ async def _get_last_statistics_compat(  # pragma: no cover - compatibility shim
         and helpers.sync_target is not None
         and start_time is None
     ):
-        return await helpers.executor(
-            helpers.sync,
-            helpers.sync_target,
-            number_of_stats,
-            statistic_id,
-            types,
-        )
+        try:
+            return await helpers.executor(
+                helpers.sync,
+                helpers.sync_target,
+                number_of_stats,
+                statistic_id,
+                types,
+                None,
+            )
+        except TypeError:
+            return await helpers.executor(
+                helpers.sync,
+                helpers.sync_target,
+                number_of_stats,
+                statistic_id,
+                types,
+            )
 
     if helpers.async_fn is None:
         return None


### PR DESCRIPTION
## Summary
- try the recorder statistics get_last_statistics executor with the modern start_time placeholder and fall back to the legacy call when needed
- keep async calls using keyword arguments and add targeted tests that cover modern, legacy, and async helper signatures
- introduce a reusable helper in the energy history tests to stand up recorder stubs for signature-compatibility checks

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: existing test_async_ensure_diagnostics_platform_registers assertion in tests/test_init_setup.py)*
- ruff check tests/test_import_energy_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e6df868c608329906ce5b10ba9668f