### PR TITLE
Remove automatic energy import scheduling

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
 from collections import Counter
 from collections.abc import Awaitable, Iterable, Mapping, MutableMapping
 from datetime import timedelta
@@ -53,7 +52,6 @@ from .coordinator import StateCoordinator
 from .energy import (
     async_import_energy_history as _async_import_energy_history_impl,
     async_register_import_energy_history_service,
-    async_schedule_initial_energy_import,
     default_samples_rate_limit_state,
     reset_samples_rate_limit_state,
 )
@@ -561,12 +559,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
 
     await async_register_import_energy_history_service(
         hass,
-        _async_import_energy_history,
-    )
-
-    async_schedule_initial_energy_import(
-        hass,
-        entry,
         _async_import_energy_history,
     )
 

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -10,7 +10,6 @@ import logging
 from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -858,24 +857,3 @@ async def async_register_import_energy_history_service(
     hass.services.async_register(
         DOMAIN, "import_energy_history", _service_import_energy_history
     )
-
-
-def async_schedule_initial_energy_import(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    import_fn: Callable[..., Awaitable[None]],
-) -> None:
-    """Schedule the initial energy history import for an entry."""
-
-    if entry.options.get(OPTION_ENERGY_HISTORY_IMPORTED):
-        return
-
-    _LOGGER.debug("%s: scheduling initial energy import", entry.entry_id)
-
-    async def _schedule_import(_event: Any | None = None) -> None:
-        await import_fn(hass, entry)
-
-    if hass.is_running:
-        hass.async_create_task(_schedule_import())
-    else:
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _schedule_import)

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -672,8 +672,6 @@ custom_components/termoweb/energy.py :: async_register_import_energy_history_ser
     Register the import_energy_history service if it is missing.
 custom_components/termoweb/energy.py :: async_register_import_energy_history_service._service_import_energy_history
     Handle the import_energy_history service call.
-custom_components/termoweb/energy.py :: async_schedule_initial_energy_import
-    Schedule the initial energy history import for an entry.
 custom_components/termoweb/heater.py :: _coerce_boost_remaining_minutes
     Return ``value`` as a positive integer minute count when possible.
 custom_components/termoweb/heater.py :: _boost_runtime_store

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+
 from custom_components.termoweb import (
     identifiers as identifiers_module,
     inventory as inventory_module,
@@ -2401,18 +2403,7 @@ def test_setup_defers_import_until_started(monkeypatch: pytest.MonkeyPatch) -> N
 
         assert await mod.async_setup_entry(hass, entry) is True
         import_mock.assert_not_called()
-
-        start_listeners = [
-            cb for event, cb in listeners if event == energy_mod.EVENT_HOMEASSISTANT_STARTED
-        ]
-        assert len(start_listeners) == 1
-        cb = start_listeners[0]
-
-        hass.async_create_task(cb(None))
-        if tasks:
-            await asyncio.gather(*tasks)
-
-        import_mock.assert_awaited_once_with(hass, entry)
+        assert all(event != EVENT_HOMEASSISTANT_STARTED for event, _ in listeners)
 
     asyncio.run(_run())
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -720,7 +720,7 @@ def test_async_setup_entry_happy_path(
         (entry, tuple(termoweb_init.PLATFORMS))
     ]
     assert stub_hass.services.has_service(termoweb_init.DOMAIN, "import_energy_history")
-    import_mock.assert_awaited_once_with(stub_hass, entry)
+    assert import_mock.await_count == 0
 
 
 def test_async_setup_entry_sets_supports_diagnostics(
@@ -1001,18 +1001,13 @@ def test_async_setup_entry_defers_until_started(
     async def _run() -> None:
         await termoweb_init.async_setup_entry(stub_hass, entry)
         await _drain_tasks(stub_hass)
-        assert not import_mock.await_count
-        assert stub_hass.bus.listeners
-        callback = next(
-            cb
-            for event, cb in stub_hass.bus.listeners
-            if event == EVENT_HOMEASSISTANT_STARTED
+        assert import_mock.await_count == 0
+        assert all(
+            event != EVENT_HOMEASSISTANT_STARTED
+            for event, _ in stub_hass.bus.listeners
         )
-        await callback(None)
-        await _drain_tasks(stub_hass)
 
     asyncio.run(_run())
-    import_mock.assert_awaited_once_with(stub_hass, entry)
 
 
 def test_import_energy_history_service_invocation(


### PR DESCRIPTION
## Summary
- stop importing `async_schedule_initial_energy_import` during setup so that energy backfills only run when the service is called
- delete the unused scheduling helper and adjust tests to assert the importer never runs automatically or registers a startup listener
- update the function map documentation to reflect the removed helper

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e7649b9b088329ad619c8370b99d32