### PR TITLE
Add cached heater name maps to Inventory

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -680,7 +680,7 @@ def prepare_heater_platform_data(
             for node_type in HEATER_NODE_TYPES
         }
 
-        name_map = build_heater_name_map(inventory, default_name_simple)
+        name_map = inventory_container.heater_name_map(default_name_simple)
     names_by_type: dict[str, dict[str, str]] = name_map.get("by_type", {})
     legacy_names: dict[str, str] = name_map.get("htr", {})
 


### PR DESCRIPTION
## Summary
- add `Inventory.heater_name_map` with cached mapping support and a default heater name factory
- delegate snapshot and heater platform code to the new helper
- extend inventory and heater tests to cover cache reuse and fallback naming

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e7734f2b24832990007104a366b191