### PR TITLE
Update coordinator tests for inventory refactor

### DIFF
--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -331,11 +331,11 @@ def test_state_coordinator_handles_none_nodes_payload(
         coordinator = _make_state_coordinator(hass, None)
 
     assert coordinator._nodes == {}
-    assert coordinator._node_inventory == []
+    assert coordinator._inventory is None
     assert sum(
         "Ignoring unexpected nodes payload" in message for message in caplog.messages
     )
-    assert coordinator._nodes_by_type == {}
+    assert coordinator._inventory_addresses_by_type() == {}
 
 
 def test_state_coordinator_logs_once_for_invalid_nodes(


### PR DESCRIPTION
## Summary
- update coordinator unit tests to pass explicit inventory to the new StateCoordinator API
- refresh coordinator coverage with new scenarios for pending settings, inventory rebuilds, and boost handling
- clean up nodes tests to assert on the refactored inventory helpers

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e7abaef33c8329b33569c998b85ca7