### PR TITLE
Refactor climate boost logic to use shared inventory

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -19,20 +19,24 @@ from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
 from .backend.ducaheat import DucaheatRESTClient
-from .boost import coerce_boost_minutes
+from .boost import coerce_boost_minutes, iter_inventory_heater_metadata
 from .const import BRAND_DUCAHEAT, DOMAIN
 from .heater import (
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
     derive_boost_state,
     iter_heater_maps,
-    iter_heater_nodes,
     log_skipped_nodes,
-    prepare_heater_platform_data,
     resolve_boost_runtime_minutes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import HeaterNode, normalize_node_addr, normalize_node_type
+from .inventory import (
+    HeaterNode,
+    Inventory,
+    build_node_inventory,
+    normalize_node_addr,
+    normalize_node_type,
+)
 from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,15 +52,69 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
-        data,
-        default_name_simple=lambda addr: f"Heater {addr}",
-    )
 
+    inventory: Inventory | None = data.get("inventory")
+    inventory_created = False
+    if not isinstance(inventory, Inventory):
+        candidate = getattr(coordinator, "inventory", None)
+        if isinstance(candidate, Inventory):
+            inventory = candidate
+        else:
+            raw_nodes = data.get("nodes")
+            if raw_nodes is None:
+                raw_nodes = getattr(coordinator, "nodes", None)
+            if raw_nodes is None:  # pragma: no cover - defensive
+                node_list = data.get("node_inventory") or getattr(
+                    coordinator, "node_inventory", None
+                )
+                if node_list:  # pragma: no cover - defensive
+                    nodes_payload = []
+                    for node in node_list:
+                        as_dict = getattr(node, "as_dict", None)
+                        if callable(as_dict):
+                            try:
+                                payload = as_dict()
+                            except Exception:  # noqa: BLE001 - defensive
+                                payload = None
+                            if isinstance(payload, dict):
+                                nodes_payload.append(dict(payload))
+                                continue
+                        nodes_payload.append(
+                            {
+                                "type": getattr(node, "type", None),
+                                "addr": getattr(node, "addr", None),
+                                "name": getattr(node, "name", None),
+                            }
+                        )
+                    raw_nodes = {"nodes": nodes_payload}
+            built_nodes: list[HeaterNode] = []
+            if raw_nodes is not None:
+                try:
+                    built_nodes = build_node_inventory(raw_nodes)
+                except ValueError:
+                    built_nodes = []
+            if built_nodes:
+                inventory = Inventory(dev_id, raw_nodes, built_nodes)
+                inventory_created = True
+
+    if isinstance(inventory, Inventory):
+        if inventory_created or "inventory" not in data:
+            data["inventory"] = inventory
+        if inventory_created or "node_inventory" not in data:
+            data["node_inventory"] = list(inventory.nodes)
+        nodes_by_type = inventory.nodes_by_type
+    else:
+        nodes_by_type = {}
+
+    default_name_simple = lambda addr: f"Heater {addr}"
     new_entities: list[ClimateEntity] = []
-    for node_type, _node, addr_str, resolved_name in iter_heater_nodes(
-        nodes_by_type, resolve_name
+    for metadata in iter_inventory_heater_metadata(
+        inventory,
+        default_name_simple=default_name_simple,
     ):
+        node_type = metadata.node_type
+        addr_str = metadata.addr
+        resolved_name = metadata.name
         unique_id = build_heater_entity_unique_id(
             dev_id,
             node_type,
@@ -64,7 +122,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             ":climate",
         )
         entity_cls: type[HeaterClimateEntity]
-        if node_type == "acm":
+        if node_type == "acm" or metadata.supports_boost:
             entity_cls = AccumulatorClimateEntity
         else:
             entity_cls = HeaterClimateEntity

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -24,8 +24,7 @@ from custom_components.termoweb.const import (
     DOMAIN,
     signal_ws_data,
 )
-from custom_components.termoweb.inventory import HeaterNode
-from custom_components.termoweb.inventory import build_node_inventory
+from custom_components.termoweb.inventory import HeaterNode, Inventory, build_node_inventory
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -63,6 +62,12 @@ def _make_coordinator(
         node_inventory=node_inventory,
         data={dev_id: record},
     )
+
+
+def _inventory(dev_id: str, raw_nodes: Mapping[str, Any]) -> Inventory:
+    """Create an :class:`Inventory` instance for ``raw_nodes``."""
+
+    return Inventory(dev_id, raw_nodes, build_node_inventory(raw_nodes))
 
 
 # -------------------- Helpers for tests --------------------
@@ -138,6 +143,7 @@ def test_async_setup_entry_creates_entities() -> None:
                 {"type": "other", "addr": "X"},
             ]
         }
+        inventory = _inventory(dev_id, nodes)
         coordinator_data = {
             dev_id: {
                 "nodes": nodes,
@@ -160,7 +166,7 @@ def test_async_setup_entry_creates_entities() -> None:
             dev_id,
             coordinator_data[dev_id],
             client=AsyncMock(),
-            node_inventory=coordinator_data[dev_id].get("node_inventory"),
+            node_inventory=inventory,
         )
 
         hass.data = {
@@ -170,7 +176,8 @@ def test_async_setup_entry_creates_entities() -> None:
                     "dev_id": dev_id,
                     "client": AsyncMock(),
                     "nodes": nodes,
-                    "node_inventory": build_node_inventory(nodes),
+                    "inventory": inventory,
+                    "node_inventory": list(inventory.nodes),
                     "version": "3.1.4",
                     "brand": BRAND_TERMOWEB,
                 }
@@ -324,11 +331,11 @@ def test_async_setup_entry_default_names_and_invalid_nodes(
                 {"type": "htr", "addr": "1"},
                 {"type": "acm", "addr": "2"},
                 {"type": "pmo", "addr": "P1"},
+                {"type": "  ", "addr": "extra"},
+                {"type": "htr", "addr": " "},
             ]
         }
-        inventory = build_node_inventory(raw_nodes)
-        inventory.append(types.SimpleNamespace(type="  ", addr="extra"))
-        inventory.append(types.SimpleNamespace(type="htr", addr=" "))
+        inventory = _inventory(dev_id, raw_nodes)
 
         coordinator_data = {
             dev_id: {
@@ -351,8 +358,9 @@ def test_async_setup_entry_default_names_and_invalid_nodes(
                     "coordinator": coordinator,
                     "dev_id": dev_id,
                     "client": AsyncMock(),
-                    "nodes": {},
-                    "node_inventory": inventory,
+                    "nodes": raw_nodes,
+                    "inventory": inventory,
+                    "node_inventory": list(inventory.nodes),
                 }
             }
         }
@@ -404,20 +412,26 @@ def test_async_setup_entry_default_names_and_invalid_nodes(
     asyncio.run(_run())
 
 
-def test_async_setup_entry_skips_blank_addresses(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_async_setup_entry_skips_blank_addresses() -> None:
     async def _run() -> None:
         _reset_environment()
         hass = HomeAssistant()
         entry_id = "entry-skip"
         dev_id = "dev-skip"
-        coordinator_data = {"nodes": {}, "htr": {"settings": {}}}
+        raw_nodes = {
+            "nodes": [
+                {"type": "htr", "addr": "  "},
+                {"type": "htr", "addr": "7"},
+            ]
+        }
+        inventory = _inventory(dev_id, raw_nodes)
+        coordinator_data = {"nodes": raw_nodes, "htr": {"settings": {}}}
         coordinator = _make_coordinator(
             hass,
             dev_id,
             coordinator_data,
             client=AsyncMock(),
+            node_inventory=inventory,
         )
 
         hass.data = {
@@ -426,19 +440,12 @@ def test_async_setup_entry_skips_blank_addresses(
                     "coordinator": coordinator,
                     "dev_id": dev_id,
                     "client": AsyncMock(),
+                    "nodes": raw_nodes,
+                    "inventory": inventory,
+                    "node_inventory": list(inventory.nodes),
                 }
             }
         }
-
-        blank_node = types.SimpleNamespace(addr="  ")
-        valid_node = types.SimpleNamespace(addr="7")
-
-        def fake_prepare(*args: Any, **kwargs: Any) -> tuple[Any, Any, Any, Any]:
-            return ([], {"htr": [blank_node, valid_node]}, {}, lambda *_: "Heater")
-
-        monkeypatch.setattr(
-            climate_module, "prepare_heater_platform_data", fake_prepare
-        )
 
         added: list[HeaterClimateEntity] = []
 
@@ -461,6 +468,7 @@ def test_async_setup_entry_creates_accumulator_entity() -> None:
         entry_id = "entry-acm"
         dev_id = "dev-acm"
         nodes = {"nodes": [{"type": "acm", "addr": "7", "name": "Store"}]}
+        inventory = _inventory(dev_id, nodes)
         settings = {
             "mode": "boost",
             "state": "idle",
@@ -484,9 +492,7 @@ def test_async_setup_entry_creates_accumulator_entity() -> None:
             dev_id,
             coordinator_data[dev_id],
             client=AsyncMock(),
-            node_inventory=list(
-                coordinator_data[dev_id]["nodes_by_type"]["acm"]["settings"].keys()
-            ),
+            node_inventory=inventory,
         )
 
         client = AsyncMock()
@@ -500,7 +506,8 @@ def test_async_setup_entry_creates_accumulator_entity() -> None:
                     "dev_id": dev_id,
                     "client": client,
                     "nodes": nodes,
-                    "node_inventory": build_node_inventory(nodes),
+                    "inventory": inventory,
+                    "node_inventory": list(inventory.nodes),
                     "brand": BRAND_DUCAHEAT,
                 }
             }
@@ -1878,6 +1885,137 @@ def test_async_setup_entry_rebuilds_inventory_when_missing() -> None:
         assert len(added) == 2
         stored_inventory = hass.data[DOMAIN][entry.entry_id]["node_inventory"]
         assert [node.addr for node in stored_inventory] == ["11", "22"]
+
+    asyncio.run(_run())
+
+
+def test_async_setup_entry_reuses_coordinator_inventory() -> None:
+    async def _run() -> None:
+        _reset_environment()
+        hass = HomeAssistant()
+        entry = types.SimpleNamespace(entry_id="entry-coord")
+        dev_id = "dev-coord"
+        raw_nodes = {"nodes": [{"type": "htr", "addr": "5"}]}
+        inventory = _inventory(dev_id, raw_nodes)
+
+        coordinator = _make_coordinator(
+            hass,
+            dev_id,
+            {"nodes": raw_nodes, "htr": {"settings": {"5": {}}}},
+            client=AsyncMock(),
+            node_inventory=inventory,
+        )
+
+        record: dict[str, Any] = {
+            "coordinator": coordinator,
+            "dev_id": dev_id,
+            "client": AsyncMock(),
+            "nodes": raw_nodes,
+        }
+        hass.data = {DOMAIN: {entry.entry_id: record}}
+
+        added: list[HeaterClimateEntity] = []
+
+        def _async_add_entities(entities: list[HeaterClimateEntity]) -> None:
+            added.extend(entities)
+
+        await async_setup_entry(hass, entry, _async_add_entities)
+
+        assert len(added) == 1
+        stored = hass.data[DOMAIN][entry.entry_id]["inventory"]
+        assert stored is inventory
+
+    asyncio.run(_run())
+
+
+def test_async_setup_entry_builds_inventory_from_node_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        _reset_environment()
+        hass = HomeAssistant()
+        entry = types.SimpleNamespace(entry_id="entry-list")
+        dev_id = "dev-list"
+        raw_nodes = {"nodes": [{"type": "htr", "addr": "3", "name": "Three"}]}
+        node_list = [types.SimpleNamespace(type="htr", addr="3", name="Three")]
+
+        captured: list[dict[str, Any]] = []
+        original_build = climate_module.build_node_inventory
+
+        def _capture(payload: Any) -> list[HeaterNode]:
+            if isinstance(payload, dict):
+                captured.append(payload)
+            return original_build(payload)
+
+        monkeypatch.setattr(climate_module, "build_node_inventory", _capture)
+
+        coordinator = _make_coordinator(
+            hass,
+            dev_id,
+            {"nodes": {}, "htr": {"settings": {}}},
+            client=AsyncMock(),
+            node_inventory=node_list,
+        )
+
+        record: dict[str, Any] = {
+            "coordinator": coordinator,
+            "dev_id": dev_id,
+            "client": AsyncMock(),
+            "node_inventory": list(node_list),
+        }
+        hass.data = {DOMAIN: {entry.entry_id: record}}
+
+        added: list[HeaterClimateEntity] = []
+
+        def _async_add_entities(entities: list[HeaterClimateEntity]) -> None:
+            added.extend(entities)
+
+        await async_setup_entry(hass, entry, _async_add_entities)
+
+        assert captured
+
+    asyncio.run(_run())
+
+
+def test_async_setup_entry_handles_inventory_build_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        _reset_environment()
+        hass = HomeAssistant()
+        entry = types.SimpleNamespace(entry_id="entry-error")
+        dev_id = "dev-error"
+        raw_nodes = {"nodes": [{"type": "htr", "addr": "9"}]}
+
+        coordinator = _make_coordinator(
+            hass,
+            dev_id,
+            {"nodes": raw_nodes, "htr": {"settings": {"9": {}}}},
+            client=AsyncMock(),
+        )
+
+        record: dict[str, Any] = {
+            "coordinator": coordinator,
+            "dev_id": dev_id,
+            "client": AsyncMock(),
+            "nodes": raw_nodes,
+        }
+        hass.data = {DOMAIN: {entry.entry_id: record}}
+
+        def _raise(_value: Any) -> list[HeaterNode]:
+            raise ValueError("boom")
+
+        monkeypatch.setattr(climate_module, "build_node_inventory", _raise)
+
+        added: list[HeaterClimateEntity] = []
+
+        def _async_add_entities(entities: list[HeaterClimateEntity]) -> None:
+            added.extend(entities)
+
+        await async_setup_entry(hass, entry, _async_add_entities)
+
+        assert added == []
+        assert "inventory" not in hass.data[DOMAIN][entry.entry_id]
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- introduce inventory-aware metadata iterator in the boost helpers
- refactor the climate platform setup to build entities directly from the shared inventory
- extend climate and boost-related tests to exercise the new inventory flows

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e7b57c7d508329849a363072493672