### PR TITLE
Use Inventory metadata for heater entities

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -23,6 +23,7 @@ from .heater import (
     prepare_heater_platform_data,
 )
 from .identifiers import build_heater_entity_unique_id
+from .inventory import Inventory, heater_platform_details_from_inventory
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,10 +36,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
     dev_id = data["dev_id"]
     gateway = GatewayOnlineBinarySensor(coord, entry.entry_id, dev_id)
 
-    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
-        data,
-        default_name_simple=lambda addr: f"Node {addr}",
-    )
+    entry_inventory = data.get("inventory")
+    if isinstance(entry_inventory, Inventory):
+        nodes_by_type, _, resolve_name = (
+            heater_platform_details_from_inventory(
+                entry_inventory,
+                default_name_simple=lambda addr: f"Node {addr}",
+            )
+        )
+    else:
+        _, nodes_by_type, _, resolve_name = (
+            prepare_heater_platform_data(
+                data,
+                default_name_simple=lambda addr: f"Node {addr}",
+            )
+        )
 
     boost_entities: list[BinarySensorEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -31,6 +31,7 @@ from .heater import (
     prepare_heater_platform_data,
 )
 from .identifiers import build_heater_entity_unique_id
+from .inventory import Inventory, heater_platform_details_from_inventory
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,10 +50,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
         StateRefreshButton(coordinator, entry.entry_id, dev_id)
     ]
 
-    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
-        data,
-        default_name_simple=lambda addr: f"Heater {addr}",
-    )
+    entry_inventory = data.get("inventory")
+    if isinstance(entry_inventory, Inventory):
+        nodes_by_type, _, resolve_name = (
+            heater_platform_details_from_inventory(
+                entry_inventory,
+                default_name_simple=lambda addr: f"Heater {addr}",
+            )
+        )
+    else:
+        _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
+            data,
+            default_name_simple=lambda addr: f"Heater {addr}",
+        )
 
     boost_entities: list[ButtonEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(


### PR DESCRIPTION
## Summary
- add a heater_platform_details_from_inventory helper to reuse cached metadata
- update sensor, binary_sensor, and button setup to prefer shared Inventory details with prepare fallback
- refresh heater platform tests to provide Inventory fixtures and assert the new naming behaviour

## Testing
- pytest tests/test_heater_energy_sensor.py tests/test_binary_sensor_button.py
- ruff check custom_components/termoweb/sensor.py custom_components/termoweb/binary_sensor.py custom_components/termoweb/button.py custom_components/termoweb/inventory.py tests/test_heater_energy_sensor.py tests/test_binary_sensor_button.py

------
https://chatgpt.com/codex/tasks/task_e_68e7c38979e8832987be9fc5220f0820