### PR TITLE
Align websocket tests with Inventory node updates

### DIFF
--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -367,11 +367,12 @@ def test_state_coordinator_logs_once_for_invalid_nodes(
     )
 
     caplog.clear()
+    invalid_inventory = inventory_builder("dev", ["bad"], [])
     with caplog.at_level(logging.DEBUG):
-        coordinator.update_nodes(["bad"])
-        coordinator.update_nodes("also bad")
+        coordinator.update_nodes(["bad"], invalid_inventory)
+        coordinator.update_nodes("also bad", invalid_inventory)
 
-    assert coordinator._inventory is None
+    assert coordinator._inventory is invalid_inventory
     assert sum(
         "Ignoring unexpected nodes payload" in message for message in caplog.messages
     ) == 1

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -255,7 +255,8 @@ def test_dispatch_nodes_without_snapshot(monkeypatch: pytest.MonkeyPatch) -> Non
     update_args = coordinator.update_nodes.call_args.args
     assert update_args[0] is payload["nodes"]
     inventory_arg = update_args[1]
-    assert hasattr(inventory_arg, "nodes")
+    assert isinstance(inventory_arg, Inventory)
+    assert inventory_arg.payload is payload["nodes"]
 
     def _extract_addr(node: Any) -> str:
         addr_attr = getattr(node, "addr", None)
@@ -362,6 +363,10 @@ def test_dispatch_nodes_updates_hass_and_coordinator(
     addr_map = client._dispatch_nodes(payload)
 
     client._coordinator.update_nodes.assert_called_once()  # type: ignore[attr-defined]
+    update_args = client._coordinator.update_nodes.call_args.args  # type: ignore[attr-defined]
+    assert update_args[0] is payload
+    assert isinstance(update_args[1], Inventory)
+    assert update_args[1].payload is payload
     assert isinstance(addr_map, dict)
     entry_state = client.hass.data[module.DOMAIN]["entry"]
     assert "node_inventory" in entry_state


### PR DESCRIPTION
## Summary
- ensure websocket dispatch tests assert that coordinator.update_nodes receives an Inventory container
- update the state coordinator invalid-node logging test to call update_nodes with an Inventory object

## Testing
- pytest tests/test_nodes.py::test_state_coordinator_logs_once_for_invalid_nodes tests/test_ws_client.py::test_dispatch_nodes_without_snapshot tests/test_ws_client.py::test_dispatch_nodes_updates_hass_and_coordinator tests/test_ws_client.py::test_ws_common_dispatch_nodes


------
https://chatgpt.com/codex/tasks/task_e_68e8212f29e4832982de9d3a3676ba21