### PR TITLE
Add Inventory assertions to websocket mock tests

### DIFF
--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -15,6 +15,7 @@ import pytest
 
 from custom_components.termoweb.backend import ducaheat_ws
 from custom_components.termoweb.installation import InstallationSnapshot
+from custom_components.termoweb.inventory import Inventory
 from homeassistant.core import HomeAssistant
 
 
@@ -542,6 +543,11 @@ async def test_read_loop_updates_ws_state_on_dev_data(
     assert ws_state["status"] == "healthy"
     assert ws_state["healthy_since"] == base_ts
     assert ws_state["last_event_at"] == base_ts
+    client._coordinator.update_nodes.assert_called_once()
+    update_args, update_kwargs = client._coordinator.update_nodes.call_args
+    assert not update_kwargs
+    assert update_args[0] == {"htr": {"status": {"1": {"power": 1}}}}
+    assert isinstance(update_args[1], Inventory)
 
 
 @pytest.mark.asyncio

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -18,6 +18,7 @@ from custom_components.termoweb.backend.sanitize import (
     redact_token_fragment,
 )
 from custom_components.termoweb.installation import InstallationSnapshot
+from custom_components.termoweb.inventory import Inventory
 from homeassistant.core import HomeAssistant
 
 
@@ -948,6 +949,11 @@ def test_dispatch_nodes_with_snapshot(monkeypatch: pytest.MonkeyPatch, caplog: p
 
     result = client._dispatch_nodes({"nodes": {"htr": {"settings": {"1": {}}}}})
     assert isinstance(result, dict)
+    client._coordinator.update_nodes.assert_called_once()
+    update_args, update_kwargs = client._coordinator.update_nodes.call_args
+    assert not update_kwargs
+    assert update_args[0] == {"nodes": {"htr": {"settings": {"1": {}}}}}
+    assert isinstance(update_args[1], Inventory)
     dispatcher.assert_called()
 
 
@@ -964,6 +970,11 @@ def test_dispatch_nodes_handles_unknown_types(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(module, "addresses_by_node_type", fake_addresses)
     client._dispatch_nodes({"nodes": {}})
+    client._coordinator.update_nodes.assert_called_once()
+    update_args, update_kwargs = client._coordinator.update_nodes.call_args
+    assert not update_kwargs
+    assert update_args[0] == {"nodes": {}}
+    assert isinstance(update_args[1], Inventory)
     dispatcher.assert_called()
 
 


### PR DESCRIPTION
## Summary
- ensure TermoWeb websocket protocol tests assert mocked coordinators receive Inventory containers alongside node payloads
- verify the Ducaheat websocket dev_data path delivers an Inventory instance to coordinator.update_nodes

## Testing
- pytest tests/test_ws_client.py::test_dispatch_nodes_updates_hass_and_coordinator
- pytest tests/test_termoweb_ws_protocol.py::test_dispatch_nodes_with_snapshot
- pytest tests/test_termoweb_ws_protocol.py::test_dispatch_nodes_handles_unknown_types
- pytest tests/test_ducaheat_ws_protocol.py::test_read_loop_updates_ws_state_on_dev_data

------
https://chatgpt.com/codex/tasks/task_e_68e8230e29b48329af3fc53001d954c2