### PR TITLE
Enforce five-minute websocket health before stretching

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from importlib import import_module
 import inspect
 import logging
+import time
 from types import ModuleType
 from typing import Any
 
@@ -452,7 +453,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
                 data["stretched"] = False
             return
 
+        min_healthy_minutes = 5
+        min_healthy_seconds = min_healthy_minutes * 60
         all_healthy = True
+        now: float | None = None
         for dev_id, task in tasks.items():
             if task.done():
                 all_healthy = False
@@ -462,11 +466,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
                 all_healthy = False
                 break
 
+            eligible = False
+            minutes_val: float | None
+            try:
+                minutes_raw = s.get("healthy_minutes")
+                minutes_val = float(minutes_raw) if minutes_raw is not None else None
+            except (TypeError, ValueError):
+                minutes_val = None
+
+            if minutes_val is not None:
+                eligible = minutes_val >= min_healthy_minutes
+            else:
+                try:
+                    since_raw = s.get("healthy_since")
+                    since_val = float(since_raw) if since_raw is not None else None
+                except (TypeError, ValueError):
+                    since_val = None
+
+                if since_val is not None:
+                    if now is None:
+                        now = time.time()
+                    if now >= since_val:
+                        eligible = (now - since_val) >= min_healthy_seconds
+
+            if not eligible:
+                all_healthy = False
+                break
+
         if all_healthy and not stretched:
             coordinator.update_interval = timedelta(seconds=STRETCHED_POLL_INTERVAL)
             data["stretched"] = True
             _LOGGER.info(
-                "WS: healthy for ≥5m; stretching REST polling to %ss",
+                "WS: healthy for ≥5 minutes; stretching REST polling to %ss",
                 STRETCHED_POLL_INTERVAL,
             )
         elif (not all_healthy) and stretched:

--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -125,7 +125,7 @@ def signal_ws_status(entry_id: str) -> str:
 DEFAULT_POLL_INTERVAL: Final = 120  # seconds
 MIN_POLL_INTERVAL: Final = 30  # seconds
 MAX_POLL_INTERVAL: Final = 3600  # seconds
-STRETCHED_POLL_INTERVAL: Final = 2700  # seconds (45 minutes) when WS healthy ≥5m
+STRETCHED_POLL_INTERVAL: Final = 2700  # seconds (45 minutes) when WS healthy ≥5 minutes
 
 # Heater energy polling interval when relying on push updates
 HTR_ENERGY_UPDATE_INTERVAL: Final = timedelta(hours=1)


### PR DESCRIPTION
## Summary
- require websocket health to remain stable for five minutes before stretching the REST polling interval
- clarify the stretched interval comment and logging to reference the five-minute threshold
- extend setup tests to cover the five-minute delay, healthy_since fallback, and invalid status handling

## Testing
- `ruff check custom_components/termoweb/__init__.py custom_components/termoweb/const.py tests/test_init_setup.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e8a757494083299c2cf7f282ffcf44