### PR TITLE
Stop caching node inventory during resolution

### DIFF
--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -428,7 +428,6 @@ def resolve_record_inventory(
 
         if mutable is not None:
             mutable["inventory"] = container
-            mutable["node_inventory"] = list(container.nodes)
 
         resolved_dev_id = container.dev_id
         return InventoryResolution(container, source, raw_count, len(container.nodes))

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -896,8 +896,10 @@ def test_async_import_energy_history_rebuilds_missing_inventory(
 
         await mod._async_import_energy_history(hass, entry)
 
-        inventory = hass.data[const.DOMAIN][entry.entry_id]["node_inventory"]
-        assert [node.addr for node in inventory] == ["A"]
+        record = hass.data[const.DOMAIN][entry.entry_id]
+        inventory = record["inventory"]
+        assert [node.addr for node in inventory.nodes] == ["A"]
+        assert "node_inventory" not in record
 
     asyncio.run(_run())
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -330,6 +330,7 @@ def test_resolve_record_inventory_uses_cached_node_list() -> None:
     assert record["inventory"] is resolution.inventory
     assert isinstance(resolution.inventory, Inventory)
     assert resolution.inventory.dev_id == "101"
+    assert record["node_inventory"] is nodes
 
 
 def test_resolve_record_inventory_falls_back_to_snapshot() -> None:
@@ -345,6 +346,7 @@ def test_resolve_record_inventory_falls_back_to_snapshot() -> None:
     assert resolution.filtered_count == 1
     assert record["inventory"] is resolution.inventory
     assert resolution.inventory.dev_id == "snapshot-dev"
+    assert "node_inventory" not in record
 
 
 def test_resolve_record_inventory_builds_from_raw_nodes() -> None:
@@ -358,6 +360,7 @@ def test_resolve_record_inventory_builds_from_raw_nodes() -> None:
     assert resolution.source == "raw_nodes"
     assert resolution.filtered_count == 1
     assert record["inventory"] is resolution.inventory
+    assert "node_inventory" not in record
     assert resolution.inventory.heater_address_map[0] == {"htr": ["5"]}
 
 
@@ -398,6 +401,7 @@ def test_resolve_record_inventory_detects_mismatched_inventory() -> None:
     assert resolution.source == "node_inventory"
     assert resolution.filtered_count == 0
     assert record["inventory"] is resolution.inventory
+    assert record["node_inventory"] == [invalid]
 
 
 def test_heater_platform_details_default_name(


### PR DESCRIPTION
## Summary
- stop resolve_record_inventory from mutating records with a cached node_inventory list
- adjust inventory resolution tests to assert that records retain or omit node_inventory as appropriate
- update the energy history import test to validate the Inventory wrapper instead of relying on cached node lists

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8c8e959a8832989e7b0b9bc7f5d7a