### PR TITLE
Remove node inventory copy from setup record

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -397,7 +397,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         "dev_id": dev_id,
         "snapshot": snapshot,
         "inventory": inventory,
-        "node_inventory": list(inventory.nodes),
         "config_entry": entry,
         "base_poll_interval": max(base_interval, MIN_POLL_INTERVAL),
         "stretched": False,

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -438,11 +438,13 @@ def test_async_setup_entry_happy_path(
     assert isinstance(record["inventory"], inventory_module.Inventory)
     assert record["inventory"].dev_id == "dev-1"
     assert record["coordinator"].inventory is record["inventory"]
-    assert list(record["inventory"].nodes) == record["node_inventory"]
-    by_type, _ = build_heater_address_map(record["node_inventory"])
+    node_list = list(record["inventory"].nodes)
+    assert node_list
+    by_type, _ = build_heater_address_map(node_list)
     assert by_type == {"htr": ["A"], "acm": ["B"]}
-    assert [node.addr for node in record["node_inventory"]] == ["A", "B"]
-    assert [node.type for node in record["node_inventory"]] == ["htr", "acm"]
+    assert [node.addr for node in node_list] == ["A", "B"]
+    assert [node.type for node in node_list] == ["htr", "acm"]
+    assert "node_inventory" not in record
     assert stub_hass.client_session_calls == 1
     assert stub_hass.config_entries.forwarded == [
         (entry, tuple(termoweb_init.PLATFORMS))


### PR DESCRIPTION
## Summary
- stop copying node inventory lists into the config entry data record and rely on the shared Inventory container
- update the setup test to assert against the Inventory nodes directly

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8cd041fc88329bc95e572d8cd948b