### PR TITLE
Refactor Ducaheat WS inventory resolution for feed subscriptions

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -1,4 +1,5 @@
 """Ducaheat specific websocket client."""
+
 from __future__ import annotations
 
 import asyncio
@@ -9,7 +10,7 @@ import logging
 import random
 import string
 import time
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, MutableMapping
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import aiohttp
@@ -30,9 +31,9 @@ from ..const import (
 from ..installation import InstallationSnapshot, ensure_snapshot
 from ..inventory import (
     Inventory,
-    build_node_inventory,
     normalize_node_addr,
     normalize_node_type,
+    resolve_record_inventory,
 )
 from .ws_client import (
     DUCAHEAT_NAMESPACE,
@@ -50,7 +51,9 @@ _LOGGER = logging.getLogger(__name__)
 def _rand_t() -> str:
     """Return a pseudo-random token string for polling requests."""
 
-    return "P" + "".join(random.choice(string.ascii_letters + string.digits) for _ in range(7))
+    return "P" + "".join(
+        random.choice(string.ascii_letters + string.digits) for _ in range(7)
+    )
 
 
 def _encode_polling_packet(pkt: str) -> bytes:
@@ -174,7 +177,9 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
     def start(self) -> asyncio.Task:
         if self._task and not self._task.done():
             return self._task
-        self._task = self._loop.create_task(self._runner(), name=f"termoweb-ws-{self.dev_id}")
+        self._task = self._loop.create_task(
+            self._runner(), name=f"termoweb-ws-{self.dev_id}"
+        )
         return self._task
 
     async def stop(self) -> None:
@@ -193,7 +198,9 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
     def _base_host(self) -> str:
         base = get_brand_api_base(self._brand).rstrip("/")
         parsed = urlsplit(base if base else API_BASE)
-        return urlunsplit((parsed.scheme or "https", parsed.netloc or parsed.path, "", "", ""))
+        return urlunsplit(
+            (parsed.scheme or "https", parsed.netloc or parsed.path, "", "", "")
+        )
 
     def _path(self) -> str:
         return "/socket.io/"
@@ -246,15 +253,15 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             "t": _rand_t(),
         }
         open_url = self._build_handshake_url(open_params)
-        #_LOGGER.debug("WS (ducaheat): OPEN GET %s", open_url.replace(token, "…"))
+        # _LOGGER.debug("WS (ducaheat): OPEN GET %s", open_url.replace(token, "…"))
         async with asyncio.timeout(15):
             async with self._session.get(open_url, headers=headers) as resp:
                 body = await resp.read()
-                #_LOGGER.debug(
+                # _LOGGER.debug(
                 #    "WS (ducaheat): OPEN GET -> %s bytes (status=%s)",
                 #    len(body),
                 #    resp.status,
-                #)
+                # )
                 if resp.status != 200:
                     raise HandshakeError(resp.status, open_url, "open GET")
         packets = _decode_polling_packets(body)
@@ -266,11 +273,15 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         sid = info.get("sid")
         ping_interval = info.get("pingInterval")
         self._ping_interval = (
-            float(ping_interval) / 1000 if isinstance(ping_interval, (int, float)) else None
+            float(ping_interval) / 1000
+            if isinstance(ping_interval, (int, float))
+            else None
         )
         ping_timeout = info.get("pingTimeout")
         self._ping_timeout = (
-            float(ping_timeout) / 1000 if isinstance(ping_timeout, (int, float)) else None
+            float(ping_timeout) / 1000
+            if isinstance(ping_timeout, (int, float))
+            else None
         )
         _LOGGER.info(
             "WS (ducaheat): OPEN decoded sid=%s pingInterval=%s pingTimeout=%s",
@@ -291,7 +302,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         }
         post_url = self._build_handshake_url(post_params)
         payload = _encode_polling_packet(f"40{self._namespace}")
-        #_LOGGER.debug("WS (ducaheat): POST 40/ns %s", post_url.replace(token, "…"))
+        # _LOGGER.debug("WS (ducaheat): POST 40/ns %s", post_url.replace(token, "…"))
         async with asyncio.timeout(15):
             async with self._session.post(
                 post_url,
@@ -299,26 +310,26 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 data=payload,
             ) as resp:
                 drain = await resp.read()
-#                _LOGGER.debug(
-#                    "WS (ducaheat): POST 40/ns -> status=%s len=%s",
-#                    resp.status,
-#                    len(drain),
-#                )
+                #                _LOGGER.debug(
+                #                    "WS (ducaheat): POST 40/ns -> status=%s len=%s",
+                #                    resp.status,
+                #                    len(drain),
+                #                )
                 if resp.status != 200:
                     raise HandshakeError(resp.status, post_url, "POST 40/ns")
 
         drain_params = dict(post_params)
         drain_params["t"] = _rand_t()
         drain_url = self._build_handshake_url(drain_params)
-#        _LOGGER.debug("WS (ducaheat): DRAIN GET %s", drain_url.replace(token, "…"))
+        #        _LOGGER.debug("WS (ducaheat): DRAIN GET %s", drain_url.replace(token, "…"))
         async with asyncio.timeout(15):
             async with self._session.get(drain_url, headers=headers) as resp:
                 body = await resp.read()
-#                _LOGGER.debug(
-#                    "WS (ducaheat): DRAIN GET -> status=%s len=%s",
-#                    resp.status,
-#                    len(body),
-#                )
+                #                _LOGGER.debug(
+                #                    "WS (ducaheat): DRAIN GET -> status=%s len=%s",
+                #                    resp.status,
+                #                    len(body),
+                #                )
                 if resp.status != 200:
                     raise HandshakeError(resp.status, drain_url, "drain GET")
 
@@ -330,8 +341,12 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             "sid": sid,
         }
         ws_url = self._build_handshake_url(ws_params)
-        ws_headers = {k: v for k, v in headers.items() if k.lower() not in ("connection", "accept-encoding")}
-#        _LOGGER.debug("WS (ducaheat): upgrading WS %s", ws_url.replace(token, "…"))
+        ws_headers = {
+            k: v
+            for k, v in headers.items()
+            if k.lower() not in ("connection", "accept-encoding")
+        }
+        #        _LOGGER.debug("WS (ducaheat): upgrading WS %s", ws_url.replace(token, "…"))
         self._ws = await self._session.ws_connect(
             ws_url,
             headers=ws_headers,
@@ -339,21 +354,21 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             autoclose=False,
             timeout=aiohttp.ClientTimeout(total=15),
         )
-#        _LOGGER.info("WS (ducaheat): upgrade OK")
+        #        _LOGGER.info("WS (ducaheat): upgrade OK")
 
         await self._ws.send_str("2probe")
-#        _LOGGER.debug("WS (ducaheat): -> 2probe")
+        #        _LOGGER.debug("WS (ducaheat): -> 2probe")
         probe = await self._ws.receive_str()
-#        _LOGGER.debug("WS (ducaheat): <- %r", probe)
+        #        _LOGGER.debug("WS (ducaheat): <- %r", probe)
         if probe != "3probe":
             _LOGGER.debug("WS (ducaheat): unexpected probe ack: %r", probe)
         await self._ws.send_str("5")
-#        _LOGGER.debug("WS (ducaheat): -> 5 (upgrade)")
+        #        _LOGGER.debug("WS (ducaheat): -> 5 (upgrade)")
 
         await self._ws.send_str(f"40{self._namespace}")
-#        _LOGGER.debug("WS (ducaheat): -> 40%s", self._namespace)
+        #        _LOGGER.debug("WS (ducaheat): -> 40%s", self._namespace)
         self._pending_dev_data = True
-#        _LOGGER.debug("WS (ducaheat): dev_data pending until namespace ack")
+        #        _LOGGER.debug("WS (ducaheat): dev_data pending until namespace ack")
         self._healthy_since = None
         self._last_event_at = None
         self._stats.frames_total = 0
@@ -404,12 +419,16 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                                         namespace,
                                     )
                                     if sep and remainder:
-                                        data = remainder if remainder.startswith("4") else "4" + remainder
+                                        data = (
+                                            remainder
+                                            if remainder.startswith("4")
+                                            else "4" + remainder
+                                        )
                                         continue
                                     break
                                 if sep and remainder:
                                     rest_payload = remainder
-#                            _LOGGER.debug("WS (ducaheat): <- SIO 40 (namespace ack)")
+                            #                            _LOGGER.debug("WS (ducaheat): <- SIO 40 (namespace ack)")
                             self._update_status("healthy")
                             if self._pending_dev_data:
                                 self._pending_dev_data = False
@@ -422,7 +441,11 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                                         exc_info=True,
                                     )
                             if rest_payload:
-                                data = rest_payload if rest_payload.startswith("4") else "4" + rest_payload
+                                data = (
+                                    rest_payload
+                                    if rest_payload.startswith("4")
+                                    else "4" + rest_payload
+                                )
                                 continue
                             break
                         payload = data[1:]
@@ -435,7 +458,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                         if payload.startswith("2/"):
                             ns_payload = payload[1:]
                             ns, sep, body = ns_payload.partition(",")
-                            if not sep or body in {"", "[]", "[\"ping\"]"}:
+                            if not sep or body in {"", "[]", '["ping"]'}:
                                 await ws.send_str("3" + ns)
                                 break
 
@@ -459,29 +482,33 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                         evt, *args = arr
                         self._stats.events_total += 1
                         self._record_frame(timestamp=now)
-                        #_LOGGER.debug("WS (ducaheat): <- SIO 42 event=%s args_len=%d", evt, len(args))
+                        # _LOGGER.debug("WS (ducaheat): <- SIO 42 event=%s args_len=%d", evt, len(args))
 
                         if evt == "message" and args and args[0] == "ping":
                             await self._emit_sio("message", "pong")
                             break
 
                         if evt == "dev_data" and args and isinstance(args[0], dict):
-                            nodes = args[0].get("nodes") if isinstance(args[0], dict) else None
+                            nodes = (
+                                args[0].get("nodes")
+                                if isinstance(args[0], dict)
+                                else None
+                            )
                             if isinstance(nodes, dict):
                                 self._latest_nodes = nodes
                                 self._log_nodes_summary(nodes)
                                 normalised = self._normalise_nodes_payload(nodes)
                                 if isinstance(normalised, dict):
                                     self._nodes_raw = deepcopy(normalised)
-                                    snapshot = self._build_nodes_snapshot(self._nodes_raw)
+                                    snapshot = self._build_nodes_snapshot(
+                                        self._nodes_raw
+                                    )
                                 else:
                                     self._nodes_raw = None
                                     snapshot = {"nodes": nodes}
                                 self._dispatch_nodes(snapshot)
                                 subs = await self._subscribe_feeds(nodes)
-                                _LOGGER.info(
-                                    "WS (ducaheat): subscribed %d feeds", subs
-                                )
+                                _LOGGER.info("WS (ducaheat): subscribed %d feeds", subs)
                                 self._update_status("healthy")
                             break
 
@@ -490,14 +517,25 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                             self._log_update_brief(payload_body)
                             translated = self._translate_path_update(payload_body)
                             if translated:
-                                normalised_update = self._normalise_nodes_payload(translated)
-                                if isinstance(normalised_update, dict) and normalised_update:
-                                    sample_updates = self._collect_sample_updates(normalised_update)
+                                normalised_update = self._normalise_nodes_payload(
+                                    translated
+                                )
+                                if (
+                                    isinstance(normalised_update, dict)
+                                    and normalised_update
+                                ):
+                                    sample_updates = self._collect_sample_updates(
+                                        normalised_update
+                                    )
                                     if self._nodes_raw is None:
                                         self._nodes_raw = deepcopy(normalised_update)
                                     else:
-                                        self._merge_nodes(self._nodes_raw, normalised_update)
-                                    snapshot = self._build_nodes_snapshot(self._nodes_raw)
+                                        self._merge_nodes(
+                                            self._nodes_raw, normalised_update
+                                        )
+                                    snapshot = self._build_nodes_snapshot(
+                                        self._nodes_raw
+                                    )
                                     self._dispatch_nodes(snapshot)
                                     if sample_updates:
                                         self._forward_sample_updates(sample_updates)
@@ -541,11 +579,9 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                     continue
                 try:
                     await ws.send_str("2")
-                    #_LOGGER.debug("WS (ducaheat): -> 2 (keepalive ping)")
+                    # _LOGGER.debug("WS (ducaheat): -> 2 (keepalive ping)")
                 except Exception:  # noqa: BLE001 - defensive logging
-                    _LOGGER.debug(
-                        "WS (ducaheat): keepalive ping failed", exc_info=True
-                    )
+                    _LOGGER.debug("WS (ducaheat): keepalive ping failed", exc_info=True)
                     break
         except asyncio.CancelledError:
             raise
@@ -566,9 +602,14 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 for section in ("settings", "samples", "status", "advanced"):
                     sec = value.get(section)
                     if isinstance(sec, Mapping):
-                        addrs.update(addr for addr in sec.keys() if isinstance(addr, str))
+                        addrs.update(
+                            addr for addr in sec.keys() if isinstance(addr, str)
+                        )
                 kinds.append(f"{key}={len(addrs) if addrs else 0}")
-        _LOGGER.info("WS (ducaheat): dev_data nodes: %s", " ".join(kinds) if kinds else "(no nodes)")
+        _LOGGER.info(
+            "WS (ducaheat): dev_data nodes: %s",
+            " ".join(kinds) if kinds else "(no nodes)",
+        )
 
     def _log_update_brief(self, body: Any) -> None:
         if not _LOGGER.isEnabledFor(logging.DEBUG):
@@ -708,9 +749,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
 
         section = relevant[section_idx] if len(relevant) > section_idx else None
         remainder = (
-            relevant[section_idx + 1 :]
-            if len(relevant) > section_idx + 1
-            else []
+            relevant[section_idx + 1 :] if len(relevant) > section_idx + 1 else []
         )
 
         target_section, nested_key = self._resolve_update_section(section)
@@ -746,75 +785,100 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
     async def _subscribe_feeds(self, nodes: Mapping[str, Any] | None) -> int:
         """Subscribe to heater status and sample feeds."""
 
-        resolved_nodes: Mapping[str, Any] | None = nodes if isinstance(nodes, Mapping) else None
+        resolved_nodes: Mapping[str, Any] | None = (
+            nodes if isinstance(nodes, Mapping) else None
+        )
         if resolved_nodes is None and isinstance(self._latest_nodes, Mapping):
             resolved_nodes = self._latest_nodes
 
-        paths: set[str] = set()
         try:
             domain_bucket = self.hass.data.setdefault(DOMAIN, {})
-            entry_bucket = domain_bucket.setdefault(self.entry_id, {})
-            if isinstance(entry_bucket, dict) and isinstance(resolved_nodes, Mapping):
-                entry_bucket["nodes"] = resolved_nodes
+            existing_record = domain_bucket.get(self.entry_id)
 
-            record = domain_bucket.get(self.entry_id)
-            snapshot_obj = ensure_snapshot(record)
+            snapshot_obj = ensure_snapshot(existing_record)
+            if snapshot_obj is None and isinstance(existing_record, Mapping):
+                candidate_snapshot = existing_record.get("snapshot")
+                if isinstance(candidate_snapshot, InstallationSnapshot):
+                    snapshot_obj = candidate_snapshot
 
-            inventory_container = self._inventory if isinstance(self._inventory, Inventory) else None
-            if inventory_container is None and isinstance(record, Mapping):
-                cached_inventory = record.get("inventory")
+            record_mapping: MutableMapping[str, Any]
+            if isinstance(existing_record, MutableMapping):
+                record_mapping = existing_record
+            else:
+                record_mapping = {}
+                if isinstance(existing_record, Mapping):
+                    record_mapping.update(existing_record)
+                if snapshot_obj is not None:
+                    record_mapping.setdefault("snapshot", snapshot_obj)
+                domain_bucket[self.entry_id] = record_mapping
+
+            if isinstance(resolved_nodes, Mapping):
+                record_mapping["nodes"] = resolved_nodes
+
+            snapshot_obj = (
+                ensure_snapshot(record_mapping)
+                if isinstance(record_mapping, Mapping)
+                else snapshot_obj
+            )
+
+            inventory_container: Inventory | None = (
+                self._inventory if isinstance(self._inventory, Inventory) else None
+            )
+            if inventory_container is None:
+                cached_inventory = record_mapping.get("inventory")
                 if isinstance(cached_inventory, Inventory):
                     inventory_container = cached_inventory
 
-            nodes_payload: Mapping[str, Any] | None = None
+            coordinator_inventory = getattr(self._coordinator, "_inventory", None)
+            coordinator_nodes: Iterable[Any] | None = None
+            if isinstance(coordinator_inventory, Inventory):
+                if inventory_container is None:
+                    inventory_container = coordinator_inventory
+                coordinator_nodes = coordinator_inventory.nodes
+            else:
+                node_inventory_attr = getattr(self._coordinator, "node_inventory", None)
+                if isinstance(node_inventory_attr, Iterable) and not isinstance(
+                    node_inventory_attr, (str, bytes)
+                ):
+                    coordinator_nodes = tuple(node_inventory_attr)
+
+            nodes_payload: Any | None
             if isinstance(resolved_nodes, Mapping):
                 nodes_payload = resolved_nodes
-            elif isinstance(record, Mapping):
-                nodes_payload = record.get("nodes")
-
-            if inventory_container is None and isinstance(snapshot_obj, InstallationSnapshot):
-                snapshot_nodes: Iterable[Any]
-                try:
-                    snapshot_nodes = tuple(snapshot_obj.inventory)
-                except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-                    snapshot_nodes = ()
-                raw_nodes_payload: Any
-                try:
-                    raw_nodes_payload = snapshot_obj.raw_nodes
-                except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-                    raw_nodes_payload = nodes_payload if nodes_payload is not None else {}
-                snapshot_dev_id = getattr(snapshot_obj, "dev_id", self.dev_id)
-                try:
-                    inventory_container = Inventory(
-                        str(snapshot_dev_id),
-                        raw_nodes_payload,
-                        snapshot_nodes,
-                    )
-                except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-                    inventory_container = None
+            else:
+                nodes_payload = record_mapping.get("nodes")
 
             if inventory_container is None:
-                payload_for_inventory: Any = nodes_payload if nodes_payload is not None else {}
-                try:
-                    inventory_nodes = build_node_inventory(payload_for_inventory)
-                except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-                    inventory_nodes = []
-                try:
-                    inventory_container = Inventory(
-                        self.dev_id,
-                        payload_for_inventory,
-                        inventory_nodes,
-                    )
-                except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-                    inventory_container = None
+                resolution = resolve_record_inventory(
+                    record_mapping,
+                    dev_id=self.dev_id,
+                    nodes_payload=nodes_payload,
+                    node_list=coordinator_nodes,
+                )
+                inventory_container = resolution.inventory
 
-            targets: list[tuple[str, str]] = []
-            if isinstance(inventory_container, Inventory):
-                targets = inventory_container.heater_sample_targets
-                self._inventory = inventory_container
-                if isinstance(record, dict):
-                    record["inventory"] = inventory_container
+            if not isinstance(inventory_container, Inventory):
+                _LOGGER.error(
+                    "WS (ducaheat): missing inventory for device %s; skipping heater subscriptions",
+                    self.dev_id,
+                )
+                return 0
 
+            self._inventory = inventory_container
+            record_mapping["inventory"] = inventory_container
+
+            if isinstance(snapshot_obj, InstallationSnapshot):
+                snapshot_nodes = (
+                    nodes_payload
+                    if nodes_payload is not None
+                    else snapshot_obj.raw_nodes
+                )
+                snapshot_obj.update_nodes(snapshot_nodes, inventory=inventory_container)
+                record_mapping.setdefault("snapshot", snapshot_obj)
+
+            targets: list[tuple[str, str]] = list(
+                inventory_container.heater_sample_targets
+            )
             if not any(node_type == "htr" for node_type, _ in targets):
                 fallback: Iterable[Any] | None = None
                 if hasattr(self._coordinator, "_addrs"):
@@ -823,7 +887,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                     except Exception:  # pragma: no cover - defensive  # noqa: BLE001
                         fallback = None
                 if fallback:
-                    seen_pairs = {pair for pair in targets}
+                    seen_pairs = set(targets)
                     for candidate in fallback:
                         addr = normalize_node_addr(candidate)
                         if not addr or ("htr", addr) in seen_pairs:
@@ -831,21 +895,22 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                         seen_pairs.add(("htr", addr))
                         targets.append(("htr", addr))
 
+            paths: set[str] = set()
             for node_type, addr in targets:
-                    paths.add(f"/{node_type}/{addr}/status")
-                    paths.add(f"/{node_type}/{addr}/samples")
+                paths.add(f"/{node_type}/{addr}/status")
+                paths.add(f"/{node_type}/{addr}/samples")
+
+            if not paths:
+                return 0
+
+            for path in sorted(paths):
+                await self._emit_sio("subscribe", path)
+
+            self._subscription_paths = paths
+            return len(paths)
         except Exception:  # pragma: no cover - defensive
             _LOGGER.debug("WS (ducaheat): subscribe failed", exc_info=True)
             return 0
-
-        if not paths:
-            return 0
-
-        for path in sorted(paths):
-            await self._emit_sio("subscribe", path)
-
-        self._subscription_paths = paths
-        return len(paths)
 
     async def _replay_subscription_paths(self) -> None:
         """Replay cached subscription paths after a reconnect."""
@@ -857,7 +922,9 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 await self._emit_sio("subscribe", path)
             except Exception:  # noqa: BLE001  # pragma: no cover - defensive logging
                 _LOGGER.debug(
-                    "WS (ducaheat): replay subscribe failed for path %s", path, exc_info=True
+                    "WS (ducaheat): replay subscribe failed for path %s",
+                    path,
+                    exc_info=True,
                 )
 
     async def _disconnect(self, reason: str) -> None:


### PR DESCRIPTION
## Summary
- update the Ducaheat websocket feed subscription helper to reuse cached Inventory data, resolve shared state, and log when inventory is missing instead of rebuilding from raw payloads
- extend the websocket protocol tests to exercise the Inventory-first workflow, coordinator fallbacks, and missing-inventory error handling

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68e8d73d50bc83299a1085836be79822