### PR TITLE
Require Inventory for TermoWeb coordinator node updates

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -1042,8 +1042,12 @@ class WebSocketClient(_WSStatusMixin):
                 self._inventory if isinstance(self._inventory, Inventory) else None
             )
         else:
-            raw_nodes = snapshot_obj.raw_nodes if snapshot_obj else {}
-            inventory_container = Inventory(self.dev_id, raw_nodes, inventory)
+            _LOGGER.debug(
+                "WS: ignoring unexpected inventory container (type=%s): %s",
+                type(inventory).__name__,
+                inventory,
+            )
+            inventory_container = None
 
         if isinstance(inventory_container, Inventory):
             if isinstance(record, MutableMapping):


### PR DESCRIPTION
## Summary
- require callers to provide an Inventory when updating coordinator nodes and rebuild lazily when metadata is missing
- ignore unexpected inventory hints in the websocket client instead of reconstructing nodes
- update coordinator and websocket tests to pass Inventory objects and cover the new behavior

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8d7309cfc8329a1fe9ea0b6f32ace