### PR TITLE
Import heater node types from inventory

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -22,13 +22,13 @@ from .boost import (
 )
 from .const import DOMAIN, signal_ws_data
 from .inventory import (
+    HEATER_NODE_TYPES,
     Inventory,
     Node,
     build_node_inventory,
     normalize_node_addr,
     normalize_node_type,
 )
-from .nodes import HEATER_NODE_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- import `HEATER_NODE_TYPES` from the inventory module in the heater helpers
- remove the obsolete import from the `nodes` module

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e8e37b038c83299d8c9df912592c9a