### PR TITLE
Add helper for heater platform metadata and update callers

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -18,12 +18,11 @@ from .coordinator import StateCoordinator
 from .entity import GatewayDispatcherEntity
 from .heater import (
     HeaterNodeBase,
+    heater_platform_details_for_entry,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
-    prepare_heater_platform_data,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import Inventory, heater_platform_details_from_inventory
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,21 +35,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     dev_id = data["dev_id"]
     gateway = GatewayOnlineBinarySensor(coord, entry.entry_id, dev_id)
 
-    entry_inventory = data.get("inventory")
-    if isinstance(entry_inventory, Inventory):
-        nodes_by_type, _, resolve_name = (
-            heater_platform_details_from_inventory(
-                entry_inventory,
-                default_name_simple=lambda addr: f"Node {addr}",
-            )
-        )
-    else:
-        _, nodes_by_type, _, resolve_name = (
-            prepare_heater_platform_data(
-                data,
-                default_name_simple=lambda addr: f"Node {addr}",
-            )
-        )
+    nodes_by_type, _, resolve_name = heater_platform_details_for_entry(
+        data,
+        default_name_simple=lambda addr: f"Node {addr}",
+    )
 
     boost_entities: list[BinarySensorEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -25,13 +25,12 @@ from .const import DOMAIN
 from .heater import (
     BoostButtonMetadata,
     HeaterNodeBase,
+    heater_platform_details_for_entry,
     iter_boost_button_metadata,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
-    prepare_heater_platform_data,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import Inventory, heater_platform_details_from_inventory
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,19 +49,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         StateRefreshButton(coordinator, entry.entry_id, dev_id)
     ]
 
-    entry_inventory = data.get("inventory")
-    if isinstance(entry_inventory, Inventory):
-        nodes_by_type, _, resolve_name = (
-            heater_platform_details_from_inventory(
-                entry_inventory,
-                default_name_simple=lambda addr: f"Heater {addr}",
-            )
-        )
-    else:
-        _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
-            data,
-            default_name_simple=lambda addr: f"Heater {addr}",
-        )
+    nodes_by_type, _, resolve_name = heater_platform_details_for_entry(
+        data,
+        default_name_simple=lambda addr: f"Heater {addr}",
+    )
 
     boost_entities: list[ButtonEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -31,14 +31,13 @@ from .coordinator import EnergyStateCoordinator
 from .entity import GatewayDispatcherEntity
 from .heater import (
     HeaterNodeBase,
+    heater_platform_details_for_entry,
     iter_boostable_heater_nodes,
     iter_heater_maps,
     iter_heater_nodes,
     log_skipped_nodes,
-    prepare_heater_platform_data,
 )
 from .identifiers import build_heater_energy_unique_id
-from .inventory import Inventory, heater_platform_details_from_inventory
 from .utils import build_gateway_device_info, float_or_none
 
 _WH_TO_KWH = 1 / 1000.0
@@ -108,19 +107,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    entry_inventory = data.get("inventory")
-    if isinstance(entry_inventory, Inventory):
-        nodes_by_type, addrs_by_type, resolve_name = (
-            heater_platform_details_from_inventory(
-                entry_inventory,
-                default_name_simple=lambda addr: f"Node {addr}",
-            )
-        )
-    else:
-        _, nodes_by_type, addrs_by_type, resolve_name = prepare_heater_platform_data(
-            data,
-            default_name_simple=lambda addr: f"Node {addr}",
-        )
+    nodes_by_type, addrs_by_type, resolve_name = heater_platform_details_for_entry(
+        data,
+        default_name_simple=lambda addr: f"Node {addr}",
+    )
 
     energy_coordinator: EnergyStateCoordinator | None = data.get(
         "energy_coordinator",

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -304,7 +304,7 @@ def test_button_setup_adds_accumulator_entities(
             raise AssertionError("prepare_heater_platform_data should not run")
 
         monkeypatch.setattr(
-            button_module,
+            heater_module,
             "prepare_heater_platform_data",
             _fail_prepare,
         )
@@ -386,7 +386,7 @@ def test_button_setup_falls_back_to_prepare_heater_platform_data(
             return_value=((), nodes_by_type, {"acm": [fallback_node.addr]}, _resolve_name)
         )
         monkeypatch.setattr(
-            button_module,
+            heater_module,
             "prepare_heater_platform_data",
             mock_prepare,
         )
@@ -436,7 +436,7 @@ def test_button_setup_falls_back_to_prepare_heater_platform_data(
 
         assert mock_prepare.call_count == 1
         call_args, call_kwargs = mock_prepare.call_args
-        assert call_args == (entry_data,)
+        assert call_args and call_args[0] == entry_data
         assert set(call_kwargs) == {"default_name_simple"}
         assert callable(call_kwargs["default_name_simple"])
 
@@ -667,7 +667,7 @@ def test_binary_sensor_setup_adds_boost_entities(
             raise AssertionError("prepare_heater_platform_data should not run")
 
         monkeypatch.setattr(
-            binary_sensor_module,
+            heater_module,
             "prepare_heater_platform_data",
             _fail_prepare,
         )

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -15,6 +15,7 @@ _install_stubs()
 
 from aiohttp import ClientError
 from custom_components.termoweb import coordinator as coordinator_module
+from custom_components.termoweb import heater as heater_module
 from custom_components.termoweb import sensor as sensor_module
 from custom_components.termoweb import const as const_module
 from custom_components.termoweb.identifiers import build_heater_energy_unique_id
@@ -363,7 +364,7 @@ def test_sensor_async_setup_entry_ignores_blank_addresses(
             raise AssertionError("prepare_heater_platform_data should not run")
 
         monkeypatch.setattr(
-            sensor_module,
+            heater_module,
             "prepare_heater_platform_data",
             _fail_prepare,
         )
@@ -426,7 +427,7 @@ def test_sensor_async_setup_entry_handles_boolean_boost_flag(
             raise AssertionError("prepare_heater_platform_data should not run")
 
         monkeypatch.setattr(
-            sensor_module,
+            heater_module,
             "prepare_heater_platform_data",
             _fail_prepare,
         )
@@ -526,7 +527,7 @@ def test_sensor_async_setup_entry_creates_entities_and_reuses_coordinator() -> N
 
         with (
             patch.object(
-                sensor_module,
+                heater_module,
                 "prepare_heater_platform_data",
                 side_effect=AssertionError(
                     "prepare_heater_platform_data should not run"


### PR DESCRIPTION
## Summary
- add `heater_platform_details_for_entry` to share heater metadata lookup logic for config entries
- refactor the binary sensor, button, and sensor platforms to rely on the new helper instead of duplicating inventory checks
- extend heater platform unit tests and update existing suites to cover the helper paths and boost/address behaviour

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e8e52c48b88329baae053c67a26a99