### PR TITLE
Use stored inventory when importing energy history

### DIFF
--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -357,13 +357,13 @@ async def async_import_energy_history(
         return
     client: RESTClient = rec["client"]
     dev_id: str = rec["dev_id"]
-    inventory_nodes: list[Any]
-    nodes_payload: Any | None = rec.get("nodes") if isinstance(rec, Mapping) else None
+    stored_inventory = rec.get("inventory") if isinstance(rec, Mapping) else None
+    node_list = getattr(stored_inventory, "nodes", None)
 
     resolution = resolve_record_inventory(
         rec,
         dev_id=dev_id,
-        nodes_payload=nodes_payload,
+        node_list=node_list,
     )
     inventory_container = resolution.inventory
     if inventory_container is None:
@@ -375,12 +375,6 @@ async def async_import_energy_history(
         return
 
     by_type, reverse_lookup = inventory_container.heater_address_map
-    logger.debug(
-        "%s: energy import using %s inventory (%d nodes)",
-        dev_id,
-        resolution.source,
-        resolution.filtered_count,
-    )
 
     requested_map: dict[str, list[str]] | None
     if nodes is None:


### PR DESCRIPTION
## Summary
- resolve energy import inventory using the cached container from the config entry record
- avoid emitting debug output when inventory is present and reuse the stored nodes for resolution
- extend energy import tests to cover cached-inventory and missing-inventory scenarios

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8f40f1a348329b3c1eba101348531