### PR TITLE
Use heater platform helper in select setup

### DIFF
--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -16,9 +16,9 @@ from .heater import (
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
     get_boost_runtime_minutes,
+    heater_platform_details_for_entry,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
-    prepare_heater_platform_data,
     resolve_boost_runtime_minutes,
     set_boost_runtime_minutes,
 )
@@ -33,7 +33,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    _, nodes_by_type, _, resolve_name = prepare_heater_platform_data(
+    nodes_by_type, _, resolve_name = heater_platform_details_for_entry(
         data,
         default_name_simple=lambda addr: f"Heater {addr}",
     )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -74,10 +74,12 @@ def test_select_setup_and_selection(
             boost_runtime=boost_runtime_store("acm", node.addr, 30),
         )
 
-        def fake_prepare(entry_data, default_name_simple):
-            return ([node], {"acm": [node]}, {"acm": [node.addr]}, lambda *_: "Accumulator 7")
+        def fake_details(entry_data, default_name_simple):
+            return ({"acm": [node]}, {"acm": [node.addr]}, lambda *_: "Accumulator 7")
 
-        monkeypatch.setattr(select_module, "prepare_heater_platform_data", fake_prepare)
+        monkeypatch.setattr(
+            select_module, "heater_platform_details_for_entry", fake_details
+        )
 
         added: list[AccumulatorBoostDurationSelect] = []
 
@@ -211,10 +213,12 @@ def test_select_restores_last_state(
             boost_runtime={},
         )
 
-        def fake_prepare(entry_data, default_name_simple):
-            return ([node], {"acm": [node]}, {"acm": [node.addr]}, lambda *_: "Accumulator 9")
+        def fake_details(entry_data, default_name_simple):
+            return ({"acm": [node]}, {"acm": [node.addr]}, lambda *_: "Accumulator 9")
 
-        monkeypatch.setattr(select_module, "prepare_heater_platform_data", fake_prepare)
+        monkeypatch.setattr(
+            select_module, "heater_platform_details_for_entry", fake_details
+        )
 
         added: list[AccumulatorBoostDurationSelect] = []
 
@@ -302,15 +306,16 @@ def test_select_filters_nodes_and_handles_fallback(
             boost_runtime={},
         )
 
-        def fake_prepare(entry_data, default_name_simple):
+        def fake_details(entry_data, default_name_simple):
             return (
-                [non_acm, disabled_acm, enabled_acm],
                 {"htr": [non_acm], "acm": [disabled_acm, enabled_acm]},
                 {"acm": [disabled_acm.addr, enabled_acm.addr]},
                 lambda *_: "Accumulator 3",
             )
 
-        monkeypatch.setattr(select_module, "prepare_heater_platform_data", fake_prepare)
+        monkeypatch.setattr(
+            select_module, "heater_platform_details_for_entry", fake_details
+        )
 
         added: list[AccumulatorBoostDurationSelect] = []
 


### PR DESCRIPTION
## Summary
- switch the select platform setup to consume `heater_platform_details_for_entry`
- align select platform unit tests with the new helper signature

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8f426a96c83298796619a1525f2d3