### PR TITLE
Update heater availability detection for inventory metadata

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -855,10 +855,28 @@ class HeaterNodeBase(CoordinatorEntity):
         return self._device_available(self._device_record())
 
     def _device_available(self, device_entry: dict[str, Any] | None) -> bool:
-        """Return True when the device entry contains node data."""
-        if not isinstance(device_entry, dict):
+        """Return True when the device entry exposes heater inventory metadata."""
+
+        if not isinstance(device_entry, Mapping):
             return False
-        return device_entry.get("nodes") is not None
+
+        inventory = device_entry.get("inventory")
+        if isinstance(inventory, Inventory):
+            return True
+
+        nodes_by_type = device_entry.get("nodes_by_type")
+        if isinstance(nodes_by_type, Mapping):
+            return True
+
+        address_map = device_entry.get("address_map")
+        if isinstance(address_map, Mapping):
+            return True
+
+        addresses_by_type = device_entry.get("addresses_by_type")
+        if isinstance(addresses_by_type, Mapping):
+            return True
+
+        return False
 
     def _device_record(self) -> dict[str, Any] | None:
         """Return the coordinator cache entry for this device."""

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2217,6 +2217,12 @@ def test_heater_properties_and_ws_update() -> None:
         coordinator_data = {
             dev_id: {
                 "nodes": {"nodes": []},
+                "nodes_by_type": {
+                    "htr": {
+                        "addrs": [addr],
+                        "settings": {addr: settings},
+                    }
+                },
                 "htr": {"settings": {addr: settings}},
                 "version": "2.0.0",
             }
@@ -2311,9 +2317,10 @@ def test_heater_properties_and_ws_update() -> None:
         finally:
             dt_util.NOW = original_now
 
-        coordinator.data[dev_id]["nodes"] = None
+        original_nodes_by_type = coordinator.data[dev_id]["nodes_by_type"]
+        coordinator.data[dev_id]["nodes_by_type"] = None
         assert heater.available is False
-        coordinator.data[dev_id]["nodes"] = {"nodes": []}
+        coordinator.data[dev_id]["nodes_by_type"] = original_nodes_by_type
         assert heater.available is True
 
         settings["mode"] = "auto"

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -645,13 +645,18 @@ def test_heater_base_async_added_without_hass() -> None:
     asyncio.run(_run())
 
 
-def test_device_available_requires_nodes_section() -> None:
+def test_device_available_accepts_inventory_metadata() -> None:
     coordinator = SimpleNamespace(hass=None)
     heater = _make_heater(coordinator)
+    inventory = Inventory("dev", {}, [])
 
     assert not heater._device_available(None)
     assert not heater._device_available({})
-    assert heater._device_available({"nodes": []})
+    assert not heater._device_available({"inventory": object()})
+    assert heater._device_available({"inventory": inventory})
+    assert heater._device_available({"nodes_by_type": {}})
+    assert heater._device_available({"address_map": {}})
+    assert heater._device_available({"addresses_by_type": {}})
 
 
 class _FakeDict(dict):

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -719,20 +719,25 @@ def test_sensor_async_setup_entry_requires_inventory() -> None:
 def test_heater_temp_sensor() -> None:
     async def _run() -> None:
         hass = HomeAssistant()
+        settings = {
+            "A": {
+                "mtemp": "21.5",
+                "units": "C",
+                "timestamp": 1_700_000_000,
+            }
+        }
         coordinator = types.SimpleNamespace(
             hass=hass,
             data={
                 "dev1": {
                     "nodes": {"nodes": [{"type": "htr", "addr": "A"}]},
-                    "htr": {
-                        "settings": {
-                            "A": {
-                                "mtemp": "21.5",
-                                "units": "C",
-                                "timestamp": 1_700_000_000,
-                            }
+                    "nodes_by_type": {
+                        "htr": {
+                            "addrs": ["A"],
+                            "settings": dict(settings),
                         }
                     },
+                    "htr": {"settings": settings},
                 }
             },
         )
@@ -783,10 +788,10 @@ def test_heater_temp_sensor() -> None:
             "units": "C",
         }
 
-        original_nodes = coordinator.data["dev1"]["nodes"]
-        coordinator.data["dev1"]["nodes"] = None
+        original_nodes_by_type = coordinator.data["dev1"]["nodes_by_type"]
+        coordinator.data["dev1"]["nodes_by_type"] = None
         assert sensor.available is False
-        coordinator.data["dev1"]["nodes"] = original_nodes
+        coordinator.data["dev1"]["nodes_by_type"] = original_nodes_by_type
         assert sensor.available is True
 
         original_device = coordinator.data["dev1"]


### PR DESCRIPTION
## Summary
- update `HeaterNodeBase._device_available` to consider inventory and derived metadata instead of raw node payloads
- adjust heater base, climate, and temperature sensor tests to reflect the new availability signals and cover inventory-only records

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8f3f2d70c8329ad04fdffc9a47139