### PR TITLE
Document inventory reuse for power monitor aliases

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,10 @@ management metadata such as `main_circuit_pmos` plus the `max_power_config`
 profiles and slots observed in captures. Inventory caches persist these nodes
 even though the integration only reads them today so future entities inherit the
 discover-once contract.【F:docs/ducaheat_api.md†L27-L33】【F:custom_components/termoweb/installation.py†L58-L117】
+The heater caches now have power-monitor siblings so websocket rebuilds retain
+forward/reverse address maps, compatibility aliases (covering legacy
+`power_monitor` keys) and subscription tuples alongside the heater metadata the
+coordinators already consume.【F:custom_components/termoweb/inventory.py†L181-L323】【F:custom_components/termoweb/installation.py†L69-L161】
 
 ## Key components
 
@@ -142,7 +146,7 @@ flowchart LR
     Gateway --> Pmo
 ```
 
-Power monitor energy counters flow exclusively through REST reads and `/pmo/{addr}/samples` requests using epoch-second windows; no WebSocket deltas supplement these feeds today.【F:docs/ducaheat_api.md†L154-L181】
+Power monitor energy counters flow exclusively through REST reads and `/pmo/{addr}/samples` requests using epoch-second windows; no WebSocket deltas supplement these feeds today.【F:docs/ducaheat_api.md†L154-L181】 Inventory rebuilds reuse the cached address maps so entity display names and compatibility aliases persist even if websocket clients need to reconstruct their snapshot state.
 
 ## Ducaheat selection & boost pipeline
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -100,6 +100,10 @@ def test_diagnostics_with_cached_inventory(caplog: pytest.LogCaptureFixture) -> 
         {"name": "Monitor", "addr": "2", "type": "pmo"},
     ]
 
+    forward_map, _ = inventory.power_monitor_address_map
+    assert forward_map == {"pmo": ["2"]}
+    assert inventory.power_monitor_sample_targets == [("pmo", "2")]
+
     flattened = _flatten(diagnostics)
     assert "dev_id" not in flattened
     assert "username" not in flattened

--- a/tests/test_installation_snapshot.py
+++ b/tests/test_installation_snapshot.py
@@ -109,6 +109,32 @@ def test_snapshot_sample_targets_filter_invalid_pairs(
     assert snapshot.heater_sample_targets == [("htr", "1"), ("acm", "2")]
 
 
+def test_snapshot_power_monitor_caches() -> None:
+    """Power monitor helpers should mirror heater cache behaviour."""
+
+    nodes = [
+        {"type": "pmo", "addr": "3", "name": "Monitor"},
+        {"type": "power_monitor", "addr": "4", "name": "Alias"},
+    ]
+    snapshot = _make_snapshot(nodes)
+
+    forward, reverse = snapshot.power_monitor_address_map
+    assert forward == {"pmo": ["3", "4"]}
+    assert reverse == {"3": {"pmo"}, "4": {"pmo"}}
+
+    sample_map, compat = snapshot.power_monitor_sample_address_map
+    assert sample_map == {"pmo": ["3", "4"]}
+    assert compat["power_monitor"] == "pmo"
+
+    targets_first = snapshot.power_monitor_sample_targets
+    targets_second = snapshot.power_monitor_sample_targets
+    assert targets_first == targets_second == [("pmo", "3"), ("pmo", "4")]
+
+    repeat_map, repeat_compat = snapshot.power_monitor_sample_address_map
+    assert repeat_map == sample_map
+    assert repeat_compat == compat
+
+
 def test_snapshot_update_nodes_accepts_inventory() -> None:
     """Providing an inventory container should refresh cached nodes."""
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -119,6 +119,12 @@ def test_power_monitor_stub() -> None:
     with pytest.raises(NotImplementedError):
         node.power_level()
 
+    assert node.sample_target() == ("pmo", "P1")
+    assert node.default_name() == "Monitor"
+
+    node.name = ""
+    assert node.default_name() == "Power Monitor P1"
+
 
 def test_thermostat_stub() -> None:
     node = ThermostatNode(name="Thermostat", addr="T1")


### PR DESCRIPTION
## Summary
- clarify that power monitor address caches preserve naming and alias metadata across rebuilds

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8f441b16083299011d9bd4d871da0