### PR TITLE
Refactor websocket inventory dispatch

### DIFF
--- a/custom_components/termoweb/backend/__init__.py
+++ b/custom_components/termoweb/backend/__init__.py
@@ -10,8 +10,8 @@ __all__ = [
     "Backend",
     "DucaheatBackend",
     "DucaheatRESTClient",
-    "TermoWebBackend",
     "HttpClientProto",
+    "TermoWebBackend",
     "WsClientProto",
     "create_backend",
 ]

--- a/custom_components/termoweb/backend/termoweb.py
+++ b/custom_components/termoweb/backend/termoweb.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from ..inventory import Inventory
 from .base import Backend, WsClientProto
 from .ws_client import WebSocketClient
-from ..inventory import Inventory
 
 try:  # pragma: no cover - exercised via backend tests
     from custom_components.termoweb.backend.termoweb_ws import (

--- a/custom_components/termoweb/boost.py
+++ b/custom_components/termoweb/boost.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import math
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, Callable, Iterator
+import math
+from typing import Any
 
 from homeassistant.util import dt as dt_util
 

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -30,12 +30,7 @@ from .heater import (
     resolve_boost_runtime_minutes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import (
-    HeaterNode,
-    Inventory,
-    normalize_node_addr,
-    normalize_node_type,
-)
+from .inventory import HeaterNode, Inventory, normalize_node_addr, normalize_node_type
 from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -108,7 +108,7 @@ async def async_get_config_entry_diagnostics(
         redacted = async_redact_data(diagnostics, SENSITIVE_FIELDS)
         if inspect.isawaitable(redacted):
             redacted = await redacted
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+    except Exception:  # pragma: no cover - defensive
         _LOGGER.exception(
             "Failed to redact diagnostics payload for %s", entry.entry_id
         )

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -23,9 +23,12 @@ from .inventory import (
 )
 from .throttle import (
     MonotonicRateLimiter,
-    default_samples_rate_limit_state,
-    reset_samples_rate_limit_state,
+    default_samples_rate_limit_state as _default_samples_rate_limit_state,
+    reset_samples_rate_limit_state as _reset_samples_rate_limit_state,
 )
+
+default_samples_rate_limit_state = _default_samples_rate_limit_state
+reset_samples_rate_limit_state = _reset_samples_rate_limit_state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -357,13 +360,9 @@ async def async_import_energy_history(
         return
     client: RESTClient = rec["client"]
     dev_id: str = rec["dev_id"]
-    inventory_nodes: list[Any]
-    nodes_payload: Any | None = rec.get("nodes") if isinstance(rec, Mapping) else None
-
     resolution = resolve_record_inventory(
         rec,
         dev_id=dev_id,
-        nodes_payload=nodes_payload,
     )
     inventory_container = resolution.inventory
     if inventory_container is None:

--- a/custom_components/termoweb/entity.py
+++ b/custom_components/termoweb/entity.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
-
-if TYPE_CHECKING:
-    from homeassistant.helpers.entity import Entity
+from typing import Any, Protocol
 
 from .heater import DispatcherSubscriptionHelper
 

--- a/custom_components/termoweb/installation.py
+++ b/custom_components/termoweb/installation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Any
 
 from .inventory import (

--- a/custom_components/termoweb/throttle.py
+++ b/custom_components/termoweb/throttle.py
@@ -1,12 +1,14 @@
 """Shared throttling helpers for the TermoWeb integration."""
 
 from __future__ import annotations
+
 """Shared throttling helpers for the TermoWeb integration."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import time
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 SleepCallable = Callable[[float], Awaitable[Any]]
 MonotonicCallable = Callable[[], float]

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -15,7 +15,9 @@ from .const import DOMAIN
 async def async_get_integration(*args, **kwargs):
     """Proxy ``homeassistant.loader.async_get_integration`` for monkeypatching."""
 
-    from homeassistant.loader import async_get_integration as loader_async_get_integration
+    from homeassistant.loader import (
+        async_get_integration as loader_async_get_integration,
+    )
 
     return await loader_async_get_integration(*args, **kwargs)
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 import re
 import subprocess
 import sys
-from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -652,6 +652,12 @@ def test_device_available_requires_nodes_section() -> None:
     assert not heater._device_available(None)
     assert not heater._device_available({})
     assert heater._device_available({"nodes": []})
+    inventory = Inventory(
+        "dev",
+        {"nodes": [{"type": "htr", "addr": "1"}]},
+        build_node_inventory([{"type": "htr", "addr": "1"}]),
+    )
+    assert heater._device_available({"inventory": inventory})
 
 
 class _FakeDict(dict):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from custom_components.termoweb.const import DOMAIN
 import custom_components.termoweb.identifiers as identifiers_module
 from custom_components.termoweb.identifiers import build_heater_energy_unique_id
 from custom_components.termoweb.inventory import (
+    Inventory,
     addresses_by_node_type,
     build_node_inventory,
     normalize_heater_addresses,
@@ -32,7 +33,7 @@ from custom_components.termoweb.utils import (
 def test_ensure_node_inventory_returns_cached_copy() -> None:
     raw = {"nodes": [{"type": "htr", "addr": "A"}]}
     cached = build_node_inventory(raw)
-    record = {"node_inventory": cached, "nodes": raw}
+    record = {"node_inventory": cached}
 
     result = ensure_node_inventory(record)
 
@@ -44,7 +45,7 @@ def test_ensure_node_inventory_filters_invalid_cached_entries() -> None:
     raw = {"nodes": [{"type": "htr", "addr": "A"}]}
     cached = build_node_inventory(raw)
     cached.append(types.SimpleNamespace(type="", addr="bad"))
-    record = {"node_inventory": cached, "nodes": {}}
+    record = {"node_inventory": cached}
 
     result = ensure_node_inventory(record)
 
@@ -64,7 +65,7 @@ def test_ensure_node_inventory_skips_node_like_entries_with_missing_fields() -> 
     raw = {"nodes": [{"type": "htr", "addr": "A"}]}
     cached = build_node_inventory(raw)
     cached.append(FakeNode())
-    record = {"node_inventory": cached, "nodes": {}}
+    record = {"node_inventory": cached}
 
     result = ensure_node_inventory(record)
 
@@ -73,25 +74,24 @@ def test_ensure_node_inventory_skips_node_like_entries_with_missing_fields() -> 
 
 def test_ensure_node_inventory_builds_and_caches() -> None:
     raw = {"nodes": [{"type": "acm", "addr": "B"}]}
-    record: dict[str, Any] = {"nodes": raw}
-    result = ensure_node_inventory(record)
+    record: dict[str, Any] = {}
+    result = ensure_node_inventory(record, nodes=raw)
 
     assert [node.addr for node in result] == ["B"]
     assert [node.addr for node in record.get("node_inventory", [])] == ["B"]
 
-    record["nodes"] = object()
     cached = ensure_node_inventory(record)
     assert cached == result
 
 
-def test_ensure_node_inventory_falls_back_to_record_nodes() -> None:
-    arg_nodes = {"nodes": []}
-    record_nodes = {"nodes": [{"type": "acm", "addr": "C"}]}
-    record: dict[str, Any] = {"nodes": record_nodes}
-    result = ensure_node_inventory(record, nodes=arg_nodes)
+def test_ensure_node_inventory_prefers_inventory_container() -> None:
+    raw = {"nodes": [{"type": "acm", "addr": "C"}]}
+    inventory = Inventory("dev", raw, build_node_inventory(raw))
+    record: dict[str, Any] = {"inventory": inventory}
+    result = ensure_node_inventory(record, nodes={"nodes": []})
 
     assert [node.addr for node in result] == ["C"]
-    assert [node.addr for node in record.get("node_inventory", [])] == ["C"]
+    assert record.get("node_inventory") == result
 
 
 def test_ensure_node_inventory_sets_empty_cache_when_missing() -> None:


### PR DESCRIPTION
## Summary
- emit inventory-centric metadata from the websocket dispatch helper and stop caching raw node payloads
- refactor the TermoWeb and Ducaheat websocket clients to persist Inventory containers while reusing cached address maps
- update entity helpers and unit tests to resolve node data through the Inventory container

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e8f4095140832980a8745933ce0642