### PR TITLE
Add power monitor support to TermoWeb energy flows

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -736,8 +736,12 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 if not normalised_addr:
                     continue
                 bucket[normalised_addr] = payload
-            if bucket:
-                updates[node_type] = bucket
+            lease_seconds = type_payload.get("lease_seconds")
+            if bucket or lease_seconds is not None:
+                updates[node_type] = {
+                    "samples": bucket,
+                    "lease_seconds": lease_seconds,
+                }
         return updates
 
     def _translate_path_update(self, payload: Any) -> dict[str, Any] | None:

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -722,8 +722,12 @@ class WebSocketClient(_WSStatusMixin):
                 if not normalised_addr:
                     continue
                 bucket[normalised_addr] = sample_payload
-            if bucket:
-                sample_updates[node_type] = bucket
+            lease_seconds = type_payload.get("lease_seconds")
+            if bucket or lease_seconds is not None:
+                sample_updates[node_type] = {
+                    "samples": bucket,
+                    "lease_seconds": lease_seconds,
+                }
 
         if merge and self._nodes_raw:
             self._merge_nodes(self._nodes_raw, nodes)

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -358,7 +358,7 @@ def test_state_coordinator_handles_none_nodes_payload(
         )
         == 0
     )
-    assert coordinator._inventory_addresses_by_type() == {}
+    assert coordinator._inventory_addresses_by_type() == {"pmo": []}
 
 
 def test_state_coordinator_logs_once_for_invalid_nodes(

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -186,13 +186,19 @@ def test_forward_ws_sample_updates_handles_power_monitors(
         hass,
         "entry",
         "dev",
-        {"power_monitor": {"7": {"power": 100}}},
+        {
+            "power_monitor": {
+                "samples": {"7": {"power": 100}},
+                "lease_seconds": 90,
+            }
+        },
     )
 
     handler.assert_called_once()
     args = handler.call_args[0]
     assert args[0] == "dev"
     assert args[1] == {"pmo": {"7": {"power": 100}}}
+    assert handler.call_args.kwargs.get("lease_seconds") == 90
 
 
 def test_forward_ws_sample_updates_skips_invalid_sections(
@@ -260,7 +266,10 @@ def test_forward_ws_sample_updates_inventory_validation(
         {
             None: {"1": {"power": 10}},
             "acm": "ignored",
-            "pmo": {"": {"power": 3}, "3": {"power": 5}},
+            "pmo": {
+                "samples": {"": {"power": 3}, "3": {"power": 5}},
+                "lease_seconds": 15,
+            },
         },
     )
 
@@ -268,6 +277,7 @@ def test_forward_ws_sample_updates_inventory_validation(
     args = handler.call_args[0]
     assert args[0] == "dev"
     assert args[1] == {"pmo": {"3": {"power": 5}}}
+    assert handler.call_args.kwargs.get("lease_seconds") == 15
 
 
 def test_termoweb_client_initialises_namespace_and_handlers(


### PR DESCRIPTION
## Summary
- add REST client handling for pmo settings and richer sample extraction
- cache energy-capable node addresses for htr, acm, and pmo types and scale websocket samples
- extend websocket bridges and tests to cover power monitor deltas and lease handling

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e8fd4f774c8329a900a03ba2c05b01