### PR TITLE
Align coordinator tests with immutable inventory outputs

### DIFF
--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -177,22 +177,24 @@ def test_node_as_dict() -> None:
 
 def test_existing_nodes_map_collects_sections() -> None:
     nodes = {
-        "nodes_by_type": {
-            "htr": {"addrs": ["1"], "settings": {"1": {"mode": "auto"}}},
-            "thm": {"addrs": [], "settings": {}},
+        "settings": {
+            "htr": {"1": {"mode": "auto"}},
+            "thm": {},
         },
-        "htr": {"addrs": ["1"], "settings": {"1": {"mode": "auto"}}},
-        "thm": {"addrs": [], "settings": {}},
+        "addresses_by_type": {"htr": ["1"], "thm": []},
+        "heater_address_map": {
+            "forward": {"htr": ["1"]},
+            "reverse": {"1": ["htr"]},
+        },
         "dev_id": "dev",
         "connected": True,
     }
 
     sections = _existing_nodes_map(nodes)
 
-    assert sections == {
-        "htr": {"addrs": ["1"], "settings": {"1": {"mode": "auto"}}},
-        "thm": {"addrs": [], "settings": {}},
-    }
+    assert sections["settings"]["htr"]["1"]["mode"] == "auto"
+    assert sections["settings"]["thm"] == {}
+    assert sections["addresses_by_type"]["htr"] == ["1"]
 
 
 def test_existing_nodes_map_handles_non_mapping_input() -> None:


### PR DESCRIPTION
## Summary
- Adjust coordinator regression tests to expect immutable inventory fields, including settings and addresses_by_type caches.
- Update energy coordinator scenarios to validate new settings/address maps and ensure refresh helpers continue to operate against cloned inventories.
- Refresh node inventory tests so _existing_nodes_map handles settings- and address-based payloads from the immutable container.

## Testing
- pytest --maxfail=1
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68e914dc928c83299e941b2a2a37f6c7