### PR TITLE
Use shared inventory container for heater helpers

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -35,14 +35,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     dev_id = data["dev_id"]
     gateway = GatewayOnlineBinarySensor(coord, entry.entry_id, dev_id)
 
-    nodes_by_type, _, resolve_name = heater_platform_details_for_entry(
+    heater_details = heater_platform_details_for_entry(
         data,
         default_name_simple=lambda addr: f"Node {addr}",
     )
+    nodes_by_type, _, resolve_name = heater_details
 
     boost_entities: list[BinarySensorEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
-        nodes_by_type, resolve_name
+        heater_details,
+        resolve_name,
     ):
         unique_id = build_heater_entity_unique_id(
             dev_id,
@@ -68,7 +70,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             "Adding %d TermoWeb heater boost binary sensors", len(boost_entities)
         )
 
-    log_skipped_nodes("binary_sensor", nodes_by_type, logger=_LOGGER)
+    log_skipped_nodes("binary_sensor", heater_details, logger=_LOGGER)
     async_add_entities([gateway, *boost_entities])
 
 

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -49,14 +49,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
         StateRefreshButton(coordinator, entry.entry_id, dev_id)
     ]
 
-    nodes_by_type, _, resolve_name = heater_platform_details_for_entry(
+    heater_details = heater_platform_details_for_entry(
         data,
         default_name_simple=lambda addr: f"Heater {addr}",
     )
+    nodes_by_type, _, resolve_name = heater_details
 
     boost_entities: list[ButtonEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
-        nodes_by_type,
+        heater_details,
         resolve_name,
         accumulators_only=True,
     ):
@@ -74,7 +75,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     if boost_entities:
         entities.extend(boost_entities)
-    log_skipped_nodes("button", nodes_by_type, logger=_LOGGER)
+    log_skipped_nodes("button", heater_details, logger=_LOGGER)
 
     async_add_entities(entities)
 

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -58,7 +58,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
         if isinstance(candidate, Inventory):
             inventory = candidate
 
-    nodes_by_type = inventory.nodes_by_type if isinstance(inventory, Inventory) else {}
 
     default_name_simple = lambda addr: f"Heater {addr}"
     new_entities: list[ClimateEntity] = []
@@ -92,7 +91,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         )
 
-    log_skipped_nodes("climate", nodes_by_type, logger=_LOGGER)
+    log_skipped_nodes("climate", inventory, logger=_LOGGER)
     if new_entities:
         _LOGGER.debug("Adding %d TermoWeb heater entities", len(new_entities))
         async_add_entities(new_entities)
@@ -326,6 +325,7 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
                 data,
                 map_key="settings",
                 node_types=[self._node_type],
+                inventory_or_details=getattr(self.coordinator, "inventory", None),
             )
         )
 

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -33,14 +33,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    nodes_by_type, _, resolve_name = heater_platform_details_for_entry(
+    heater_details = heater_platform_details_for_entry(
         data,
         default_name_simple=lambda addr: f"Heater {addr}",
     )
+    nodes_by_type, _, resolve_name = heater_details
 
     new_entities: list[AccumulatorBoostDurationSelect] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
-        nodes_by_type,
+        heater_details,
         resolve_name,
         accumulators_only=True,
     ):
@@ -62,7 +63,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         )
 
-    log_skipped_nodes("select", nodes_by_type, logger=_LOGGER)
+    log_skipped_nodes("select", heater_details, logger=_LOGGER)
 
     if new_entities:
         _LOGGER.debug("Adding %d TermoWeb boost selectors", len(new_entities))

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -256,7 +256,7 @@ def test_button_setup_adds_accumulator_entities(
         calls: list[str | None] = []
 
         def fake_iter_boostable(
-            nodes_by_type,
+            inventory_or_details,
             resolve_name,
             *,
             node_types=None,
@@ -264,7 +264,13 @@ def test_button_setup_adds_accumulator_entities(
         ):
             assert accumulators_only is True
             assert node_types is None
-            for node in nodes_by_type.get("acm", []):
+            if isinstance(inventory_or_details, tuple):
+                nodes_map = inventory_or_details[0]
+            elif hasattr(inventory_or_details, "nodes_by_type"):
+                nodes_map = inventory_or_details.nodes_by_type
+            else:
+                nodes_map = {}
+            for node in nodes_map.get("acm", []):
                 addr = getattr(node, "addr", None)
                 calls.append(addr)
                 if addr == acm_node.addr:
@@ -643,7 +649,7 @@ def test_binary_sensor_setup_adds_boost_entities(
         calls: list[str | None] = []
 
         def fake_iter_boostable(
-            nodes_by_type,
+            inventory_or_details,
             resolve_name,
             *,
             node_types=None,
@@ -651,7 +657,13 @@ def test_binary_sensor_setup_adds_boost_entities(
         ):
             assert accumulators_only is False
             assert node_types is None
-            for node in nodes_by_type.get("acm", []):
+            if isinstance(inventory_or_details, tuple):
+                nodes_map = inventory_or_details[0]
+            elif hasattr(inventory_or_details, "nodes_by_type"):
+                nodes_map = inventory_or_details.nodes_by_type
+            else:
+                nodes_map = {}
+            for node in nodes_map.get("acm", []):
                 addr = getattr(node, "addr", None)
                 calls.append(addr)
                 if addr == boost_node.addr:


### PR DESCRIPTION
## Summary
- refactor heater helper utilities to consume shared Inventory details instead of raw node mappings
- update heater platform setup callers to pass inventory metadata through, including energy aggregation helpers
- align binary sensor, button, select, climate, and sensor tests with the new helper interfaces

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e9289d027c8329a10a644ea65cc89f