### PR TITLE
Refactor heater availability to use normalized settings

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -67,16 +67,18 @@ def _make_coordinator(
     inventory_payload: Mapping[str, Any] | None = None,
     inventory_nodes: Iterable[Any] | None = None,
 ) -> FakeCoordinator:
+    normalised = FakeCoordinator._normalise_device_record(record)
+
     return FakeCoordinator(
         hass,
         client=client,
         dev_id=dev_id,
-        dev=record,
-        nodes=record.get("nodes", {}),
+        dev=normalised,
+        nodes=normalised.get("nodes", {}),
         inventory=inventory,
         inventory_payload=inventory_payload,
         inventory_nodes=inventory_nodes,
-        data={dev_id: record},
+        data={dev_id: normalised},
     )
 
 

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -672,9 +672,10 @@ def test_device_available_accepts_inventory_metadata() -> None:
     assert not heater._device_available({})
     assert not heater._device_available({"inventory": object()})
     assert heater._device_available({"inventory": inventory})
-    assert heater._device_available({"nodes_by_type": {}})
-    assert heater._device_available({"address_map": {}})
+    assert not heater._device_available({"nodes_by_type": {}})
+    assert heater._device_available({"heater_address_map": {"forward": {"htr": ["A"]}}})
     assert heater._device_available({"addresses_by_type": {}})
+    assert heater._device_available({"settings": {"htr": {"A": {}}}})
 
 
 class _FakeDict(dict):
@@ -718,7 +719,10 @@ def test_heater_section_falls_back_to_legacy_data() -> None:
     )
 
     section = heater._heater_section()
-    assert section == {"settings": {"A": {"mode": "auto"}}}
+    assert section == {
+        "addrs": ["A"],
+        "settings": {"A": {"mode": "auto"}},
+    }
 
 
 def test_heater_settings_missing_mapping() -> None:

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -745,6 +745,8 @@ def test_heater_temp_sensor() -> None:
                         }
                     },
                     "htr": {"settings": settings},
+                    "settings": {"htr": dict(settings)},
+                    "addresses_by_type": {"htr": ["A"]},
                 }
             },
         )
@@ -795,10 +797,10 @@ def test_heater_temp_sensor() -> None:
             "units": "C",
         }
 
-        original_nodes_by_type = coordinator.data["dev1"]["nodes_by_type"]
-        coordinator.data["dev1"]["nodes_by_type"] = None
-        assert sensor.available is False
-        coordinator.data["dev1"]["nodes_by_type"] = original_nodes_by_type
+        original_addresses = coordinator.data["dev1"]["addresses_by_type"]
+        coordinator.data["dev1"]["addresses_by_type"] = {}
+        assert sensor.available is True
+        coordinator.data["dev1"]["addresses_by_type"] = original_addresses
         assert sensor.available is True
 
         original_device = coordinator.data["dev1"]

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -370,9 +370,8 @@ def test_boost_entities_expose_state(monkeypatch: pytest.MonkeyPatch) -> None:
     coordinator = SimpleNamespace(
         data={
             "dev": {
-                "nodes_by_type": {
-                    "acm": {"settings": {"1": settings}},
-                }
+                "settings": {"acm": {"1": settings}},
+                "addresses_by_type": {"acm": ["1"]},
             }
         },
         resolve_boost_end=_resolver,
@@ -431,9 +430,8 @@ def test_boost_entities_handle_missing_data() -> None:
     coordinator = SimpleNamespace(
         data={
             "dev": {
-                "nodes_by_type": {
-                    "acm": {"settings": {"1": {}}},
-                }
+                "settings": {"acm": {"1": {}}},
+                "addresses_by_type": {"acm": ["1"]},
             }
         }
     )
@@ -483,7 +481,12 @@ def test_boost_entities_handle_missing_data() -> None:
 
 def test_boost_end_sensor_returns_base_state_when_available() -> None:
     coordinator = SimpleNamespace(
-        data={"dev": {"nodes_by_type": {"acm": {"settings": {"1": {}}}}}}
+        data={
+            "dev": {
+                "settings": {"acm": {"1": {}}},
+                "addresses_by_type": {"acm": ["1"]},
+            }
+        }
     )
 
     sensor = HeaterBoostEndSensor(
@@ -512,7 +515,12 @@ def test_boost_end_sensor_returns_base_state_when_available() -> None:
 
 def test_boost_end_sensor_handles_isoformat_error() -> None:
     coordinator = SimpleNamespace(
-        data={"dev": {"nodes_by_type": {"acm": {"settings": {"1": {}}}}}}
+        data={
+            "dev": {
+                "settings": {"acm": {"1": {}}},
+                "addresses_by_type": {"acm": ["1"]},
+            }
+        }
     )
 
     sensor = HeaterBoostEndSensor(


### PR DESCRIPTION
## Summary
- update HeaterNodeBase to derive availability and settings from normalized address and settings maps
- add helpers for test coordinators to expose normalized metadata and adjust heater-related tests accordingly
- refresh boost helper tests to use the new settings structure

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e92c3fae388329b313ddf48f26abcc