### PR TITLE
Ensure boost metadata and websocket payloads rely on inventory data

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -1927,6 +1927,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
                 "addr": None,
                 "kind": "nodes",
                 "addr_map": addr_map_payload,
+                "addresses_by_type": addr_map_payload,
             }
             async_dispatcher_send(
                 self.hass,
@@ -1945,6 +1946,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
                     "kind": f"{node_type}_settings",
                     "node_type": node_type,
                     "addr_map": addr_map,
+                    "addresses_by_type": addr_map,
                 },
             )
         for node_type, addr in set(sample_addrs):
@@ -1959,6 +1961,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
                     "kind": f"{node_type}_samples",
                     "node_type": node_type,
                     "addr_map": addr_map,
+                    "addresses_by_type": addr_map,
                 },
             )
         self._log_legacy_update(


### PR DESCRIPTION
## Summary
- build heater metadata for boost features from inventory-provided heater tuples instead of cached `nodes_by_type`
- derive coordinator address caches directly from inventory nodes and mirror address maps in websocket dispatch payloads for downstream consumers

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e9396557dc8329bbc46b6be2b460ce