### PR TITLE
Ensure power monitor addresses remain in heater address maps

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -1088,6 +1088,9 @@ class WebSocketClient(_WSStatusMixin):
         energy_coordinator = (
             record.get("energy_coordinator") if isinstance(record, Mapping) else None
         )
+        if pmo_addresses:
+            cleaned_map["pmo"] = list(pmo_addresses)
+
         if hasattr(energy_coordinator, "update_addresses"):
             energy_coordinator.update_addresses(cleaned_map)
 
@@ -1105,7 +1108,18 @@ class WebSocketClient(_WSStatusMixin):
                 if pmo_addresses or "pmo" in nodes_by_type:
                     bucket = self._ensure_type_bucket(dev_map, nodes_by_type, "pmo")
                     if pmo_addresses:
-                        bucket["addrs"] = list(pmo_addresses)
+                        addresses_copy = list(pmo_addresses)
+                        bucket["addrs"] = addresses_copy
+                        addr_map = dev_map.get("addr_map")
+                        if isinstance(addr_map, Mapping):
+                            updated_map = dict(addr_map)
+                            updated_map["pmo"] = list(addresses_copy)
+                            dev_map["addr_map"] = updated_map
+                        addresses_by_type = dev_map.get("addresses_by_type")
+                        if isinstance(addresses_by_type, Mapping):
+                            updated_map = dict(addresses_by_type)
+                            updated_map["pmo"] = list(addresses_copy)
+                            dev_map["addresses_by_type"] = updated_map
                 updated = dict(coordinator_data)
                 updated[self.dev_id] = dev_map
                 self._coordinator.data = updated  # type: ignore[attr-defined]

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -612,7 +612,14 @@ def test_apply_heater_addresses_includes_power_monitors(
         {"htr": ["1"], "pmo": ["", "5"]}, inventory=None, snapshot=None
     )
 
-    assert result == {"htr": ["1"]}
+    assert result == {"htr": ["1"], "pmo": ["5"]}
+
+    energy_coordinator = client.hass.data[module.DOMAIN]["entry"][
+        "energy_coordinator"
+    ]
+    energy_coordinator.update_addresses.assert_called_once()
+    payload_arg = energy_coordinator.update_addresses.call_args.args[0]
+    assert payload_arg == {"htr": ["1"], "pmo": ["5"]}
 
     coordinator_data = getattr(client._coordinator, "data", {})  # type: ignore[attr-defined]
     dev_state = coordinator_data.get("device") if isinstance(coordinator_data, dict) else None
@@ -624,6 +631,7 @@ def test_apply_heater_addresses_includes_power_monitors(
 
     second = client._apply_heater_addresses({"pmo": "7"}, inventory=None, snapshot=None)
     assert second.get("htr") == []
+    assert second.get("pmo") == ["7"]
 
     coordinator_data = getattr(client._coordinator, "data", {})  # type: ignore[attr-defined]
     dev_state = coordinator_data.get("device") if isinstance(coordinator_data, dict) else None


### PR DESCRIPTION
## Summary
- include any discovered power monitor addresses when normalising heater address maps so they are visible to the energy coordinator and cache consumers
- propagate the same power monitor list into the coordinator cache without overwriting existing structures
- extend websocket protocol tests to cover power monitor propagation for both the direct client helper and the websocket test suite

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: multiple pre-existing suite failures unrelated to these changes)*
- pytest tests/test_termoweb_ws_protocol.py -k power_monitor -q
- pytest tests/test_ws_client.py -k power_monitors -q


------
https://chatgpt.com/codex/tasks/task_e_68e955e9e38c83299c39b37a79c9c633