### PR TITLE
Switch TermoWeb metadata handling to inventory

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -56,7 +56,6 @@ from .energy import (
     default_samples_rate_limit_state,
     reset_samples_rate_limit_state,
 )
-from .installation import InstallationSnapshot
 from .inventory import Inventory, build_node_inventory
 from .utils import async_get_integration_version as _async_get_integration_version
 
@@ -360,14 +359,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
     nodes = await client.get_nodes(dev_id)
     node_inventory = build_node_inventory(nodes)
     # Inventory-centric design: build and freeze the gateway/node topology once
-    # during setup so every runtime component can trust the shared snapshot.
+    # during setup so every runtime component can trust the shared metadata.
     inventory = Inventory(dev_id, nodes, node_inventory)
-    snapshot = InstallationSnapshot(
-        dev_id=dev_id,
-        raw_nodes=nodes,
-        inventory=inventory,
-    )
-
     if inventory.nodes:
         type_counts = Counter(node.type for node in inventory.nodes)
         summary = ", ".join(
@@ -395,8 +388,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         "client": backend.client,
         "coordinator": coordinator,
         "dev_id": dev_id,
-        "snapshot": snapshot,
         "inventory": inventory,
+        "nodes": nodes,
         "config_entry": entry,
         "base_poll_interval": max(base_interval, MIN_POLL_INTERVAL),
         "stretched": False,

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -64,7 +64,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     dev_id = data["dev_id"]
 
     inventory = _resolve_inventory(data)
-    default_name = lambda addr: f"Heater {addr}"
+    def default_name(addr: str) -> str:
+        """Return a placeholder name for heater nodes."""
+
+        return f"Heater {addr}"
     if inventory is not None:
         heater_details = heater_platform_details_from_inventory(
             inventory,

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -378,7 +378,7 @@ def test_button_setup_falls_back_to_prepare_heater_platform_data(
             coordinator,
         )
 
-        entry_data["inventory"] = {"nodes": []}
+        entry_data.pop("inventory", None)
 
         fallback_node = heater_node_factory("7", node_type="acm")
         nodes_by_type = {"acm": [fallback_node]}
@@ -398,13 +398,16 @@ def test_button_setup_falls_back_to_prepare_heater_platform_data(
         )
 
         def _fake_iter(
-            nodes_by_type_arg,
+            metadata_or_details,
             resolve_name,
             *,
             node_types=None,
             accumulators_only=False,
         ):
-            assert nodes_by_type_arg is nodes_by_type
+            assert isinstance(metadata_or_details, tuple)
+            assert metadata_or_details[0] == nodes_by_type
+            assert metadata_or_details[1] == {"acm": [fallback_node.addr]}
+            assert metadata_or_details[2] is _resolve_name
             assert resolve_name is _resolve_name
             assert accumulators_only is True
             assert node_types is None

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2327,6 +2327,10 @@ def test_heater_properties_and_ws_update() -> None:
             dt_util.NOW = original_now
 
         original_nodes_by_type = coordinator.data[dev_id]["nodes_by_type"]
+        coordinator.data[dev_id].pop("inventory", None)
+        coordinator.data[dev_id].pop("addresses_by_type", None)
+        coordinator.data[dev_id].pop("nodes", None)
+        coordinator.data[dev_id]["htr"] = {}
         coordinator.data[dev_id]["nodes_by_type"] = None
         assert heater.available is False
         coordinator.data[dev_id]["nodes_by_type"] = original_nodes_by_type

--- a/tests/test_heater_base.py
+++ b/tests/test_heater_base.py
@@ -675,7 +675,7 @@ def test_device_available_accepts_inventory_metadata() -> None:
     assert not heater._device_available({"nodes_by_type": {}})
     assert heater._device_available({"heater_address_map": {"forward": {"htr": ["A"]}}})
     assert heater._device_available({"addresses_by_type": {}})
-    assert heater._device_available({"settings": {"htr": {"A": {}}}})
+    assert not heater._device_available({"settings": {"htr": {"A": {}}}})
 
 
 class _FakeDict(dict):

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -882,8 +882,21 @@ def test_total_energy_sensor() -> None:
                 }
             }
         }
+        raw_nodes = {
+            "nodes": [
+                {"type": "htr", "addr": "A"},
+                {"type": "acm", "addr": "B"},
+            ]
+        }
+        inventory = Inventory("1", raw_nodes, build_node_inventory(raw_nodes))
+        hass.data[DOMAIN][entry_id]["inventory"] = inventory
         total_sensor = InstallationTotalEnergySensor(
-            coord, entry_id, "1", "Total Energy", "tot"
+            coord,
+            entry_id,
+            "1",
+            "Total Energy",
+            "tot",
+            inventory,
         )
         total_sensor.hass = hass
         with patch.object(
@@ -1005,8 +1018,15 @@ def test_energy_and_power_sensor_properties() -> None:
 
         coordinator.data = copy.deepcopy(base_data)
 
+    raw_nodes = {"nodes": [{"type": "htr", "addr": "A"}]}
+    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
     total_sensor = InstallationTotalEnergySensor(
-        coordinator, "entry", "dev", "Total", "tot"
+        coordinator,
+        "entry",
+        "dev",
+        "Total",
+        "tot",
+        inventory,
     )
     total_sensor.hass = hass
     hass.data = {
@@ -1014,6 +1034,7 @@ def test_energy_and_power_sensor_properties() -> None:
             "entry": {
                 "coordinator": coordinator,
                 "dev_id": "dev",
+                "inventory": inventory,
             }
         }
     }
@@ -1054,8 +1075,21 @@ def test_energy_sensor_respects_scale_metadata() -> None:
         "uid",
         "Node",
     )
+    raw_nodes = {
+        "nodes": [
+            {"type": "htr", "addr": "A"},
+            {"type": "htr", "addr": "B"},
+        ]
+    }
+    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    coordinator.data.setdefault("dev", {})["inventory"] = inventory
     total_sensor = InstallationTotalEnergySensor(
-        coordinator, "entry", "dev", "Total", "tot"
+        coordinator,
+        "entry",
+        "dev",
+        "Total",
+        "tot",
+        inventory,
     )
 
     assert energy_sensor.native_value == pytest.approx(1.5)

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -2459,12 +2459,19 @@ def test_energy_polling_matches_import(monkeypatch: pytest.MonkeyPatch) -> None:
             "uid",
             "Device A",
         )
+        raw_nodes = {"nodes": [{"type": "htr", "addr": "A"}]}
+        inventory = inventory_module.Inventory(
+            "dev",
+            raw_nodes,
+            inventory_module.build_node_inventory(raw_nodes),
+        )
         total_entity = sensor_mod.InstallationTotalEnergySensor(
             coordinator,
             "entry",
             "dev",
             "Total",
             "total_uid",
+            inventory,
         )
 
         assert energy_entity.native_value == pytest.approx(1.3)
@@ -2948,9 +2955,12 @@ def test_service_uses_snapshot_inventory(monkeypatch: pytest.MonkeyPatch) -> Non
 
         rec = hass.data[const.DOMAIN][entry.entry_id]
         rec.pop("node_inventory", None)
-        rec["snapshot"] = InstallationSnapshot(
-            dev_id="dev",
-            raw_nodes={"nodes": [{"type": "htr", "addr": "A"}]},
+        raw_nodes = {"nodes": [{"type": "htr", "addr": "A"}]}
+        rec["nodes"] = raw_nodes
+        rec["inventory"] = inventory_module.Inventory(
+            "dev",
+            raw_nodes,
+            inventory_module.build_node_inventory(raw_nodes),
         )
 
         hass.data[const.DOMAIN]["other"] = object()

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -175,11 +175,11 @@ def test_forward_ws_sample_updates_handles_power_monitors(
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": {}}})
     raw_nodes = {"nodes": [{"type": "pmo", "addr": "7", "name": "PM"}]}
     inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
-    snapshot = InstallationSnapshot(dev_id="dev", raw_nodes=raw_nodes, inventory=inventory)
     handler = MagicMock()
     hass.data[base_ws.DOMAIN]["entry"] = {
         "energy_coordinator": SimpleNamespace(handle_ws_samples=handler),
-        "snapshot": snapshot,
+        "inventory": inventory,
+        "nodes": raw_nodes,
     }
 
     base_ws.forward_ws_sample_updates(


### PR DESCRIPTION
## Summary
- persist the Inventory container and raw node payload on setup instead of caching an InstallationSnapshot
- refactor sensors, websocket routing, and helper utilities to resolve metadata from the stored inventory data
- tighten heater availability logic and update tests to validate the inventory-centric data layout

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68e955b009508329a139b88c5fa05ee5