### PR TITLE
Remove unused nodes import from energy coordinator tests

### DIFF
--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -14,7 +14,6 @@ _install_stubs()
 
 from aiohttp import ClientError
 from custom_components.termoweb import coordinator as coord_module
-from custom_components.termoweb import nodes as nodes_module
 from custom_components.termoweb.api import BackendAuthError, BackendRateLimitError
 from custom_components.termoweb.const import (
     HTR_ENERGY_UPDATE_INTERVAL,


### PR DESCRIPTION
## Summary
- drop the unused nodes module import from energy coordinator tests to rely on inventory fixtures

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: existing test failures in binary sensor button, climate, heater, and import energy history suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e9559c3f888329aca04e2ba73590a5