### PR TITLE
Streamline heater platform metadata lookups

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Mapping
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -18,33 +18,14 @@ from .coordinator import StateCoordinator
 from .entity import GatewayDispatcherEntity
 from .heater import (
     HeaterNodeBase,
-    HeaterPlatformDetails,
-    heater_platform_details_from_inventory,
     heater_platform_details_for_entry,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import Inventory
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _resolve_inventory(entry_data: Mapping[str, Any]) -> Inventory | None:
-    """Return the Inventory associated with ``entry_data`` when present."""
-
-    candidate = entry_data.get("inventory")
-    if isinstance(candidate, Inventory):
-        return candidate
-
-    coordinator = entry_data.get("coordinator")
-    candidate = getattr(coordinator, "inventory", None)
-    if isinstance(candidate, Inventory):
-        return candidate
-
-    return None
-
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up one connectivity binary sensor per TermoWeb hub (dev_id)."""
@@ -53,26 +34,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     dev_id = data["dev_id"]
     gateway = GatewayOnlineBinarySensor(coord, entry.entry_id, dev_id)
 
-    inventory = _resolve_inventory(data)
     default_name = lambda addr: f"Node {addr}"
-    if inventory is not None:
-        heater_details = heater_platform_details_from_inventory(
-            inventory,
-            default_name_simple=default_name,
-        )
-    else:
-        heater_details = heater_platform_details_for_entry(
-            data,
-            default_name_simple=default_name,
-        )
-    _, _, resolve_name = heater_details
-    metadata_source: Inventory | HeaterPlatformDetails = (
-        inventory if inventory is not None else heater_details
+    heater_details = heater_platform_details_for_entry(
+        data,
+        default_name_simple=default_name,
     )
+    _, _, resolve_name = heater_details
 
     boost_entities: list[BinarySensorEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
-        metadata_source,
+        heater_details,
         resolve_name,
     ):
         unique_id = build_heater_entity_unique_id(
@@ -99,7 +70,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             "Adding %d TermoWeb heater boost binary sensors", len(boost_entities)
         )
 
-    log_skipped_nodes("binary_sensor", metadata_source, logger=_LOGGER)
+    log_skipped_nodes("binary_sensor", heater_details, logger=_LOGGER)
     async_add_entities([gateway, *boost_entities])
 
 

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Mapping
+from typing import Any
 
 from homeassistant.components.button import ButtonEntity
 
@@ -25,36 +25,17 @@ from .const import DOMAIN
 from .heater import (
     BoostButtonMetadata,
     HeaterNodeBase,
-    HeaterPlatformDetails,
-    heater_platform_details_from_inventory,
     heater_platform_details_for_entry,
     iter_boost_button_metadata,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import Inventory
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
 _SERVICE_REQUEST_ACCUMULATOR_BOOST = "request_accumulator_boost"
-
-
-def _resolve_inventory(entry_data: Mapping[str, Any]) -> Inventory | None:
-    """Return the Inventory associated with ``entry_data`` when available."""
-
-    candidate = entry_data.get("inventory")
-    if isinstance(candidate, Inventory):
-        return candidate
-
-    coordinator = entry_data.get("coordinator")
-    candidate = getattr(coordinator, "inventory", None)
-    if isinstance(candidate, Inventory):
-        return candidate
-
-    return None
-
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Expose hub refresh and accumulator boost helper buttons."""
@@ -63,25 +44,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
 
-    inventory = _resolve_inventory(data)
     def default_name(addr: str) -> str:
         """Return a placeholder name for heater nodes."""
 
         return f"Heater {addr}"
-    if inventory is not None:
-        heater_details = heater_platform_details_from_inventory(
-            inventory,
-            default_name_simple=default_name,
-        )
-    else:
-        heater_details = heater_platform_details_for_entry(
-            data,
-            default_name_simple=default_name,
-        )
-    _, _, resolve_name = heater_details
-    metadata_source: Inventory | HeaterPlatformDetails = (
-        inventory if inventory is not None else heater_details
+    heater_details = heater_platform_details_for_entry(
+        data,
+        default_name_simple=default_name,
     )
+    _, _, resolve_name = heater_details
 
     entities: list[ButtonEntity] = [
         StateRefreshButton(coordinator, entry.entry_id, dev_id)
@@ -89,7 +60,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     boost_entities: list[ButtonEntity] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
-        metadata_source,
+        heater_details,
         resolve_name,
         accumulators_only=True,
     ):
@@ -107,7 +78,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     if boost_entities:
         entities.extend(boost_entities)
-    log_skipped_nodes("button", metadata_source, logger=_LOGGER)
+    log_skipped_nodes("button", heater_details, logger=_LOGGER)
 
     async_add_entities(entities)
 

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Mapping
+from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.helpers.entity import EntityCategory
@@ -15,9 +15,7 @@ from .heater import (
     BOOST_DURATION_OPTIONS,
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
-    HeaterPlatformDetails,
     get_boost_runtime_minutes,
-    heater_platform_details_from_inventory,
     heater_platform_details_for_entry,
     iter_boostable_heater_nodes,
     log_skipped_nodes,
@@ -25,24 +23,8 @@ from .heater import (
     set_boost_runtime_minutes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import Inventory
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _resolve_inventory(entry_data: Mapping[str, Any]) -> Inventory | None:
-    """Return the Inventory attached to ``entry_data`` when available."""
-
-    candidate = entry_data.get("inventory")
-    if isinstance(candidate, Inventory):
-        return candidate
-
-    coordinator = entry_data.get("coordinator")
-    candidate = getattr(coordinator, "inventory", None)
-    if isinstance(candidate, Inventory):
-        return candidate
-
-    return None
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -51,26 +33,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    inventory = _resolve_inventory(data)
     default_name = lambda addr: f"Heater {addr}"
-    if inventory is not None:
-        heater_details = heater_platform_details_from_inventory(
-            inventory,
-            default_name_simple=default_name,
-        )
-    else:
-        heater_details = heater_platform_details_for_entry(
-            data,
-            default_name_simple=default_name,
-        )
-    _, _, resolve_name = heater_details
-    metadata_source: Inventory | HeaterPlatformDetails = (
-        inventory if inventory is not None else heater_details
+    heater_details = heater_platform_details_for_entry(
+        data,
+        default_name_simple=default_name,
     )
+    _, _, resolve_name = heater_details
 
     new_entities: list[AccumulatorBoostDurationSelect] = []
     for node_type, _node, addr_str, base_name in iter_boostable_heater_nodes(
-        metadata_source,
+        heater_details,
         resolve_name,
         accumulators_only=True,
     ):
@@ -92,7 +64,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         )
 
-    log_skipped_nodes("select", metadata_source, logger=_LOGGER)
+    log_skipped_nodes("select", heater_details, logger=_LOGGER)
 
     if new_entities:
         _LOGGER.debug("Adding %d TermoWeb boost selectors", len(new_entities))

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -264,12 +264,10 @@ def test_button_setup_adds_accumulator_entities(
         ):
             assert accumulators_only is True
             assert node_types is None
-            if isinstance(inventory_or_details, tuple):
-                nodes_map = inventory_or_details[0]
-            elif hasattr(inventory_or_details, "nodes_by_type"):
-                nodes_map = inventory_or_details.nodes_by_type
-            else:
-                nodes_map = {}
+            assert isinstance(inventory_or_details, tuple)
+            nodes_map, addrs_map, resolver = inventory_or_details
+            assert set(addrs_map.get("acm", [])) == {acm_node.addr, acm_skip.addr}
+            assert resolver is resolve_name
             for node in nodes_map.get("acm", []):
                 addr = getattr(node, "addr", None)
                 calls.append(addr)
@@ -660,12 +658,10 @@ def test_binary_sensor_setup_adds_boost_entities(
         ):
             assert accumulators_only is False
             assert node_types is None
-            if isinstance(inventory_or_details, tuple):
-                nodes_map = inventory_or_details[0]
-            elif hasattr(inventory_or_details, "nodes_by_type"):
-                nodes_map = inventory_or_details.nodes_by_type
-            else:
-                nodes_map = {}
+            assert isinstance(inventory_or_details, tuple)
+            nodes_map, addrs_map, resolver = inventory_or_details
+            assert set(addrs_map.get("acm", [])) == {boost_node.addr, skip_node.addr}
+            assert resolver is resolve_name
             for node in nodes_map.get("acm", []):
                 addr = getattr(node, "addr", None)
                 calls.append(addr)

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -317,12 +317,8 @@ def test_sensor_async_setup_entry_defaults_and_skips_invalid(
 
         assert calls and calls[0][0] == "sensor"
         logged_details = calls[0][1]
-        if isinstance(logged_details, tuple):
-            logged_nodes = logged_details[0]
-        elif hasattr(logged_details, "nodes_by_type"):
-            logged_nodes = logged_details.nodes_by_type
-        else:
-            logged_nodes = {}
+        assert isinstance(logged_details, tuple)
+        logged_nodes = logged_details[0]
         assert "pmo" in logged_nodes
         messages = [record.getMessage() for record in caplog.records]
         assert any(


### PR DESCRIPTION
## Summary
- call `heater_platform_details_for_entry` directly from the binary sensor, button, select, and sensor setup routines
- rely on the returned heater metadata tuple for boost iteration, logging, and total energy handling without local inventory helpers
- update the platform tests to assert the streamlined metadata plumbing

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e96d9da0688329948e8f38a1705be3