### PR TITLE
Align Ducaheat websocket dispatch with shared inventory flow

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
+from collections.abc import Iterable, Mapping, MutableMapping
 from copy import deepcopy
 import gzip
 import json
@@ -11,15 +12,15 @@ import logging
 import random
 import string
 import time
-from typing import Any, Iterable, Mapping, MutableMapping
+from typing import Any
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import aiohttp
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from ..api import RESTClient
-from ..const import (
+from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.const import (
     ACCEPT_LANGUAGE,
     API_BASE,
     BRAND_DUCAHEAT,
@@ -28,19 +29,22 @@ from ..const import (
     get_brand_api_base,
     get_brand_requested_with,
     get_brand_user_agent,
+    signal_ws_data,
 )
-from ..inventory import (
+from custom_components.termoweb.inventory import (
+    HEATER_NODE_TYPES,
     Inventory,
     normalize_node_addr,
     normalize_node_type,
     resolve_record_inventory,
 )
-from .ws_client import (
+from custom_components.termoweb.backend.ws_client import (
     DUCAHEAT_NAMESPACE,
     HandshakeError,
     WSStats,
     _WSCommon,
     _WsLeaseMixin,
+    _prepare_nodes_dispatch,
     forward_ws_sample_updates,
     resolve_ws_update_section,
 )
@@ -545,9 +549,9 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                         break
                         break
                     continue
-                elif msg.type == aiohttp.WSMsgType.ERROR:
+                if msg.type == aiohttp.WSMsgType.ERROR:
                     raise RuntimeError(f"websocket error: {ws.exception()}")
-                elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED}:
+                if msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED}:
                     raise RuntimeError("websocket closed")
         finally:
             _LOGGER.debug("WS (ducaheat): read loop ended (ws closed or error)")
@@ -703,6 +707,424 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         snapshot: dict[str, Any] = {"nodes": nodes_copy, "nodes_by_type": nodes_by_type}
         snapshot.update(nodes_by_type)
         return snapshot
+
+    def _ensure_type_bucket(
+        self, dev_map: dict[str, Any], nodes_by_type: dict[str, Any], node_type: str
+    ) -> dict[str, Any]:
+        """Return the node bucket for ``node_type`` with default sections."""
+
+        bucket = nodes_by_type.get(node_type)
+        if bucket is None:
+            bucket = {
+                "addrs": [],
+                "settings": {},
+                "advanced": {},
+                "samples": {},
+            }
+            nodes_by_type[node_type] = bucket
+        else:
+            bucket.setdefault("addrs", [])
+            bucket.setdefault("settings", {})
+            bucket.setdefault("advanced", {})
+            bucket.setdefault("samples", {})
+        if node_type == "htr":
+            dev_map["htr"] = bucket
+        return bucket
+
+    def _apply_heater_addresses(
+        self,
+        normalized_map: Mapping[Any, Iterable[Any]] | None,
+        *,
+        inventory: Inventory | None = None,
+    ) -> dict[str, list[str]]:
+        """Update entry and coordinator state with heater address data."""
+
+        cleaned_map: dict[str, list[str]] = {}
+        if isinstance(normalized_map, Mapping):
+            for raw_type, addrs in normalized_map.items():
+                node_type = normalize_node_type(raw_type)
+                if not node_type:
+                    continue
+                if node_type not in HEATER_NODE_TYPES:
+                    continue
+                if isinstance(addrs, (str, bytes)):
+                    addr_iterable: Iterable[Any] = [addrs]
+                else:
+                    addr_iterable = addrs or []
+                addresses: list[str] = []
+                for candidate in addr_iterable:
+                    addr = normalize_node_addr(candidate)
+                    if not addr or addr in addresses:
+                        continue
+                    addresses.append(addr)
+                if addresses:
+                    cleaned_map[node_type] = addresses
+                else:
+                    cleaned_map.setdefault(node_type, [])
+
+        cleaned_map.setdefault("htr", [])
+
+        record_container = self.hass.data.get(DOMAIN, {})
+        record_raw = (
+            record_container.get(self.entry_id)
+            if isinstance(record_container, dict)
+            else None
+        )
+        record = record_raw if isinstance(record_raw, Mapping) else None
+        record_mutable: MutableMapping[str, Any] | None = (
+            record_raw if isinstance(record_raw, MutableMapping) else None
+        )
+
+        if isinstance(inventory, Inventory):
+            inventory_container = inventory
+        elif inventory is None:
+            inventory_container = (
+                self._inventory if isinstance(self._inventory, Inventory) else None
+            )
+        else:
+            _LOGGER.debug(
+                "WS (ducaheat): ignoring unexpected inventory container (type=%s): %s",
+                type(inventory).__name__,
+                inventory,
+            )
+            inventory_container = None
+
+        if isinstance(inventory_container, Inventory):
+            if isinstance(record_mutable, MutableMapping):
+                record_mutable["inventory"] = inventory_container
+            if not isinstance(self._inventory, Inventory):
+                self._inventory = inventory_container
+
+        pmo_addresses: list[str] = []
+        if isinstance(inventory_container, Inventory):
+            forward_map, _ = inventory_container.power_monitor_address_map
+            pmo_addresses = list(forward_map.get("pmo", []))
+        elif isinstance(normalized_map, Mapping):
+            raw_addrs = normalized_map.get("pmo")
+            if isinstance(raw_addrs, (str, bytes)):
+                candidates: Iterable[Any] = [raw_addrs]
+            elif isinstance(raw_addrs, Iterable):
+                candidates = raw_addrs
+            else:
+                candidates = []
+            seen: set[str] = set()
+            for candidate in candidates:
+                addr = normalize_node_addr(candidate, use_default_when_falsey=True)
+                if not addr or addr in seen:
+                    continue
+                seen.add(addr)
+                pmo_addresses.append(addr)
+
+        energy_coordinator = (
+            record.get("energy_coordinator") if isinstance(record, Mapping) else None
+        )
+        if pmo_addresses:
+            cleaned_map["pmo"] = list(pmo_addresses)
+
+        if hasattr(energy_coordinator, "update_addresses"):
+            energy_coordinator.update_addresses(cleaned_map)
+
+        coordinator_data = getattr(self._coordinator, "data", None)
+        if isinstance(coordinator_data, dict):
+            dev_map = coordinator_data.get(self.dev_id)
+            if isinstance(dev_map, dict):
+                nodes_by_type: dict[str, Any] = dev_map.setdefault("nodes_by_type", {})
+
+                def _iter_addresses(candidate: Any) -> Iterable[Any]:
+                    """Return iterable form of ``candidate`` for address merging."""
+
+                    if isinstance(candidate, (str, bytes)):
+                        return [candidate]
+                    if isinstance(candidate, Iterable):
+                        return candidate
+                    return []
+
+                def _merge_addresses(
+                    existing: Any,
+                    candidates: Iterable[Any],
+                ) -> list[str]:
+                    """Return normalised union of ``existing`` and ``candidates``."""
+
+                    merged: list[str] = []
+                    seen: set[str] = set()
+                    if isinstance(existing, Iterable) and not isinstance(
+                        existing, (str, bytes)
+                    ):
+                        for candidate in existing:
+                            addr = normalize_node_addr(
+                                candidate,
+                                use_default_when_falsey=True,
+                            )
+                            if not addr or addr in seen:
+                                continue
+                            merged.append(addr)
+                            seen.add(addr)
+                    for candidate in candidates:
+                        addr = normalize_node_addr(
+                            candidate,
+                            use_default_when_falsey=True,
+                        )
+                        if not addr or addr in seen:
+                            continue
+                        merged.append(addr)
+                        seen.add(addr)
+                    return merged
+
+                addresses_by_type: dict[str, list[str]] = {}
+                existing_addresses = dev_map.get("addresses_by_type")
+                if isinstance(existing_addresses, Mapping):
+                    for raw_type, raw_addrs in existing_addresses.items():
+                        node_type = normalize_node_type(
+                            raw_type,
+                            use_default_when_falsey=True,
+                        )
+                        if not node_type:
+                            continue
+                        merged = _merge_addresses(
+                            addresses_by_type.get(node_type),
+                            _iter_addresses(raw_addrs),
+                        )
+                        addresses_by_type[node_type] = merged
+
+                for node_type, addrs in cleaned_map.items():
+                    if not addrs and node_type != "htr":
+                        continue
+                    bucket = self._ensure_type_bucket(dev_map, nodes_by_type, node_type)
+                    merged_addrs = _merge_addresses(bucket.get("addrs"), addrs)
+                    if merged_addrs or node_type == "htr":
+                        bucket["addrs"] = merged_addrs
+                    addresses_by_type[node_type] = merged_addrs
+                    if node_type == "pmo" and merged_addrs:
+                        addr_map = dev_map.get("addr_map")
+                        if isinstance(addr_map, Mapping):
+                            updated_map = dict(addr_map)
+                            updated_map["pmo"] = list(merged_addrs)
+                            dev_map["addr_map"] = updated_map
+
+                if (pmo_addresses or "pmo" in nodes_by_type) and "pmo" not in cleaned_map:
+                    bucket = self._ensure_type_bucket(dev_map, nodes_by_type, "pmo")
+                    merged_addrs = _merge_addresses(bucket.get("addrs"), pmo_addresses)
+                    bucket["addrs"] = merged_addrs
+                    addresses_by_type["pmo"] = merged_addrs
+                    if merged_addrs:
+                        addr_map = dev_map.get("addr_map")
+                        if isinstance(addr_map, Mapping):
+                            updated_map = dict(addr_map)
+                            updated_map["pmo"] = list(merged_addrs)
+                            dev_map["addr_map"] = updated_map
+
+                if "htr" not in addresses_by_type:
+                    addresses_by_type["htr"] = []
+
+                dev_map["addresses_by_type"] = {
+                    node_type: list(addrs)
+                    for node_type, addrs in addresses_by_type.items()
+                }
+
+                updated = dict(coordinator_data)
+                updated[self.dev_id] = dev_map
+                self._coordinator.data = updated  # type: ignore[attr-defined]
+
+        return cleaned_map
+
+    def _update_legacy_section(
+        self,
+        *,
+        node_type: str,
+        addr: str,
+        section: str,
+        body: Any,
+        dev_map: dict[str, Any],
+        nodes_by_type: dict[str, Any],
+    ) -> bool:
+        """Store legacy section updates and mirror them in raw state."""
+
+        bucket = self._ensure_type_bucket(dev_map, nodes_by_type, node_type)
+        section_map: dict[str, Any] = bucket.setdefault(section, {})
+        if not isinstance(section_map, dict):
+            return False
+        value: Any = dict(body) if isinstance(body, Mapping) else body
+        section_map[addr] = value
+        if (
+            section == "settings"
+            and normalize_node_type(node_type) == "acm"
+            and isinstance(value, MutableMapping)
+        ):
+            coordinator = getattr(self, "_coordinator", None)
+            apply_helper = getattr(coordinator, "_apply_accumulator_boost_metadata", None)
+            if callable(apply_helper):
+                now = None
+                estimate = getattr(coordinator, "_device_now_estimate", None)
+                if callable(estimate):
+                    now = estimate()
+                try:
+                    apply_helper(value, now=now)
+                except Exception as err:  # pragma: no cover - defensive
+                    _LOGGER.debug(
+                        "WS (ducaheat): boost metadata derivation failed for %s/%s: %s",
+                        node_type,
+                        addr,
+                        err,
+                        exc_info=err,
+                    )
+        if section == "settings":
+            canonical_type = normalize_node_type(
+                node_type, use_default_when_falsey=True
+            ) or node_type
+            if canonical_type:
+                settings_map: MutableMapping[str, Any] = dev_map.setdefault(
+                    "settings", {}
+                )
+                existing_bucket = settings_map.get(canonical_type)
+                if isinstance(existing_bucket, MutableMapping):
+                    settings_bucket = existing_bucket
+                elif isinstance(existing_bucket, Mapping):
+                    settings_bucket = dict(existing_bucket)
+                    settings_map[canonical_type] = settings_bucket
+                else:
+                    settings_bucket = {}
+                    settings_map[canonical_type] = settings_bucket
+                normalised_addr = normalize_node_addr(
+                    addr,
+                    use_default_when_falsey=True,
+                )
+                if not normalised_addr and isinstance(addr, str):
+                    stripped = addr.strip()
+                    normalised_addr = stripped or None
+                if not normalised_addr and addr is not None and not isinstance(addr, str):
+                    candidate = str(addr).strip()
+                    normalised_addr = candidate or None
+                if normalised_addr:
+                    existing_payload = settings_bucket.get(normalised_addr)
+                    if (
+                        isinstance(existing_payload, MutableMapping)
+                        and isinstance(value, Mapping)
+                    ):
+                        existing_payload.update(value)
+                        section_map[addr] = existing_payload
+                    else:
+                        settings_bucket[normalised_addr] = value
+        if not isinstance(self._nodes_raw, dict):
+            self._nodes_raw = {}
+        raw_bucket = self._nodes_raw.setdefault(node_type, {})
+        raw_section = raw_bucket.setdefault(section, {})
+        if isinstance(raw_section, dict):
+            raw_section[addr] = deepcopy(body)
+        return True
+
+    def _dispatch_nodes(self, payload: dict[str, Any]) -> None:
+        """Publish node updates with inventory-aware cache refresh."""
+
+        if not isinstance(payload, dict):  # pragma: no cover - defensive
+            return
+
+        is_snapshot = isinstance(payload.get("nodes_by_type"), Mapping)
+        raw_nodes: Any = payload.get("nodes") if is_snapshot else payload
+
+        context = _prepare_nodes_dispatch(
+            self.hass,
+            entry_id=self.entry_id,
+            coordinator=self._coordinator,
+            raw_nodes=raw_nodes,
+            inventory=self._inventory,
+        )
+
+        inventory = context.inventory
+        if self._inventory is None and isinstance(inventory, Inventory):
+            self._inventory = inventory
+
+        addr_map = context.addr_map
+        record = context.record
+        raw_nodes_payload = context.payload
+        if raw_nodes_payload is None:
+            raw_nodes_payload = (
+                inventory.payload if isinstance(inventory, Inventory) else {}
+            )
+
+        if isinstance(record, MutableMapping):
+            record["nodes"] = raw_nodes_payload
+            if isinstance(inventory, Inventory):
+                record["inventory"] = inventory
+
+        nodes_by_type_payload: Mapping[str, Any] | None
+        if is_snapshot:
+            nodes_by_type_payload = payload.get("nodes_by_type")
+        else:
+            nodes_by_type_payload = None
+
+        coordinator_data = getattr(self._coordinator, "data", None)
+        dev_map: dict[str, Any] | None = None
+        nodes_by_type_cache: dict[str, Any] | None = None
+        if isinstance(coordinator_data, dict):
+            candidate = coordinator_data.get(self.dev_id)
+            if isinstance(candidate, dict):
+                dev_map = candidate
+                nodes_by_type_cache = dev_map.setdefault("nodes_by_type", {})
+
+        if isinstance(nodes_by_type_payload, Mapping) and dev_map is not None:
+            for raw_type, sections in nodes_by_type_payload.items():
+                node_type = normalize_node_type(raw_type)
+                if not node_type or not isinstance(sections, Mapping):
+                    continue
+                if nodes_by_type_cache is None:
+                    nodes_by_type_cache = dev_map.setdefault("nodes_by_type", {})
+                self._ensure_type_bucket(dev_map, nodes_by_type_cache, node_type)
+                for section, addr_map_payload in sections.items():
+                    mapped_section, nested_key = self._resolve_update_section(section)
+                    target_section = mapped_section or section
+                    if not isinstance(addr_map_payload, Mapping):
+                        continue
+                    if target_section not in {"settings", "advanced", "samples"}:
+                        continue
+                    for addr, body in addr_map_payload.items():
+                        normalised_addr = normalize_node_addr(
+                            addr,
+                            use_default_when_falsey=True,
+                        )
+                        if not normalised_addr:
+                            continue
+                        payload_body: Any
+                        if nested_key and isinstance(body, Mapping):
+                            payload_body = body.get(nested_key)
+                        else:
+                            payload_body = body
+                        if payload_body is None:
+                            continue
+                        self._update_legacy_section(
+                            node_type=node_type,
+                            addr=normalised_addr,
+                            section=target_section,
+                            body=payload_body,
+                            dev_map=dev_map,
+                            nodes_by_type=nodes_by_type_cache,
+                        )
+
+        normalized_addresses = self._apply_heater_addresses(
+            addr_map,
+            inventory=inventory,
+        )
+
+        nodes_copy = deepcopy(payload.get("nodes", raw_nodes_payload))
+        nodes_by_type_copy: dict[str, Any]
+        if isinstance(nodes_by_type_payload, Mapping):
+            nodes_by_type_copy = deepcopy(nodes_by_type_payload)
+        else:
+            nodes_by_type_copy = {}
+
+        unknown_types = context.unknown_types
+
+        payload_copy = {
+            "dev_id": self.dev_id,
+            "node_type": None,
+            "nodes": nodes_copy,
+            "nodes_by_type": nodes_by_type_copy,
+            "addr_map": {node_type: list(addrs) for node_type, addrs in normalized_addresses.items()},
+        }
+
+        if unknown_types:
+            payload_copy["unknown_types"] = sorted(unknown_types)
+
+        self._dispatcher(self.hass, signal_ws_data(self.entry_id), payload_copy)
 
     @staticmethod
     def _merge_nodes(target: dict[str, Any], source: Mapping[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- Update the Ducaheat websocket client to reuse the shared inventory dispatch helpers and merge heater address and settings caches on every snapshot or incremental update
- Extend the Ducaheat websocket protocol tests with a coordinator stub and assertions that snapshots and incremental updates expose addresses_by_type and settings alongside nodes_by_type

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e9ff544bc0832997ee0d1a028f49b6