### PR TITLE
Ensure Ducaheat boost toggles claim nodes and call /boost endpoints

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -637,7 +637,7 @@ class RESTClient:
         payload = build_acm_boost_payload(boost, boost_time)
 
         headers = await self._authed_headers()
-        path = f"/api/v2/devs/{dev_id}/{node_type}/{addr_str}/status"
+        path = f"/api/v2/devs/{dev_id}/{node_type}/{addr_str}/boost"
         self._log_non_htr_payload(
             node_type=node_type,
             dev_id=dev_id,


### PR DESCRIPTION
## Summary
- add a segmented select helper and claim ACM nodes before writing boost state
- send all ACM boost toggles to the /boost endpoint for both REST clients
- update fake sessions and harnesses to assert select/boost/release call ordering

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea05d0d4808329890b783bf732bef2