### PR TITLE
Add coverage for import service string entity id normalization

### DIFF
--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -954,6 +954,93 @@ def test_register_import_service_uses_module_asyncio(
     asyncio.run(_run())
 
 
+def test_service_accepts_single_entity_id_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        (
+            mod,
+            energy_mod,
+            const,
+            _import_stats,
+            _update_meta,
+            _last_stats,
+            _get_period,
+            _delete_stats,
+            ConfigEntry,
+            HomeAssistant,
+            ent_reg,
+        ) = await _load_module(monkeypatch)
+
+        hass = HomeAssistant()
+
+        entries: dict[str, ConfigEntry] = {}
+        hass.config_entries = types.SimpleNamespace(
+            async_update_entry=lambda entry, *, options: entry.options.update(options),
+            async_get_entry=lambda entry_id: entries.get(entry_id),
+        )
+
+        entry = ConfigEntry("cache-test", options={})
+        entries[entry.entry_id] = entry
+
+        uid = identifiers_module.build_heater_energy_unique_id("dev", "htr", "A")
+        ent_reg.add(
+            "sensor.dev_A_energy",
+            "sensor",
+            const.DOMAIN,
+            uid,
+            "A energy",
+            config_entry_id=entry.entry_id,
+        )
+
+        gather_calls: list[int] = []
+
+        async def fake_gather(*tasks: Any, return_exceptions: bool = False) -> list[Any]:
+            gather_calls.append(len(tasks))
+            results: list[Any] = []
+            for task in tasks:
+                try:
+                    results.append(await task)
+                except Exception as err:  # pragma: no cover - defensive
+                    if return_exceptions:
+                        results.append(err)
+                    else:
+                        raise
+            return results
+
+        class Services:
+            def __init__(self) -> None:
+                self._svcs: dict[str, dict[str, object]] = {}
+
+            def has_service(self, domain: str, service: str) -> bool:
+                return service in self._svcs.get(domain, {})
+
+            def async_register(self, domain: str, service: str, func: object) -> None:
+                self._svcs.setdefault(domain, {})[service] = func
+
+            def get(self, domain: str, service: str) -> object:
+                return self._svcs[domain][service]
+
+        hass.services = Services()
+
+        monkeypatch.setattr(energy_mod.asyncio, "gather", fake_gather)
+
+        import_mock = AsyncMock()
+        await energy_mod.async_register_import_energy_history_service(hass, import_mock)
+
+        service = hass.services.get(const.DOMAIN, "import_energy_history")
+        await service(types.SimpleNamespace(data={"entity_id": "sensor.dev_A_energy"}))
+
+        assert gather_calls == [1]
+        import_mock.assert_awaited_once()
+        args, kwargs = import_mock.await_args
+        assert args[:2] == (hass, entry)
+        assert args[2] == {"htr": ["A"]}
+        assert kwargs == {"reset_progress": False, "max_days": None}
+
+    asyncio.run(_run())
+
+
 def test_async_import_energy_history_rebuilds_missing_inventory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a regression test that exercises the import_energy_history service when passed a single entity_id string
- verify the import coroutine is created once with the expected node selection for that entity

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea0b35f060832981feb1edc022f274