### PR TITLE
Add test for rate limiter overrides

### DIFF
--- a/tests/test_energy_rate_limit.py
+++ b/tests/test_energy_rate_limit.py
@@ -51,3 +51,38 @@ def test_default_samples_rate_limit_state_round_trip() -> None:
 
     reset_samples_rate_limit_state()
     assert limiter.last_timestamp() == 0.0
+
+
+def test_default_samples_rate_limit_state_overrides_time_and_sleep() -> None:
+    """Existing limiter should accept new monotonic and sleep callables."""
+
+    limiter = default_samples_rate_limit_state()
+
+    current = 3.2
+    monotonic_calls: list[float] = []
+
+    def new_monotonic() -> float:
+        monotonic_calls.append(current)
+        return current
+
+    sleep_calls: list[float] = []
+
+    async def new_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    new_time = types.SimpleNamespace(monotonic=new_monotonic)
+
+    reset_samples_rate_limit_state(time_module=new_time, sleep=new_sleep)
+
+    updated = default_samples_rate_limit_state(time_module=new_time, sleep=new_sleep)
+
+    assert updated is limiter
+    assert updated.monotonic is new_monotonic
+    assert updated.sleep is new_sleep
+
+    asyncio.run(updated.async_throttle())
+
+    assert monotonic_calls == [pytest.approx(current)]
+    assert not sleep_calls
+
+    reset_samples_rate_limit_state()


### PR DESCRIPTION
## Summary
- add a regression test ensuring `default_samples_rate_limit_state` reuses the existing limiter when new monotonic and sleep callables are provided

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea0b4deed88329bf311a701a4665f5