### PR TITLE
Include accumulator boost setpoint and unit in boost payloads

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -943,12 +943,30 @@ class DucaheatRESTClient(RESTClient):
         *,
         boost: bool,
         boost_time: int | None = None,
-        ) -> Any:
+        stemp: float | None = None,
+        units: str | None = None,
+    ) -> Any:
         """Toggle an accumulator boost session via segmented endpoints."""
 
         node_type, addr_str = self._resolve_node_descriptor(("acm", addr))
         headers = await self._authed_headers()
-        payload = build_acm_boost_payload(boost, boost_time)
+        formatted_temp: str | None = None
+        if stemp is not None:
+            try:
+                formatted_temp = self._format_temp(stemp)
+            except ValueError as err:
+                raise ValueError(f"Invalid stemp value: {stemp!r}") from err
+
+        unit_value: str | None = None
+        if units is not None:
+            unit_value = self._ensure_units(units)
+
+        payload = build_acm_boost_payload(
+            boost,
+            boost_time,
+            stemp=formatted_temp,
+            units=unit_value,
+        )
         if boost:
             minutes = validate_boost_minutes(boost_time)
             _LOGGER.info(

--- a/custom_components/termoweb/backend/sanitize.py
+++ b/custom_components/termoweb/backend/sanitize.py
@@ -69,13 +69,29 @@ def validate_boost_minutes(value: int | None) -> int | None:
     return minutes
 
 
-def build_acm_boost_payload(boost: bool, boost_time: int | None) -> dict[str, Any]:
+def build_acm_boost_payload(
+    boost: bool,
+    boost_time: int | None,
+    *,
+    stemp: str | None = None,
+    units: str | None = None,
+) -> dict[str, Any]:
     """Return a validated accumulator boost payload."""
 
     payload: dict[str, Any] = {"boost": bool(boost)}
     minutes = validate_boost_minutes(boost_time)
     if minutes is not None:
         payload["boost_time"] = minutes
+    if stemp is not None:
+        temp_str = str(stemp).strip()
+        if not temp_str:
+            raise ValueError("stemp must be a non-empty string when provided")
+        payload["stemp"] = temp_str
+    if units is not None:
+        unit = str(units).strip().upper()
+        if unit not in {"C", "F"}:
+            raise ValueError(f"Invalid units: {units!r}")
+        payload["units"] = unit
     return payload
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1908,11 +1908,18 @@ def test_rest_set_acm_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
             "4",
             boost=True,
             boost_time=45,
+            stemp=21.5,
+            units="c",
         )
         assert result == {"ok": True}
         path2, kwargs2 = session.request_calls[1][1:3]
         assert path2 == "https://api.termoweb.fake/api/v2/devs/dev/acm/4/boost"
-        assert kwargs2["json"] == {"boost": True, "boost_time": 45}
+        assert kwargs2["json"] == {
+            "boost": True,
+            "boost_time": 45,
+            "stemp": "21.5",
+            "units": "C",
+        }
 
         with pytest.raises(ValueError):
             await client.set_acm_extra_options("dev", "4")
@@ -2103,6 +2110,8 @@ def test_ducaheat_acm_boost_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
             "7",
             boost=True,
             boost_time=30,
+            stemp=20.0,
+            units="f",
         )
         assert result_start["boost_state"]["boost_active"] is True
         assert result_start["boost_state"]["boost_minutes_delta"] == 30
@@ -2111,7 +2120,12 @@ def test_ducaheat_acm_boost_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
         assert select_call_2[1] == "https://api.termoweb.fake/api/v2/devs/dev/acm/7/select"
         assert select_call_2[2]["json"] == {"select": True}
         assert boost_call_2[1] == "https://api.termoweb.fake/api/v2/devs/dev/acm/7/boost"
-        assert boost_call_2[2]["json"] == {"boost": True, "boost_time": 30}
+        assert boost_call_2[2]["json"] == {
+            "boost": True,
+            "boost_time": 30,
+            "stemp": "20.0",
+            "units": "F",
+        }
         assert release_call_2[1] == "https://api.termoweb.fake/api/v2/devs/dev/acm/7/select"
         assert release_call_2[2]["json"] == {"select": False}
 

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -302,13 +302,21 @@ async def test_ducaheat_set_acm_boost_state_claims_select(
     monkeypatch.setattr(ducaheat_rest_client, "get_rtc_time", rtc_mock)
 
     result = await ducaheat_rest_client.set_acm_boost_state(
-        "dev", "3", boost=True, boost_time=15
+        "dev",
+        "3",
+        boost=True,
+        boost_time=15,
+        stemp=21.2,
+        units="c",
     )
 
     assert result["boost"] is True
     assert calls == [
         ("/api/v2/devs/dev/acm/3/select", {"select": True}),
-        ("/api/v2/devs/dev/acm/3/boost", {"boost": True, "boost_time": 15}),
+        (
+            "/api/v2/devs/dev/acm/3/boost",
+            {"boost": True, "boost_time": 15, "stemp": "21.2", "units": "C"},
+        ),
         ("/api/v2/devs/dev/acm/3/select", {"select": False}),
     ]
     rtc_mock.assert_awaited_once_with("dev")
@@ -409,6 +417,12 @@ def test_validate_boost_minutes_and_payload() -> None:
     assert validate_boost_minutes(15) == 15
     assert build_acm_boost_payload(True, None) == {"boost": True}
     assert build_acm_boost_payload(False, 30) == {"boost": False, "boost_time": 30}
+    assert build_acm_boost_payload(
+        True,
+        20,
+        stemp="21.0",
+        units="c",
+    ) == {"boost": True, "boost_time": 20, "stemp": "21.0", "units": "C"}
 
     with pytest.raises(ValueError):
         validate_boost_minutes(0)
@@ -416,6 +430,10 @@ def test_validate_boost_minutes_and_payload() -> None:
         validate_boost_minutes("bad")
     with pytest.raises(ValueError):
         build_acm_boost_payload(True, 0)
+    with pytest.raises(ValueError):
+        build_acm_boost_payload(True, 10, stemp="  ")
+    with pytest.raises(ValueError):
+        build_acm_boost_payload(True, 10, units="kelvin")
 
 
 def test_ducaheat_log_segmented_post_handles_non_mapping(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -741,7 +741,7 @@ def test_accumulator_async_set_preset_mode_transitions(
         entry_id = "entry-acm-preset"
         dev_id = "dev-acm-preset"
         addr = "11"
-        settings = {"mode": "auto", "units": "C"}
+        settings = {"mode": "auto", "units": "C", "boost_temp": "21.0"}
         record = {
             "nodes": {},
             "nodes_by_type": {"acm": {"settings": {addr: dict(settings)}}},
@@ -798,6 +798,8 @@ def test_accumulator_async_set_preset_mode_transitions(
             addr,
             boost=True,
             boost_time=42,
+            stemp=21.0,
+            units="C",
         )
         assert settings_map["mode"] == "boost"
         assert settings_map["boost_active"] is True
@@ -1107,7 +1109,12 @@ def test_accumulator_service_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_id = "entry-acm-services"
         dev_id = "dev-acm-services"
         addr = "3"
-        settings = {"mode": "auto", "boost_time": 60, "boost_temp": "20.0"}
+        settings = {
+            "mode": "auto",
+            "boost_time": 60,
+            "boost_temp": "20.0",
+            "units": "C",
+        }
         record = {
             "nodes": {},
             "nodes_by_type": {"acm": {"settings": {addr: dict(settings)}}},
@@ -1176,6 +1183,8 @@ def test_accumulator_service_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
             addr,
             boost=True,
             boost_time=45,
+            stemp=21.2,
+            units="C",
         )
         assert settings_map["mode"] == "boost"
         assert settings_map["boost_active"] is True
@@ -1196,6 +1205,8 @@ def test_accumulator_service_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
             addr,
             boost=True,
             boost_time=75,
+            stemp=21.2,
+            units="C",
         )
         assert settings_map["boost_remaining"] == 75
         assert fallback_calls == 1
@@ -1228,7 +1239,12 @@ def test_accumulator_service_error_paths(monkeypatch: pytest.MonkeyPatch) -> Non
         entry_id = "entry-acm-errors"
         dev_id = "dev-acm-errors"
         addr = "4"
-        settings = {"mode": "auto", "boost_time": 60}
+        settings = {
+            "mode": "auto",
+            "boost_time": 60,
+            "boost_temp": "19.5",
+            "units": "F",
+        }
         record = {
             "nodes": {},
             "nodes_by_type": {"acm": {"settings": {addr: dict(settings)}}},
@@ -1307,6 +1323,8 @@ def test_accumulator_service_error_paths(monkeypatch: pytest.MonkeyPatch) -> Non
             addr,
             boost=True,
             boost_time=20,
+            stemp=19.5,
+            units="F",
         )
         assert fallback_calls == 0
         client.set_acm_boost_state.side_effect = None


### PR DESCRIPTION
## Summary
- extend the accumulator boost payload builder to carry formatted setpoints and normalised units
- update the REST clients and climate entity to provide the boost setpoint and unit when starting a boost session
- refresh API and Ducaheat tests to exercise the new boost payload contract

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68ea0ab97c608329b0d532686eb86583