### PR TITLE
Refine websocket node dispatch payloads

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -1104,7 +1104,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             inventory=inventory,
         )
 
-        nodes_copy = deepcopy(payload.get("nodes", raw_nodes_payload))
         nodes_by_type_copy: dict[str, Any]
         if isinstance(nodes_by_type_payload, Mapping):
             nodes_by_type_copy = deepcopy(nodes_by_type_payload)
@@ -1116,7 +1115,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         payload_copy = {
             "dev_id": self.dev_id,
             "node_type": None,
-            "nodes": nodes_copy,
             "nodes_by_type": nodes_by_type_copy,
             "addr_map": {node_type: list(addrs) for node_type, addrs in normalized_addresses.items()},
         }

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -965,7 +965,7 @@ def test_dispatch_nodes_with_inventory(monkeypatch: pytest.MonkeyPatch, caplog: 
     client._coordinator.update_nodes.assert_called_once()
     update_args, update_kwargs = client._coordinator.update_nodes.call_args
     assert not update_kwargs
-    assert update_args[0] == {"nodes": {"htr": {"settings": {"1": {}}}}}
+    assert update_args[0] is None
     assert isinstance(update_args[1], Inventory)
     dispatcher.assert_called()
     dev_map = client._coordinator.data["device"]
@@ -988,7 +988,7 @@ def test_dispatch_nodes_handles_unknown_types(monkeypatch: pytest.MonkeyPatch) -
     client._coordinator.update_nodes.assert_called_once()
     update_args, update_kwargs = client._coordinator.update_nodes.call_args
     assert not update_kwargs
-    assert update_args[0] == {"nodes": {}}
+    assert update_args[0] is None
     assert isinstance(update_args[1], Inventory)
     dispatcher.assert_called()
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -381,7 +381,7 @@ def test_dispatch_nodes_without_snapshot(monkeypatch: pytest.MonkeyPatch) -> Non
     assert seen["nodes_payload"] is payload["nodes"]
     coordinator.update_nodes.assert_called_once()
     update_args = coordinator.update_nodes.call_args.args
-    assert update_args[0] is payload["nodes"]
+    assert update_args[0] is None
     inventory_arg = update_args[1]
     assert isinstance(inventory_arg, Inventory)
     assert inventory_arg.payload is payload["nodes"]
@@ -398,6 +398,7 @@ def test_dispatch_nodes_without_snapshot(monkeypatch: pytest.MonkeyPatch) -> Non
     dispatcher.assert_called_once()
     dispatched_payload = dispatcher.call_args.args[2]
     assert dispatched_payload["addr_map"] == {"htr": ["1"]}
+    assert "nodes" not in dispatched_payload
 
 
 def test_prepare_nodes_dispatch_handles_non_mapping_record(
@@ -573,7 +574,7 @@ def test_dispatch_nodes_updates_hass_and_coordinator(
 
     client._coordinator.update_nodes.assert_called_once()  # type: ignore[attr-defined]
     update_args = client._coordinator.update_nodes.call_args.args  # type: ignore[attr-defined]
-    assert update_args[0] is payload
+    assert update_args[0] is None
     assert isinstance(update_args[1], Inventory)
     assert update_args[1].payload is payload
     assert isinstance(addr_map, dict)
@@ -1229,11 +1230,17 @@ def test_ws_common_dispatch_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
     coordinator.update_nodes.assert_called_once()
     update_args, update_kwargs = coordinator.update_nodes.call_args
     assert not update_kwargs
-    assert update_args[0] == payload["nodes"]
+    assert update_args[0] is None
     assert update_args[1] is inventory_obj
     dispatcher.assert_called_once()
     record = hass.data[base_ws.DOMAIN]["entry"]
     assert record.get("inventory") is inventory_obj
+    dispatched_payload = dispatcher.call_args.args[2]
+    assert dispatched_payload == {
+        "dev_id": "dev",
+        "node_type": None,
+        "addr_map": {"htr": ["1"]},
+    }
 
 
 def test_ws_client_start_selects_delegate(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- update the shared websocket node dispatcher to avoid forwarding raw node snapshots when inventory data is available
- remove raw node snapshots from Ducaheat websocket dispatcher payloads and refresh the associated tests
- align websocket client unit tests with the new coordinator contract

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea0ad0558c83298a856143a14efbda