### PR TITLE
Add power monitor energy and power sensors

### DIFF
--- a/custom_components/termoweb/identifiers.py
+++ b/custom_components/termoweb/identifiers.py
@@ -46,3 +46,32 @@ def build_heater_energy_unique_id(dev_id: Any, node_type: Any, addr: Any) -> str
     """Return the canonical unique ID for a heater energy sensor."""
 
     return build_heater_unique_id(dev_id, node_type, addr, suffix=":energy")
+
+
+def build_power_monitor_unique_id(
+    dev_id: Any,
+    addr: Any,
+    *,
+    suffix: str | None = None,
+) -> str:
+    """Return the canonical unique ID for a power monitor node or entity."""
+
+    return build_heater_unique_id(dev_id, "pmo", addr, suffix=suffix)
+
+
+def build_power_monitor_device_unique_id(dev_id: Any, addr: Any) -> str:
+    """Return the canonical unique ID for a power monitor device."""
+
+    return build_power_monitor_unique_id(dev_id, addr)
+
+
+def build_power_monitor_energy_unique_id(dev_id: Any, addr: Any) -> str:
+    """Return the canonical unique ID for a power monitor energy sensor."""
+
+    return build_power_monitor_unique_id(dev_id, addr, suffix=":energy")
+
+
+def build_power_monitor_power_unique_id(dev_id: Any, addr: Any) -> str:
+    """Return the canonical unique ID for a power monitor power sensor."""
+
+    return build_power_monitor_unique_id(dev_id, addr, suffix=":power")


### PR DESCRIPTION
## Summary
- create dedicated power monitor energy and power sensors backed by the shared coordinator
- add unique ID and DeviceInfo helpers so PMOs register as individual devices
- extend sensor tests to cover PMO entity creation and metadata

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea0b5f28c88329b59670bed4d2815b