### PR TITLE
Add backend module export tests

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -93,3 +93,17 @@ def test_backend_requires_create_override() -> None:
     client = DummyHttpClient()
     with pytest.raises(TypeError):
         InvalidBackend(brand="termoweb", client=client)
+
+
+def test_backend_module_exports_expected_classes() -> None:
+    """The backend module exposes the concrete backend implementations."""
+
+    backend_module = __import__(
+        Backend.__module__.rsplit(".", 1)[0], fromlist=["DucaheatBackend", "TermoWebBackend"]
+    )
+
+    assert getattr(backend_module, "DucaheatBackend") is DucaheatBackend
+    assert getattr(backend_module, "TermoWebBackend") is TermoWebBackend
+
+    with pytest.raises(AttributeError):
+        getattr(backend_module, "MissingThing")


### PR DESCRIPTION
## Summary
- add coverage ensuring the backend module exposes the Ducaheat and TermoWeb implementations
- verify the module raises AttributeError for unknown backend lookups

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68ea11acf6088329b57bfa3930711862