### PR TITLE
Add tests for ws_client module exports

### DIFF
--- a/tests/test_backend_ws_client_module.py
+++ b/tests/test_backend_ws_client_module.py
@@ -1,0 +1,25 @@
+"""Smoke tests for the websocket client facade module."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from custom_components.termoweb.backend import ducaheat_ws, termoweb_ws
+
+
+def test_ws_client_exports_real_classes() -> None:
+    """Ensure ``ws_client`` re-exports the real backend client classes."""
+
+    module = importlib.import_module("custom_components.termoweb.backend.ws_client")
+    assert getattr(module, "DucaheatWSClient") is ducaheat_ws.DucaheatWSClient
+    assert getattr(module, "TermoWebWSClient") is termoweb_ws.TermoWebWSClient
+
+
+def test_ws_client_missing_attribute_raises() -> None:
+    """Verify unknown attributes raise ``AttributeError``."""
+
+    module = importlib.import_module("custom_components.termoweb.backend.ws_client")
+    with pytest.raises(AttributeError):
+        getattr(module, "BogusClient")


### PR DESCRIPTION
## Summary
- add a lightweight test module that imports `custom_components.termoweb.backend.ws_client`
- assert the facade exposes the concrete Ducaheat and TermoWeb websocket client classes
- verify an unknown attribute still raises `AttributeError`

## Testing
- pytest tests/test_backend_ws_client_module.py


------
https://chatgpt.com/codex/tasks/task_e_68ea11b1f4b88329851725413d8c819e