### PR TITLE
Add test for energy service registration skip behavior

### DIFF
--- a/tests/test_energy_service_registration.py
+++ b/tests/test_energy_service_registration.py
@@ -1,0 +1,42 @@
+"""Tests for energy service registration utilities."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.termoweb.energy import (
+    async_register_import_energy_history_service,
+)
+
+
+class _StubServices:
+    """Stub Home Assistant service registry for testing."""
+
+    def __init__(self) -> None:
+        self.registrations: list[tuple[str, str]] = []
+
+    def has_service(self, domain: str, service: str) -> bool:
+        """Pretend the service is already registered."""
+
+        return True
+
+    def async_register(self, domain: str, service: str, handler) -> None:  # pragma: no cover - defensive
+        """Record registrations for inspection."""
+
+        self.registrations.append((domain, service))
+
+
+@pytest.mark.asyncio
+async def test_async_register_import_energy_history_service_skips_registration() -> None:
+    """The service registration is skipped when it already exists."""
+
+    hass = SimpleNamespace(services=_StubServices())
+    import_fn = AsyncMock()
+
+    await async_register_import_energy_history_service(hass, import_fn)
+
+    import_fn.assert_not_called()
+    assert hass.services.registrations == []


### PR DESCRIPTION
## Summary
- add a focused test covering energy import service registration when the service already exists
- ensure the mocked import function and hass service registry are not used when skipping registration

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea11b56ab48329ab3fc11b57055aa8