### PR TITLE
Add tests for energy ISO date conversion

### DIFF
--- a/tests/test_energy_utils.py
+++ b/tests/test_energy_utils.py
@@ -1,0 +1,15 @@
+"""Tests for energy utilities."""
+
+from custom_components.termoweb.energy import _iso_date
+
+
+def test_iso_date_for_recent_timestamp() -> None:
+    """_iso_date should convert timestamp to ISO date string."""
+
+    assert _iso_date(1_700_000_000) == "2023-11-14"
+
+
+def test_iso_date_for_unix_epoch() -> None:
+    """_iso_date should convert zero to the Unix epoch date."""
+
+    assert _iso_date(0) == "1970-01-01"


### PR DESCRIPTION
## Summary
- add unit tests ensuring `_iso_date` converts timestamps to ISO-formatted dates
- cover both a recent timestamp and the Unix epoch edge case

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea11b7f13083298bf9cf8d4dafb812