### PR TITLE
Remove Ducaheat node cache fallback

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -162,7 +162,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         self._task: asyncio.Task | None = None
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._stats = WSStats()
-        self._latest_nodes: Mapping[str, Any] | None = None
         self._nodes_raw: dict[str, Any] | None = None
         self._subscription_paths: set[str] = set()
         self._pending_dev_data = False
@@ -500,7 +499,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                                 else None
                             )
                             if isinstance(nodes, dict):
-                                self._latest_nodes = nodes
                                 self._log_nodes_summary(nodes)
                                 normalised = self._normalise_nodes_payload(nodes)
                                 if isinstance(normalised, dict):
@@ -1243,12 +1241,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
     async def _subscribe_feeds(self, nodes: Mapping[str, Any] | None) -> int:
         """Subscribe to heater status and sample feeds."""
 
-        resolved_nodes: Mapping[str, Any] | None = (
-            nodes if isinstance(nodes, Mapping) else None
-        )
-        if resolved_nodes is None and isinstance(self._latest_nodes, Mapping):
-            resolved_nodes = self._latest_nodes
-
         try:
             domain_bucket = self.hass.data.setdefault(DOMAIN, {})
             existing_record = domain_bucket.get(self.entry_id)
@@ -1261,9 +1253,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 if isinstance(existing_record, Mapping):
                     record_mapping.update(existing_record)
                 domain_bucket[self.entry_id] = record_mapping
-
-            if isinstance(resolved_nodes, Mapping):
-                record_mapping["nodes"] = resolved_nodes
 
             inventory_container: Inventory | None = (
                 self._inventory if isinstance(self._inventory, Inventory) else None
@@ -1278,14 +1267,8 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             if isinstance(coordinator_inventory, Inventory):
                 coordinator_nodes = coordinator_inventory.nodes
 
-            nodes_payload: Any | None
-            if isinstance(resolved_nodes, Mapping):
-                nodes_payload = resolved_nodes
-            else:
-                nodes_payload = record_mapping.get("nodes")
-
             should_resolve = inventory_container is None and (
-                nodes_payload is not None
+                isinstance(nodes, Mapping)
                 or not isinstance(coordinator_inventory, Inventory)
             )
 
@@ -1293,7 +1276,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 resolution = resolve_record_inventory(
                     record_mapping,
                     dev_id=self.dev_id,
-                    nodes_payload=nodes_payload,
+                    nodes_payload=nodes if isinstance(nodes, Mapping) else None,
                     node_list=coordinator_nodes,
                 )
                 inventory_container = resolution.inventory

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -156,12 +156,7 @@ def _make_client(monkeypatch: pytest.MonkeyPatch) -> ducaheat_ws.DucaheatWSClien
         raw_nodes,
         build_node_inventory(raw_nodes),
     )
-    hass.data[ducaheat_ws.DOMAIN]["entry"].update(
-        {
-            "inventory": inventory,
-            "nodes": raw_nodes,
-        }
-    )
+    hass.data[ducaheat_ws.DOMAIN]["entry"]["inventory"] = inventory
     return client
 
 
@@ -1545,7 +1540,7 @@ async def test_namespace_ack_skips_unexpected_namespace(
 
     dispatch.assert_called_once()
     subscribe_mock.assert_awaited_once()
-    assert client._latest_nodes == {"htr": {"status": {"1": {}}}}
+    assert client._nodes_raw == {"htr": {"status": {"1": {}}}}
 
 
 @pytest.mark.asyncio
@@ -1614,13 +1609,17 @@ async def test_disconnect_closes_websocket(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
-async def test_subscribe_feeds_reuses_cached_nodes(
+async def test_subscribe_feeds_stores_inventory_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cached inventory should populate subscriptions when nodes are omitted."""
+    """Subscription state should persist the resolved inventory without nodes."""
 
     client = _make_client(monkeypatch)
-    client._latest_nodes = {"htr": {"samples": {"1": {}}}}
+    bucket = client.hass.data[ducaheat_ws.DOMAIN]["entry"]
+    bucket.pop("inventory", None)
+    client._inventory = None
+
+    nodes_payload = {"htr": {"status": {"1": {}}}}
 
     emissions: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -1629,12 +1628,12 @@ async def test_subscribe_feeds_reuses_cached_nodes(
         AsyncMock(side_effect=lambda evt, path: emissions.append((evt, path))),
     )
 
-    count = await client._subscribe_feeds(None)
+    count = await client._subscribe_feeds(nodes_payload)
 
     assert count == 2
     assert {path for _evt, path in emissions} == {"/htr/1/samples", "/htr/1/status"}
-    bucket = client.hass.data[ducaheat_ws.DOMAIN]["entry"]
-    assert bucket["nodes"] == client._latest_nodes
+    assert "nodes" not in bucket
+    assert isinstance(bucket.get("inventory"), Inventory)
 
 
 @pytest.mark.asyncio
@@ -1709,16 +1708,11 @@ async def test_subscribe_feeds_handles_missing_targets(
     """When no subscription targets exist the helper should no-op."""
 
     client = _make_client(monkeypatch)
-    raw_nodes = {}
-    client.hass.data[ducaheat_ws.DOMAIN]["entry"].update(
-        {
-            "nodes": raw_nodes,
-            "inventory": Inventory(
-                "device",
-                raw_nodes,
-                build_node_inventory(raw_nodes),
-            ),
-        }
+    payload = {"nodes": []}
+    client.hass.data[ducaheat_ws.DOMAIN]["entry"]["inventory"] = Inventory(
+        "device",
+        payload,
+        build_node_inventory(payload),
     )
     emit_mock = AsyncMock()
     monkeypatch.setattr(client, "_emit_sio", emit_mock)
@@ -1736,16 +1730,11 @@ async def test_subscribe_feeds_uses_coordinator_fallback(
     """Fallback coordinator addresses should be subscribed when snapshot empty."""
 
     client = _make_client(monkeypatch)
-    raw_nodes = {}
-    client.hass.data[ducaheat_ws.DOMAIN]["entry"].update(
-        {
-            "nodes": raw_nodes,
-            "inventory": Inventory(
-                "device",
-                raw_nodes,
-                build_node_inventory(raw_nodes),
-            ),
-        }
+    payload = {"nodes": []}
+    client.hass.data[ducaheat_ws.DOMAIN]["entry"]["inventory"] = Inventory(
+        "device",
+        payload,
+        build_node_inventory(payload),
     )
     client._coordinator._addrs = lambda: ["5", " ", "5"]
 


### PR DESCRIPTION
## Summary
- resolve Ducaheat websocket subscription targets exclusively from the stored inventory
- avoid persisting transient node payloads in the hass data bucket while retaining inventory updates
- refresh websocket protocol tests to follow the inventory-only subscription flow

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea118e2b048329bdbfacaff02722d0