### PR TITLE
Expand accumulator boost duration options

### DIFF
--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -25,6 +25,7 @@ from .const import DOMAIN
 from .heater import (
     BoostButtonMetadata,
     HeaterNodeBase,
+    format_boost_duration_label,
     heater_platform_details_for_entry,
     iter_boost_button_metadata,
     iter_boostable_heater_nodes,
@@ -195,7 +196,7 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
     """Button that starts an accumulator boost for a fixed duration."""
 
     _attr_icon = "mdi:timer-play"
-    _attr_translation_key = "accumulator_boost_minutes"
+    _attr_translation_key = "accumulator_boost_hours"
 
     def __init__(
         self,
@@ -214,6 +215,7 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
         """Initialise the boost helper button for a fixed duration."""
 
         self._minutes = minutes
+        label_text = format_boost_duration_label(minutes)
         super().__init__(
             coordinator,
             entry_id,
@@ -221,7 +223,7 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
             addr,
             base_name,
             unique_id,
-            label=label or f"Boost {minutes} minutes",
+            label=label or f"Boost {label_text}",
             node_type=node_type,
         )
         if icon is not None:
@@ -237,7 +239,13 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
     def translation_placeholders(self) -> dict[str, str]:
         """Expose the configured boost duration for translations."""
 
-        return {"minutes": str(self._minutes)}
+        hours_label = format_boost_duration_label(self._minutes)
+        hours = self._minutes // 60
+        return {
+            "hours_label": hours_label,
+            "hours": str(hours),
+            "minutes": str(self._minutes),
+        }
 
 
 class AccumulatorBoostCancelButton(AccumulatorBoostButtonBase):

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -50,12 +50,57 @@ class BoostButtonMetadata:
     icon: str
 
 
-BOOST_BUTTON_METADATA: Final[tuple[BoostButtonMetadata, ...]] = (
-    BoostButtonMetadata(30, "30", "Boost 30 minutes", "mdi:timer-play"),
-    BoostButtonMetadata(60, "60", "Boost 60 minutes", "mdi:timer-play"),
-    BoostButtonMetadata(120, "120", "Boost 120 minutes", "mdi:timer-play"),
-    BoostButtonMetadata(None, "cancel", "Cancel boost", "mdi:timer-off"),
-)
+_BOOST_HOUR_ICON_SUFFIXES: Final[dict[int, str]] = {
+    1: "one",
+    2: "two",
+    3: "three",
+    4: "four",
+    5: "five",
+    6: "six",
+    7: "seven",
+    8: "eight",
+    9: "nine",
+    10: "ten",
+}
+
+
+def format_boost_duration_label(minutes: int) -> str:
+    """Return a human-readable label for boost durations."""
+
+    if minutes <= 0:
+        return "0 minutes"
+    if minutes % 60:
+        return f"{minutes} minutes"
+    hours = minutes // 60
+    suffix = "hour" if hours == 1 else "hours"
+    return f"{hours} {suffix}"
+
+
+def _build_boost_button_metadata() -> tuple[BoostButtonMetadata, ...]:
+    """Return the configured metadata describing boost helper buttons."""
+
+    entries: list[BoostButtonMetadata] = []
+    for hours in range(1, 11):
+        minutes = hours * 60
+        icon_suffix = _BOOST_HOUR_ICON_SUFFIXES.get(hours)
+        icon = (
+            f"mdi:clock-time-{icon_suffix}-outline"
+            if icon_suffix is not None
+            else "mdi:clock-outline"
+        )
+        entries.append(
+            BoostButtonMetadata(
+                minutes,
+                str(minutes),
+                f"Boost {format_boost_duration_label(minutes)}",
+                icon,
+            )
+        )
+    entries.append(BoostButtonMetadata(None, "cancel", "Cancel boost", "mdi:timer-off"))
+    return tuple(entries)
+
+
+BOOST_BUTTON_METADATA: Final[tuple[BoostButtonMetadata, ...]] = _build_boost_button_metadata()
 BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = tuple(
     option.minutes for option in BOOST_BUTTON_METADATA if option.minutes is not None
 )

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -15,6 +15,7 @@ from .heater import (
     BOOST_DURATION_OPTIONS,
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
+    format_boost_duration_label,
     get_boost_runtime_minutes,
     heater_platform_details_for_entry,
     iter_boostable_heater_nodes,
@@ -79,7 +80,10 @@ class AccumulatorBoostDurationSelect(RestoreEntity, HeaterNodeBase, SelectEntity
     _attr_icon = "mdi:timer-cog-outline"
     _attr_translation_key = "accumulator_boost_duration"
 
-    _OPTION_MAP = {str(option): option for option in BOOST_DURATION_OPTIONS}
+    _OPTION_MAP = {
+        format_boost_duration_label(option): option
+        for option in BOOST_DURATION_OPTIONS
+    }
     _REVERSE_OPTION_MAP = {value: key for key, value in _OPTION_MAP.items()}
 
     def __init__(
@@ -164,8 +168,10 @@ class AccumulatorBoostDurationSelect(RestoreEntity, HeaterNodeBase, SelectEntity
         resolved = self._validate_minutes(minutes)
         option = self._REVERSE_OPTION_MAP.get(resolved)
         if option is None:
-            option = str(DEFAULT_BOOST_DURATION)
             resolved = DEFAULT_BOOST_DURATION
+            option = self._REVERSE_OPTION_MAP.get(resolved)
+            if option is None:
+                option = format_boost_duration_label(resolved)
         self._attr_current_option = option
         if persist and self.hass is not None:
             set_boost_runtime_minutes(

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -32,8 +32,8 @@
       "force_refresh": {
         "name": "Force refresh"
       },
-      "accumulator_boost_minutes": {
-        "name": "Boost {minutes} minutes"
+      "accumulator_boost_hours": {
+        "name": "Boost {hours_label}"
       },
       "accumulator_boost_cancel": {
         "name": "Cancel boost"

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -36,8 +36,8 @@
       "force_refresh": {
         "name": "Force refresh"
       },
-      "accumulator_boost_minutes": {
-        "name": "Boost {minutes} minutes"
+      "accumulator_boost_hours": {
+        "name": "Boost {hours_label}"
       },
       "accumulator_boost_cancel": {
         "name": "Cancel boost"

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -477,7 +477,11 @@ def test_accumulator_boost_button_triggers_service() -> None:
         )
         button.hass = hass
 
-        assert button.translation_placeholders == {"minutes": "60"}
+        assert button.translation_placeholders == {
+            "hours_label": "1 hour",
+            "hours": "1",
+            "minutes": "60",
+        }
 
         await button.async_press()
 
@@ -584,7 +588,7 @@ def test_accumulator_boost_button_handles_missing_hass() -> None:
             "8",
             "Kitchen",
             "uid-no-hass",
-            minutes=30,
+            minutes=60,
             node_type="acm",
         )
         button.hass = None


### PR DESCRIPTION
## Summary
- replace the accumulator boost metadata with hour-based presets from 1–10 hours and refreshed icons
- update the boost duration select entity to expose the hour labels and fall back cleanly to the default duration
- refresh translations and unit tests to cover the expanded option set

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea117e6e788329865b0cee70badddd