### PR TITLE
Add tests for Ducaheat brand header defaults

### DIFF
--- a/tests/test_ducaheat_brand_headers_defaults.py
+++ b/tests/test_ducaheat_brand_headers_defaults.py
@@ -1,0 +1,29 @@
+"""Tests for the Ducaheat brand header defaults."""
+
+from custom_components.termoweb.backend.ducaheat_ws import _brand_headers
+from custom_components.termoweb.const import USER_AGENT
+
+
+def test_brand_headers_default_user_agent() -> None:
+    """User agent falls back to integration default while keeping required keys."""
+
+    headers = _brand_headers("", "")
+    expected_keys = {
+        "User-Agent",
+        "Accept-Language",
+        "X-Requested-With",
+        "Origin",
+        "Referer",
+        "Accept",
+        "Accept-Encoding",
+        "Cache-Control",
+        "Pragma",
+        "Connection",
+    }
+
+    assert headers["User-Agent"] == USER_AGENT
+    assert expected_keys <= set(headers)
+    assert headers["X-Requested-With"] == ""
+
+    custom_agent = "Integration/1.0"
+    assert _brand_headers(custom_agent, "")["User-Agent"] == custom_agent


### PR DESCRIPTION
## Summary
- add a regression test for the Ducaheat websocket `_brand_headers` helper when caller arguments are empty
- ensure a provided user agent value takes precedence over the integration default

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: existing websocket protocol tests are currently red in the baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68ea173c3b188329af5687f9455af165