### PR TITLE
Add tests for power monitor device info helper

### DIFF
--- a/tests/test_utils_power_monitor_device_info.py
+++ b/tests/test_utils_power_monitor_device_info.py
@@ -1,0 +1,31 @@
+"""Tests for ``build_power_monitor_device_info`` helper."""
+
+from __future__ import annotations
+
+import types
+
+from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb.utils import build_power_monitor_device_info
+
+
+def test_build_power_monitor_device_info_defaults_when_missing_entry() -> None:
+    """Ensure default manufacturer and name are used without entry data."""
+
+    hass = types.SimpleNamespace(data={})
+
+    info = build_power_monitor_device_info(hass, "entry-id", "gateway", "01")
+
+    assert info["manufacturer"] == "TermoWeb"
+    assert info["name"] == "Power Monitor 01"
+
+
+def test_build_power_monitor_device_info_uses_brand_override() -> None:
+    """Ensure brand overrides manufacturer while keeping fallback name."""
+
+    entry_id = "entry-id"
+    hass = types.SimpleNamespace(data={DOMAIN: {entry_id: {"brand": "Ducaheat"}}})
+
+    info = build_power_monitor_device_info(hass, entry_id, "gateway", "02")
+
+    assert info["manufacturer"] == "Ducaheat"
+    assert info["name"] == "Power Monitor 02"


### PR DESCRIPTION
## Summary
- add regression coverage for the power monitor device info helper without config entry data
- ensure brand overrides update the manufacturer while leaving the fallback name in place

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` *(fails: existing websocket protocol and init setup suites fail in the current test baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68ea173a729c8329be7fc5e7ff9c2c83