### PR TITLE
Add test covering statistics row helper behaviour

### DIFF
--- a/tests/test_energy_statistics_row_get.py
+++ b/tests/test_energy_statistics_row_get.py
@@ -1,0 +1,19 @@
+"""Tests for the `_statistics_row_get` helper."""
+
+from types import SimpleNamespace
+
+from custom_components.termoweb.energy import _statistics_row_get
+
+
+def test_statistics_row_get_handles_dicts_and_namespaces() -> None:
+    """Ensure `_statistics_row_get` supports dict rows and attribute rows."""
+
+    dict_row = {"start": "begin", "sum": 42}
+    namespace_row = SimpleNamespace(start=object(), sum=5)
+
+    assert _statistics_row_get(dict_row, "start") == "begin"
+    assert _statistics_row_get(dict_row, "sum") == 42
+
+    start_marker = namespace_row.start
+    assert _statistics_row_get(namespace_row, "start") is start_marker
+    assert _statistics_row_get(namespace_row, "sum") == 5


### PR DESCRIPTION
## Summary
- add a unit test that exercises `_statistics_row_get` with dicts and attribute-style rows

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: multiple pre-existing websocket protocol tests, inventory snapshot payload name error)*

------
https://chatgpt.com/codex/tasks/task_e_68ea17344da48329a76dba09ce5d7d6c