### PR TITLE
Add tests for websocket update section resolver

### DIFF
--- a/tests/test_ws_update_section.py
+++ b/tests/test_ws_update_section.py
@@ -1,0 +1,25 @@
+"""Unit tests for ``resolve_ws_update_section``."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.termoweb.backend.ws_client import resolve_ws_update_section
+
+
+@pytest.mark.parametrize(
+    "input_section, expected",
+    [
+        (None, (None, None)),
+        ("status", ("status", None)),
+        ("advanced_setup", ("advanced", "advanced_setup")),
+        ("setup", ("settings", "setup")),
+        ("custom", ("settings", "custom")),
+    ],
+)
+def test_resolve_ws_update_section(
+    input_section: str | None, expected: tuple[str | None, str | None]
+) -> None:
+    """Ensure websocket section names map to the expected tuples."""
+
+    assert resolve_ws_update_section(input_section) == expected


### PR DESCRIPTION
## Summary
- add a parametrized unit test that exercises `resolve_ws_update_section`

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(times out at 30s)*
- pytest tests/test_ws_update_section.py


------
https://chatgpt.com/codex/tasks/task_e_68ea173fd0108329a5c2192aa299f315