### PR TITLE
Add tests for WSStats defaults and mutation

### DIFF
--- a/tests/test_ws_stats.py
+++ b/tests/test_ws_stats.py
@@ -1,0 +1,32 @@
+"""Unit tests for the :class:`WSStats` dataclass."""
+
+from __future__ import annotations
+
+from custom_components.termoweb.backend.ws_client import WSStats
+
+
+def test_ws_stats_defaults() -> None:
+    """WSStats should expose explicit zero/empty defaults."""
+
+    stats = WSStats()
+
+    assert stats.frames_total == 0
+    assert stats.events_total == 0
+    assert stats.last_event_ts == 0.0
+    assert stats.last_paths is None
+
+
+def test_ws_stats_mutation_usage() -> None:
+    """Mimic frame/event accounting updates to document expected usage."""
+
+    stats = WSStats()
+
+    stats.frames_total += 3
+    stats.events_total += 2
+    stats.last_event_ts = 123.456
+    stats.last_paths = ["/devices", "/devices/node"]
+
+    assert stats.frames_total == 3
+    assert stats.events_total == 2
+    assert stats.last_event_ts == 123.456
+    assert stats.last_paths == ["/devices", "/devices/node"]


### PR DESCRIPTION
## Summary
- add unit tests that verify the default values exposed by `WSStats`
- cover the typical frame and event counter mutations to document expected usage

## Testing
- pytest tests/test_ws_stats.py

------
https://chatgpt.com/codex/tasks/task_e_68ea173de42c8329adda275e7e73b040