### PR TITLE
Enforce 60-minute boost increments

### DIFF
--- a/custom_components/termoweb/backend/sanitize.py
+++ b/custom_components/termoweb/backend/sanitize.py
@@ -64,8 +64,10 @@ def validate_boost_minutes(value: int | None) -> int | None:
         minutes = int(value)
     except (TypeError, ValueError) as err:  # pragma: no cover - defensive
         raise ValueError(f"Invalid boost_time value: {value!r}") from err
-    if minutes <= 0:
-        raise ValueError("boost_time must be a positive integer")
+    if minutes < 60 or minutes > 600 or minutes % 60 != 0:
+        raise ValueError(
+            "boost_time must be between 60 and 600 minutes in 60-minute increments"
+        )
     return minutes
 
 

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -1201,9 +1201,9 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
                 minutes,
             )
             return None
-        if value > 120:
+        if value < 60 or value > 600 or value % 60 != 0:
             _LOGGER.error(
-                "Boost duration must be between 1 and 120 minutes for type=%s addr=%s: %s",
+                "Boost duration must be between 60 and 600 minutes in 60-minute increments for type=%s addr=%s: %s",
                 self._node_type,
                 self._addr,
                 value,

--- a/custom_components/termoweb/services.yaml
+++ b/custom_components/termoweb/services.yaml
@@ -53,8 +53,8 @@ set_acm_preset:
   name: Configure accumulator boost preset
   description: >-
     Update the default boost duration and/or temperature for a TermoWeb
-    accumulator. Minutes are capped at 120; omit a field to keep the existing
-    value.
+    accumulator. Minutes must be between 60 and 600 in 60-minute increments;
+    omit a field to keep the existing value.
   target:
     entity:
       domain: climate
@@ -62,12 +62,13 @@ set_acm_preset:
   fields:
     minutes:
       name: Default boost duration
-      description: Number of minutes the boost should run when no override is provided.
-      example: 90
+      description: Number of minutes the boost should run when no override is provided (60–600, step 60).
+      example: 120
       selector:
         number:
-          min: 1
-          max: 120
+          min: 60
+          max: 600
+          step: 60
           unit_of_measurement: minutes
     temperature:
       name: Boost temperature
@@ -78,8 +79,8 @@ start_boost:
   name: Start accumulator boost
   description: >-
     Trigger an immediate boost on a TermoWeb accumulator. Provide a duration to
-    override the default (maximum 120 minutes), or omit it to use the stored
-    preset.
+    override the default (60–600 minutes in 60-minute increments), or omit it to
+    use the stored preset.
   target:
     entity:
       domain: climate
@@ -87,12 +88,13 @@ start_boost:
   fields:
     minutes:
       name: Boost duration
-      description: Duration of the boost session in minutes (1–120). Optional.
-      example: 60
+      description: Duration of the boost session in minutes (60–600, step 60). Optional.
+      example: 180
       selector:
         number:
-          min: 1
-          max: 120
+          min: 60
+          max: 600
+          step: 60
           unit_of_measurement: minutes
 
 cancel_boost:


### PR DESCRIPTION
## Summary
- tighten backend and climate boost validation to require 60–600 minute increments of 60
- update service descriptions and selectors to reflect the new boost duration rules

## Testing
- not run (per user request to defer)


------
https://chatgpt.com/codex/tasks/task_e_68ea1719467483298f602e32cbccd961