### PR TITLE
Add unit tests for identifier unique ID helpers

### DIFF
--- a/tests/test_identifiers_unique_ids.py
+++ b/tests/test_identifiers_unique_ids.py
@@ -1,0 +1,79 @@
+"""Tests for identifier builders focusing on unique ID helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb import identifiers as identifiers_module
+from custom_components.termoweb.identifiers import (
+    build_heater_entity_unique_id,
+    build_heater_unique_id,
+    build_power_monitor_device_unique_id,
+    build_power_monitor_energy_unique_id,
+    build_power_monitor_power_unique_id,
+    build_power_monitor_unique_id,
+)
+
+
+def test_build_heater_unique_id_prefixes_suffix_with_colon() -> None:
+    """Suffixes should gain a leading colon when missing."""
+
+    unique_id = build_heater_unique_id(" dev ", " htr ", " 01 ", suffix="status")
+
+    assert unique_id == f"{DOMAIN}:dev:htr:01:status"
+
+
+def test_build_heater_entity_unique_id_defers_to_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The entity helper should delegate to the heater unique ID builder."""
+
+    calls: list[tuple[object, ...]] = []
+
+    def _record(dev_id: object, node_type: object, addr: object, *, suffix: object | None = None) -> str:
+        calls.append((dev_id, node_type, addr, suffix))
+        return "recorded"
+
+    monkeypatch.setattr(identifiers_module, "build_heater_unique_id", _record)
+
+    assert build_heater_entity_unique_id("dev", "acm", "02", suffix="energy") == "recorded"
+    assert calls == [("dev", "acm", "02", "energy")]
+
+
+def test_power_monitor_helpers_defers_to_heater_unique_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Power-monitor helpers should pass through to the heater ID builder."""
+
+    calls: list[tuple[object, ...]] = []
+
+    def _record(dev_id: object, node_type: object, addr: object, *, suffix: object | None = None) -> str:
+        calls.append((dev_id, node_type, addr, suffix))
+        return "uid"
+
+    monkeypatch.setattr(identifiers_module, "build_heater_unique_id", _record)
+
+    assert build_power_monitor_unique_id("dev", "03", suffix="daily") == "uid"
+    assert build_power_monitor_device_unique_id("dev", "03") == "uid"
+    assert build_power_monitor_energy_unique_id("dev", "03") == "uid"
+    assert build_power_monitor_power_unique_id("dev", "03") == "uid"
+    assert calls == [
+        ("dev", "pmo", "03", "daily"),
+        ("dev", "pmo", "03", None),
+        ("dev", "pmo", "03", ":energy"),
+        ("dev", "pmo", "03", ":power"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "dev_id, node_type, addr",
+    [
+        ("", "htr", "01"),
+        ("dev", "", "01"),
+        ("dev", "htr", ""),
+    ],
+)
+def test_build_heater_unique_id_requires_all_components(
+    dev_id: str, node_type: str, addr: str
+) -> None:
+    """Missing components should raise ValueError."""
+
+    with pytest.raises(ValueError):
+        build_heater_unique_id(dev_id, node_type, addr)


### PR DESCRIPTION
## Summary
- add new tests validating heater and power monitor unique ID helpers
- ensure suffix coercion, wrapper delegation, and error handling are covered

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` *(fails: baseline websocket and inventory tests already failing on work branch)*

------
https://chatgpt.com/codex/tasks/task_e_68ea1ac22d30832989be05783e454170