### PR TITLE
Add tests for Ducaheat programme temperature serialisation

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -1072,8 +1072,8 @@ class DucaheatRESTClient(RESTClient):
 
     def _serialise_prog_temps(self, ptemp: list[float]) -> dict[str, str]:
         """Serialise preset temperatures into the API schema."""
-        antifrost, eco, comfort = self._ensure_ptemp(ptemp)
-        return {"antifrost": antifrost, "eco": eco, "comfort": comfort}
+        cold, night, day = self._ensure_ptemp(ptemp)
+        return {"cold": cold, "night": night, "day": day}
 
     def _safe_temperature(self, value: Any) -> str | None:
         """Defensively format inbound temperature values."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1791,7 +1791,7 @@ def test_ducaheat_set_htr_settings_writes_segmented(monkeypatch) -> None:
         assert set(prog_json) == {"prog"}
         assert prog_json["prog"]["1"] == [1] * 48
         ptemp_json = session.request_calls[2][2]["json"]
-        assert ptemp_json == {"antifrost": "5.0", "eco": "15.0", "comfort": "21.0"}
+        assert ptemp_json == {"cold": "5.0", "night": "15.0", "day": "21.0"}
 
     asyncio.run(_run())
 

--- a/tests/test_ducaheat_serialise_prog_temps.py
+++ b/tests/test_ducaheat_serialise_prog_temps.py
@@ -1,0 +1,45 @@
+"""Tests for Ducaheat preset temperature serialisation."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.termoweb.backend.ducaheat import DucaheatRESTClient
+
+
+class _StubSession:
+    """Minimal session stub for constructing the REST client."""
+
+
+def _make_client() -> DucaheatRESTClient:
+    """Create a Ducaheat REST client with placeholder credentials."""
+
+    return DucaheatRESTClient(
+        _StubSession(),
+        "user",
+        "pass",
+        api_base="https://api.termoweb.fake",
+    )
+
+
+def test_serialise_prog_temps_formats_values() -> None:
+    """Preset temperatures should be formatted to one decimal place."""
+
+    client = _make_client()
+    result = client._serialise_prog_temps([5, 15.26, 21])
+    assert result == {"cold": "5.0", "night": "15.3", "day": "21.0"}
+
+
+@pytest.mark.parametrize(
+    "ptemp",
+    (
+        123,
+        [10, 15],
+        [10, "bad", 20],
+    ),
+)
+def test_serialise_prog_temps_invalid_inputs(ptemp: object) -> None:
+    """Invalid preset temperature inputs should raise ``ValueError``."""
+
+    client = _make_client()
+    with pytest.raises(ValueError):
+        client._serialise_prog_temps(ptemp)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- ensure the Ducaheat REST client serialises preset temperatures using the cold/night/day keys
- add unit tests that cover successful formatting and invalid preset lists

## Testing
- pytest tests/test_ducaheat_serialise_prog_temps.py tests/test_api.py::test_ducaheat_set_htr_settings_writes_segmented -q

------
https://chatgpt.com/codex/tasks/task_e_68ea227811f08329ae82cdc324410e97