### PR TITLE
Drop legacy node snapshots in websocket dispatch

### DIFF
--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -886,7 +886,7 @@ def test_translate_nodes_list_merges_nested_updates(monkeypatch: pytest.MonkeyPa
 
 
 def test_apply_nodes_payload_merges_and_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Applying node payloads should build snapshots and dispatch updates."""
+    """Applying node payloads should normalize and dispatch updates."""
 
     client, _sio, dispatcher = _make_client(monkeypatch)
     client._collect_update_addresses = MagicMock(return_value=[("htr", "1")])  # type: ignore[attr-defined]
@@ -1123,6 +1123,15 @@ def test_handle_event_includes_addr_map(monkeypatch: pytest.MonkeyPatch) -> None
     )
     assert settings_payload is not None
     assert settings_payload["addr_map"] == {"htr": ["2"]}
+
+    dev_state = client._coordinator.data.get("device")
+    assert isinstance(dev_state, Mapping)
+    assert "nodes" not in dev_state
+    nodes_by_type = dev_state.get("nodes_by_type")
+    assert isinstance(nodes_by_type, Mapping)
+    htr_bucket = nodes_by_type.get("htr")
+    assert isinstance(htr_bucket, Mapping)
+    assert htr_bucket.get("addrs") == ["2"]
 
 
 def test_update_legacy_settings_updates_settings_map(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -692,6 +692,7 @@ def test_dispatch_nodes_updates_hass_and_coordinator(
     if isinstance(coordinator_data, dict):
         dev_state = coordinator_data.get("device")
         if isinstance(dev_state, dict):
+            assert "nodes" not in dev_state
             nodes_by_type = dev_state.get("nodes_by_type", {})
             if isinstance(nodes_by_type, dict):
                 pmo_section = nodes_by_type.get("pmo", {})


### PR DESCRIPTION
## Summary
- stop caching websocket node snapshots on the TermoWeb client and rely on inventory-driven address maps
- update websocket unit tests to assert against coordinator inventory data instead of the removed snapshot payloads

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: baseline boost validation expectations in tests/test_api.py and related suites)*
- pytest tests/test_termoweb_ws_protocol.py::test_handle_event_includes_addr_map tests/test_ws_client.py::test_dispatch_nodes_updates_hass_and_coordinator -q


------
https://chatgpt.com/codex/tasks/task_e_68ea24969c548329bafa9fb378942e70