### PR TITLE
Refactor inventory resolution to ignore node cache

### DIFF
--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -42,7 +42,14 @@ async def async_get_config_entry_diagnostics(
         if isinstance(candidate, Mapping):
             record = candidate
 
-    resolution = resolve_record_inventory(record)
+    nodes_payload: Any | None = None
+    if isinstance(record, Mapping):
+        if "nodes" in record:
+            nodes_payload = record.get("nodes")
+        elif "raw_nodes" in record:
+            nodes_payload = record.get("raw_nodes")
+
+    resolution = resolve_record_inventory(record, nodes_payload=nodes_payload)
     inventory_container = resolution.inventory
     inventory_source_label = resolution.source
     if inventory_container is not None:
@@ -108,7 +115,7 @@ async def async_get_config_entry_diagnostics(
         redacted = async_redact_data(diagnostics, SENSITIVE_FIELDS)
         if inspect.isawaitable(redacted):
             redacted = await redacted
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
+    except Exception:  # pragma: no cover - defensive
         _LOGGER.exception(
             "Failed to redact diagnostics payload for %s", entry.entry_id
         )

--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -263,7 +263,7 @@ class Inventory:
                 filtered_forward[node_type] = normalized
                 for addr in normalized:
                     reverse_map.setdefault(addr, set()).add(node_type)
-            filtered_forward.setdefault("pmo", tuple())
+            filtered_forward.setdefault("pmo", ())
             cached = (
                 filtered_forward,
                 {addr: frozenset(node_types) for addr, node_types in reverse_map.items()},
@@ -486,8 +486,6 @@ def resolve_record_inventory(
     payload_candidate = nodes_payload
 
     nodes_candidate: Iterable[Any] | None = node_list
-    if mapping is not None and nodes_candidate is None and "node_inventory" in mapping:
-        nodes_candidate = mapping.get("node_inventory")
 
     def _node_pairs(items: Iterable[Any]) -> set[tuple[str, str]]:
         pairs: set[tuple[str, str]] = set()
@@ -543,13 +541,11 @@ def resolve_record_inventory(
         nodes_tuple, raw_count = node_info
         result = _finalize(
             nodes_tuple,
-            source="node_inventory",
+            source="node_list",
             raw_count=raw_count,
             payload=payload_candidate,
         )
         if result is not None:
-            if mutable is not None:
-                mutable.pop("node_inventory", None)
             return result
 
     snapshot = mapping.get("snapshot") if mapping is not None else None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -133,9 +133,7 @@ def test_diagnostics_uses_raw_nodes_fallback(
     }
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        "node_inventory": list(build_node_inventory(raw_nodes)),
-    }
+    hass.data[DOMAIN][entry.entry_id] = {"nodes": raw_nodes}
 
     with caplog.at_level(logging.DEBUG):
         diagnostics = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
@@ -150,7 +148,7 @@ def test_diagnostics_uses_raw_nodes_fallback(
     assert "time_zone" not in diagnostics["home_assistant"]
 
     assert (
-        "Diagnostics inventory source for entry-two: node_inventory (raw=1, filtered=1)"
+        "Diagnostics inventory source for entry-two: raw_nodes (raw=1, filtered=1)"
         in caplog.text
     )
 

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -1436,16 +1436,16 @@ def test_heater_sample_targets_use_record_inventory(
     assert client._inventory is inventory
 
 
-def test_heater_sample_targets_build_from_record_node_inventory(
+def test_heater_sample_targets_build_from_record_raw_nodes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cached node inventory should seed rebuilds when inventory is missing."""
+    """Raw node payloads should seed inventory rebuilds when cached inventory is missing."""
 
     client, _sio, _ = _make_client(monkeypatch)
     record = client.hass.data[module.DOMAIN]["entry"]
     raw_nodes = {"nodes": [{"type": "htr", "addr": "13"}]}
     record.clear()
-    record["node_inventory"] = module.build_node_inventory(raw_nodes)
+    record["nodes"] = raw_nodes
     record.pop("inventory", None)
 
     client._inventory = None
@@ -1454,7 +1454,7 @@ def test_heater_sample_targets_build_from_record_node_inventory(
 
     assert targets == [("htr", "13")]
     assert isinstance(client._inventory, Inventory)
-    assert client._inventory.payload == {}
+    assert client._inventory.payload == raw_nodes
     assert any(node.addr == "13" for node in client._inventory.nodes)
 
 


### PR DESCRIPTION
## Summary
- update resolve_record_inventory to ignore record-provided node_inventory data and treat explicit node lists distinctly
- feed raw node payloads into diagnostics inventory resolution and refresh related tests to reflect the stricter behaviour
- align websocket subscription tests with the new raw-node rebuild flow

## Testing
- `pytest tests/test_inventory.py`
- `pytest tests/test_diagnostics.py`
- `pytest tests/test_termoweb_ws_protocol.py::test_heater_sample_targets_build_from_record_raw_nodes`
- `ruff check custom_components/termoweb/inventory.py custom_components/termoweb/diagnostics.py tests/test_inventory.py tests/test_diagnostics.py tests/test_termoweb_ws_protocol.py`

------
https://chatgpt.com/codex/tasks/task_e_68ea24a600608329ac31e93b70ff2b9f