### PR TITLE
Dynamic payload stale window for Ducaheat WS

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -323,6 +323,7 @@ class _WSStatusMixin:
         state["last_payload_at"] = tracker.last_payload_at
         state["last_heartbeat_at"] = tracker.last_heartbeat_at
         state["payload_stale"] = tracker.payload_stale
+        state["payload_stale_after"] = tracker.payload_stale_after
         if changed:
             self._notify_ws_status(
                 tracker,

--- a/tests/test_ws_status_payload_tracking.py
+++ b/tests/test_ws_status_payload_tracking.py
@@ -27,6 +27,7 @@ class StubTracker:
     payload_stale: bool = False
     last_payload_at: float | None = None
     last_heartbeat_at: float | None = None
+    payload_stale_after: float | None = None
     mark_payload_calls: list[dict[str, Any]] = field(default_factory=list)
     mark_heartbeat_calls: list[dict[str, Any]] = field(default_factory=list)
     refresh_calls: list[dict[str, Any]] = field(default_factory=list)
@@ -45,6 +46,8 @@ class StubTracker:
         self.last_payload_at = timestamp
         if timestamp is not None:
             self.last_heartbeat_at = timestamp
+        if stale_after is not None:
+            self.payload_stale_after = stale_after
         self.payload_stale = self.next_payload_stale
         return self.mark_payload_result
 


### PR DESCRIPTION
## Summary
- derive websocket payload freshness windows from lease metadata and persist the cadence state for health tracking
- surface the dynamic window in the shared Home Assistant state/log output and reset it on disconnect
- add regression tests covering the new cadence-derived window behaviour and tracker updates

## Testing
- pytest tests/test_ducaheat_ws_protocol.py -k payload_window
- pytest tests/test_ws_status_payload_tracking.py
- pytest tests/test_ducaheat_ws_status_reset.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: known boost_time validation test updates pending, see docs/test_failure_recovery_plan.md)*

------
https://chatgpt.com/codex/tasks/task_e_68ea23e1b89c8329888f1b71757fb666