### PR TITLE
Add tests for trimmed power monitor device info names

### DIFF
--- a/tests/test_utils_power_monitor_device_info.py
+++ b/tests/test_utils_power_monitor_device_info.py
@@ -29,3 +29,41 @@ def test_build_power_monitor_device_info_uses_brand_override() -> None:
 
     assert info["manufacturer"] == "Ducaheat"
     assert info["name"] == "Power Monitor 02"
+
+
+def test_build_power_monitor_device_info_trims_custom_name() -> None:
+    """Ensure custom names are trimmed while keeping identifiers and defaults."""
+
+    hass = types.SimpleNamespace(data={})
+
+    info = build_power_monitor_device_info(
+        hass,
+        "entry-id",
+        "gateway-42",
+        "07",
+        name="  Kitchen Meter  ",
+    )
+
+    assert info["name"] == "Kitchen Meter"
+    assert info["manufacturer"] == "TermoWeb"
+    assert info["identifiers"] == {(DOMAIN, "gateway-42", "pmo", "07")}
+
+
+def test_build_power_monitor_device_info_trimmed_name_with_brand_override() -> None:
+    """Ensure trimmed names persist when brand overrides the manufacturer."""
+
+    entry_id = "entry-id"
+    hass = types.SimpleNamespace(
+        data={DOMAIN: {entry_id: {"brand": "  Tevolve  "}}},
+    )
+
+    info = build_power_monitor_device_info(
+        hass,
+        entry_id,
+        "gateway-99",
+        "08",
+        name="  Kitchen Meter  ",
+    )
+
+    assert info["name"] == "Kitchen Meter"
+    assert info["manufacturer"] == "Tevolve"


### PR DESCRIPTION
## Summary
- add a regression test confirming custom power monitor names are trimmed while preserving identifiers and defaults
- ensure providing both a trimmed name and brand override keeps the name and replaces the manufacturer

## Testing
- pytest tests/test_utils_power_monitor_device_info.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea4f102e588329bc7987f8e160ea4d