### PR TITLE
Use stored inventory for diagnostics node output

### DIFF
--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -42,14 +42,7 @@ async def async_get_config_entry_diagnostics(
         if isinstance(candidate, Mapping):
             record = candidate
 
-    nodes_payload: Any | None = None
-    if isinstance(record, Mapping):
-        if "nodes" in record:
-            nodes_payload = record.get("nodes")
-        elif "raw_nodes" in record:
-            nodes_payload = record.get("raw_nodes")
-
-    resolution = resolve_record_inventory(record, nodes_payload=nodes_payload)
+    resolution = resolve_record_inventory(record)
     inventory_container = resolution.inventory
     inventory_source_label = resolution.source
     if inventory_container is not None:


### PR DESCRIPTION
## Summary
- rely solely on the stored inventory when building diagnostics node listings
- update diagnostics tests to exercise Inventory containers instead of raw-node fallbacks

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/diagnostics.py tests/test_diagnostics.py

------
https://chatgpt.com/codex/tasks/task_e_68ea4f2e4ae08329a8a8961bafeb2621