### PR TITLE
Remove legacy heater inventory helper

### DIFF
--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -46,7 +46,6 @@ __all__ = [
     "HEATER_NODE_TYPES",
     "NODE_CLASS_BY_TYPE",
     "AccumulatorNode",
-    "HeaterInventoryDetails",
     "HeaterNode",
     "Inventory",
     "InventoryResolution",
@@ -57,7 +56,6 @@ __all__ = [
     "_normalize_node_identifier",
     "addresses_by_node_type",
     "build_heater_address_map",
-    "build_heater_inventory_details",
     "build_node_inventory",
     "heater_platform_details_from_inventory",
     "heater_sample_subscription_targets",
@@ -767,34 +765,6 @@ def build_heater_address_map(
             reverse.setdefault(address, set()).add(node_type)
 
     return by_type, reverse
-
-
-@dataclass(slots=True)
-class HeaterInventoryDetails:
-    """Describe cached metadata derived from heater nodes."""
-
-    nodes_by_type: dict[str, list[Node]]
-    explicit_name_pairs: set[tuple[str, str]]
-    address_map: dict[str, list[str]]
-    reverse_address_map: dict[str, set[str]]
-
-
-def build_heater_inventory_details(
-    nodes: Iterable[Node],
-) -> HeaterInventoryDetails:
-    """Return derived heater metadata for ``nodes``."""
-
-    inventory = Inventory("", {}, nodes)
-    nodes_by_type = inventory.nodes_by_type
-    explicit_names = inventory.explicit_heater_names
-    filtered_forward, filtered_reverse = inventory.heater_address_map
-
-    return HeaterInventoryDetails(
-        nodes_by_type=nodes_by_type,
-        explicit_name_pairs=explicit_names,
-        address_map=filtered_forward,
-        reverse_address_map=filtered_reverse,
-    )
 
 
 def heater_platform_details_from_inventory(

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -359,26 +359,6 @@ def test_inventory_heater_sample_targets_filters_invalid(
     targets = heater_inventory.heater_sample_targets
     assert targets == [("htr", "1")]
     assert ("acm", "2") not in targets
-
-
-def test_build_heater_inventory_details_wraps_inventory(
-    heater_inventory: Inventory,
-) -> None:
-    """Legacy helper should return data derived from the ``Inventory`` wrapper."""
-
-    from custom_components.termoweb.inventory import (  # noqa: PLC0415
-        build_heater_inventory_details,
-    )
-
-    details = build_heater_inventory_details(heater_inventory.nodes)
-    forward, reverse = heater_inventory.heater_address_map
-
-    assert details.nodes_by_type == heater_inventory.nodes_by_type
-    assert details.explicit_name_pairs == heater_inventory.explicit_heater_names
-    assert details.address_map == forward
-    assert details.reverse_address_map == reverse
-
-
 def test_resolve_record_inventory_prefers_existing_container() -> None:
     """Resolution should return stored inventory without rebuilding."""
 


### PR DESCRIPTION
## Summary
- drop the unused `HeaterInventoryDetails` dataclass and builder from the inventory module
- update the inventory test suite to rely on the production `Inventory` APIs

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea4f459c748329972c9e5ef825c132