### PR TITLE
Remove redundant Ducaheat alias from config flow

### DIFF
--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 from . import async_list_devices, create_rest_client
 from .api import BackendAuthError, BackendRateLimitError
 from .const import (
-    BRAND_DUCAHEAT as CONST_BRAND_DUCAHEAT,
+    BRAND_DUCAHEAT,
     BRAND_LABELS,
     BRAND_TERMOWEB,
     CONF_BRAND,
@@ -28,7 +28,7 @@ from .const import (
 )
 from .utils import async_get_integration_version
 
-BRAND_DUCAHEAT = CONST_BRAND_DUCAHEAT
+__all__ = ["BRAND_DUCAHEAT"]
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove the redundant alias for `BRAND_DUCAHEAT` in the config flow module
- expose the constant via `__all__` so existing imports continue to work

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea4f4ca3e483299c17357f60ed3798