### PR TITLE
Add tests for websocket getattr client resolution

### DIFF
--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -391,6 +391,31 @@ def test_forward_ws_sample_updates_inventory_validation(
     assert handler.call_args.kwargs.get("lease_seconds") == 15
 
 
+def test_getattr_exposes_ducaheat_ws_client() -> None:
+    """__getattr__ should expose the Ducaheat websocket client class."""
+
+    cls = base_ws.__getattr__("DucaheatWSClient")
+    assert cls.__name__ == ducaheat_ws.DucaheatWSClient.__name__
+    assert cls.__module__ == ducaheat_ws.DucaheatWSClient.__module__
+
+
+def test_getattr_exposes_termoweb_ws_client() -> None:
+    """__getattr__ should expose the TermoWeb websocket client class."""
+
+    cls = base_ws.__getattr__("TermoWebWSClient")
+    assert cls.__name__ == module.TermoWebWSClient.__name__
+    assert cls.__module__ == module.TermoWebWSClient.__module__
+
+
+def test_getattr_raises_for_unknown_client() -> None:
+    """Unknown attributes should raise AttributeError via __getattr__."""
+
+    with pytest.raises(AttributeError) as exc_info:
+        base_ws.__getattr__("UnknownClient")
+
+    assert exc_info.value.args == ("UnknownClient",)
+
+
 def test_termoweb_client_initialises_namespace_and_handlers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add unit tests covering ws_client.__getattr__ returning the Ducaheat and TermoWeb client classes
- add a negative unit test asserting unknown websocket clients raise AttributeError

## Testing
- pytest tests/test_ws_client.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea4f0d2cb48329901c1a902622e887