### PR TITLE
Remove unused heater platform data helper

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -813,29 +813,6 @@ def heater_platform_details_for_entry(
     )
 
 
-def prepare_heater_platform_data(
-    entry_data: dict[str, Any],
-    *,
-    default_name_simple: Callable[[str], str],
-) -> tuple[
-    tuple[Node, ...],
-    dict[str, list[Node]],
-    dict[str, list[str]],
-    Callable[[str, str], str],
-]:
-    """Return node metadata and name resolution helpers for a config entry."""
-    details = heater_platform_details_for_entry(
-        entry_data,
-        default_name_simple=default_name_simple,
-    )
-
-    inventory_nodes = details.inventory.nodes
-    nodes_by_type = details.nodes_by_type
-    addrs_by_type = details.addrs_by_type
-
-    return inventory_nodes, dict(nodes_by_type), addrs_by_type, details.resolve_name
-
-
 class HeaterNodeBase(CoordinatorEntity):
     """Base entity implementing common TermoWeb heater behaviour."""
 

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -708,10 +708,6 @@ custom_components/termoweb/heater.py :: log_skipped_nodes
     Log skipped TermoWeb nodes for a given platform.
 custom_components/termoweb/heater.py :: build_heater_name_map
     Return a mapping of heater node identifiers to friendly names.
-custom_components/termoweb/heater.py :: prepare_heater_platform_data
-    Return node metadata and name resolution helpers for a config entry.
-custom_components/termoweb/heater.py :: prepare_heater_platform_data.resolve_name
-    Resolve the friendly name for ``addr`` of the given node type.
 custom_components/termoweb/heater.py :: HeaterNodeBase.__init__
     Initialise a heater entity tied to a TermoWeb device.
 custom_components/termoweb/heater.py :: HeaterNodeBase.async_added_to_hass

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -184,9 +184,7 @@ def test_power_monitor_sensors_register_device_info() -> None:
     asyncio.run(_run())
 
 
-def test_sensor_async_setup_entry_ignores_blank_addresses(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_sensor_async_setup_entry_ignores_blank_addresses() -> None:
     async def _run() -> None:
         hass = HomeAssistant()
         entry = types.SimpleNamespace(entry_id="entry-skip")
@@ -218,15 +216,6 @@ def test_sensor_async_setup_entry_ignores_blank_addresses(
         record["inventory"] = inventory
         record["node_inventory"] = list(inventory.nodes)
 
-        def _fail_prepare(*_args: Any, **_kwargs: Any) -> tuple[Any, ...]:
-            raise AssertionError("prepare_heater_platform_data should not run")
-
-        monkeypatch.setattr(
-            heater_module,
-            "prepare_heater_platform_data",
-            _fail_prepare,
-        )
-
         added: list[Any] = []
 
         def _add_entities(entities: list[Any]) -> None:
@@ -244,9 +233,7 @@ def test_sensor_async_setup_entry_ignores_blank_addresses(
     asyncio.run(_run())
 
 
-def test_sensor_async_setup_entry_handles_boolean_boost_flag(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_sensor_async_setup_entry_handles_boolean_boost_flag() -> None:
     async def _run() -> None:
         hass = HomeAssistant()
         entry = types.SimpleNamespace(entry_id="entry-boost-bool")
@@ -280,15 +267,6 @@ def test_sensor_async_setup_entry_handles_boolean_boost_flag(
         record = hass.data[DOMAIN][entry.entry_id]
         record["inventory"] = inventory
         record["node_inventory"] = list(inventory.nodes)
-
-        def _fail_prepare(*_args: Any, **_kwargs: Any) -> tuple[Any, ...]:
-            raise AssertionError("prepare_heater_platform_data should not run")
-
-        monkeypatch.setattr(
-            heater_module,
-            "prepare_heater_platform_data",
-            _fail_prepare,
-        )
 
         added: list[Any] = []
 
@@ -384,13 +362,6 @@ def test_sensor_async_setup_entry_creates_entities_and_reuses_coordinator() -> N
         ]
 
         with (
-            patch.object(
-                heater_module,
-                "prepare_heater_platform_data",
-                side_effect=AssertionError(
-                    "prepare_heater_platform_data should not run"
-                ),
-            ),
             patch.object(
                 EnergyStateCoordinator,
                 "async_config_entry_first_refresh",


### PR DESCRIPTION
## Summary
- remove the unused `prepare_heater_platform_data` helper and rely on `heater_platform_details_for_entry`
- update heater platform unit tests to exercise the public API directly
- adjust sensor tests and generated documentation references to drop the helper

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea4f3e17988329a379c714d4a7574c