### PR TITLE
Refactor authed headers helper usage

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -110,7 +110,7 @@ class DucaheatRESTClient(RESTClient):
         """Fetch and normalise node settings for the Ducaheat API."""
 
         node_type, addr = self._resolve_node_descriptor(node)
-        headers = await self._authed_headers()
+        headers = await self.authed_headers()
         path = f"/api/v2/devs/{dev_id}/{node_type}/{addr}"
         payload = await self._request("GET", path, headers=headers)
 
@@ -151,7 +151,7 @@ class DucaheatRESTClient(RESTClient):
 
         node_type, addr = self._resolve_node_descriptor(node)
         if node_type == "htr":
-            headers = await self._authed_headers()
+            headers = await self.authed_headers()
             base = f"/api/v2/devs/{dev_id}/htr/{addr}"
             responses: dict[str, Any] = {}
 
@@ -257,7 +257,7 @@ class DucaheatRESTClient(RESTClient):
                 dev_id, (node_type, addr), start, stop
             )
 
-        headers = await self._authed_headers()
+        headers = await self.authed_headers()
         path = f"/api/v2/devs/{dev_id}/htr/{addr}/samples"
         params = {"start": int(start * 1000), "end": int(stop * 1000)}
         data = await self._request("GET", path, headers=headers, params=params)
@@ -608,7 +608,7 @@ class DucaheatRESTClient(RESTClient):
     ) -> dict[str, Any]:
         """Apply segmented writes for accumulator nodes."""
 
-        headers = await self._authed_headers()
+        headers = await self.authed_headers()
         base = f"/api/v2/devs/{dev_id}/acm/{addr}"
         responses: dict[str, Any] = {}
 
@@ -958,7 +958,7 @@ class DucaheatRESTClient(RESTClient):
         """Write default boost configuration using segmented endpoints."""
 
         node_type, addr_str = self._resolve_node_descriptor(("acm", addr))
-        headers = await self._authed_headers()
+        headers = await self.authed_headers()
         payload = self._build_acm_extra_options_payload(boost_time, boost_temp)
         return await self._post_acm_endpoint(
             f"/api/v2/devs/{dev_id}/{node_type}/{addr_str}/setup",
@@ -981,7 +981,7 @@ class DucaheatRESTClient(RESTClient):
         """Toggle an accumulator boost session via segmented endpoints."""
 
         node_type, addr_str = self._resolve_node_descriptor(("acm", addr))
-        headers = await self._authed_headers()
+        headers = await self.authed_headers()
         formatted_temp: str | None = None
         if stemp is not None:
             try:

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -1321,7 +1321,7 @@ class WebSocketClient(_WSStatusMixin):
 
     async def _get_token(self) -> str:
         """Reuse the REST client token for websocket authentication."""
-        headers = await self._client._authed_headers()  # noqa: SLF001
+        headers = await self._client.authed_headers()
         auth_header = (
             headers.get("Authorization") if isinstance(headers, dict) else None
         )

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -44,8 +44,6 @@ custom_components/termoweb/api.py :: RESTClient._request
     Perform an HTTP request.
 custom_components/termoweb/api.py :: RESTClient._ensure_token
     Ensure a bearer token is present; fetch if missing.
-custom_components/termoweb/api.py :: RESTClient._authed_headers
-    Return HTTP headers including a valid bearer token.
 custom_components/termoweb/api.py :: RESTClient.user_agent
     Return the configured User-Agent string.
 custom_components/termoweb/api.py :: RESTClient.requested_with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2004,7 +2004,7 @@ def ducaheat_rest_harness(
             rtc_calls.append(dev_id)
             return dict(rtc_template)
 
-        monkeypatch.setattr(client, "_authed_headers", fake_headers)
+        monkeypatch.setattr(client, "authed_headers", fake_headers)
         monkeypatch.setattr(client, "_request", fake_request)
         monkeypatch.setattr(client, "_post_segmented", fake_post_segmented)
         monkeypatch.setattr(client, "get_rtc_time", fake_rtc)

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -62,7 +62,7 @@ class DummyClient:
     ) -> list[dict[str, object]]:
         return []
 
-    async def _authed_headers(self) -> dict[str, str]:  # pragma: no cover - stub
+    async def authed_headers(self) -> dict[str, str]:  # pragma: no cover - stub
         return {"Authorization": "Bearer token"}
 
 
@@ -73,7 +73,7 @@ def ducaheat_rest_client(monkeypatch: pytest.MonkeyPatch) -> DucaheatRESTClient:
     async def fake_headers() -> dict[str, str]:
         return {"Authorization": "Bearer token"}
 
-    monkeypatch.setattr(client, "_authed_headers", fake_headers)
+    monkeypatch.setattr(client, "authed_headers", fake_headers)
     return client
 
 
@@ -210,7 +210,7 @@ async def test_ducaheat_rest_set_node_settings_acm_invalid_inputs(
     async def fake_headers() -> dict[str, str]:
         return {}
 
-    monkeypatch.setattr(ducaheat_rest_client, "_authed_headers", fake_headers)
+    monkeypatch.setattr(ducaheat_rest_client, "authed_headers", fake_headers)
 
     with pytest.raises(ValueError):
         await ducaheat_rest_client.set_node_settings("dev", ("acm", "3"), **kwargs)

--- a/tests/test_ducaheat_acm_writes.py
+++ b/tests/test_ducaheat_acm_writes.py
@@ -36,7 +36,7 @@ def test_ducaheat_acm_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
                 message="malformed",
             )
 
-        monkeypatch.setattr(client, "_authed_headers", fake_headers)
+        monkeypatch.setattr(client, "authed_headers", fake_headers)
         monkeypatch.setattr(client, "_request", fake_request)
         mock_rtc = AsyncMock(return_value={})
         monkeypatch.setattr(client, "get_rtc_time", mock_rtc)

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -36,7 +36,7 @@ class DummyREST:
         self._session = SimpleNamespace(closed=True)
         self._ensure_token = AsyncMock()
         headers = authed_headers or {"Authorization": "Bearer token"}
-        self._authed_headers = AsyncMock(return_value=headers)
+        self.authed_headers = AsyncMock(return_value=headers)
         self.api_base = api_base
         self.user_agent = "agent"
         self.requested_with = requested_with

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -37,9 +37,6 @@ class DummyREST:
     async def authed_headers(self) -> dict[str, str]:
         return self._headers
 
-    async def _authed_headers(self) -> dict[str, str]:
-        return await self.authed_headers()
-
     async def refresh_token(self) -> None:
         self._access_token = None
         await self._ensure_token()
@@ -896,7 +893,7 @@ async def test_termoweb_get_token_from_rest(monkeypatch: pytest.MonkeyPatch) -> 
 
     client = _make_termoweb_client(monkeypatch)
     rest_client = client._client
-    rest_client._authed_headers = AsyncMock(  # type: ignore[attr-defined]
+    rest_client.authed_headers = AsyncMock(  # type: ignore[attr-defined]
         return_value={"Authorization": "Bearer newtoken"}
     )
     token = await client._get_token()
@@ -911,7 +908,7 @@ async def test_termoweb_get_token_missing_header(
 
     client = _make_termoweb_client(monkeypatch)
     rest_client = client._client
-    rest_client._authed_headers = AsyncMock(return_value={})  # type: ignore[attr-defined]
+    rest_client.authed_headers = AsyncMock(return_value={})  # type: ignore[attr-defined]
     with pytest.raises(RuntimeError):
         await client._get_token()
 


### PR DESCRIPTION
## Summary
- move RESTClient authed header construction into the public helper and update REST consumers
- switch websocket code to the public helper and drop the private alias
- refresh tests, fixtures, and docs to patch the surviving helper

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5191fc5883298f4af8294c821eb4