### PR TITLE
Route heater writes through set_node_settings

### DIFF
--- a/custom_components/termoweb/api.py
+++ b/custom_components/termoweb/api.py
@@ -699,29 +699,6 @@ class RESTClient:
         )
         return self._extract_samples(data)
 
-    async def set_htr_settings(
-        self,
-        dev_id: str,
-        addr: str | int,
-        *,
-        mode: str | None = None,
-        stemp: float | None = None,
-        prog: list[int] | None = None,
-        ptemp: list[float] | None = None,
-        units: str = "C",
-    ) -> Any:
-        """Update heater settings for the specified node."""
-
-        return await self.set_node_settings(
-            dev_id,
-            ("htr", addr),
-            mode=mode,
-            stemp=stemp,
-            prog=prog,
-            ptemp=ptemp,
-            units=units,
-        )
-
     def _resolve_node_descriptor(self, node: NodeDescriptor) -> tuple[str, str]:
         """Return ``(node_type, addr)`` for the provided descriptor."""
 

--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -44,20 +44,6 @@ class HttpClientProto(Protocol):
     ) -> list[dict[str, str | int]]:
         """Return historical samples for the specified node."""
 
-    async def set_htr_settings(
-        self,
-        dev_id: str,
-        addr: str | int,
-        *,
-        mode: str | None = None,
-        stemp: float | None = None,
-        prog: list[int] | None = None,
-        ptemp: list[float] | None = None,
-        units: str = "C",
-    ) -> Any:
-        """Update heater settings for the specified node."""
-
-
 class WsClientProto(Protocol):
     """Protocol for websocket clients used by the integration."""
 

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -440,11 +440,11 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
         ptemp: list[float] | None,
         units: str,
     ) -> None:
-        """Send settings via the heater-specific API."""
+        """Send settings for this heater to the backend."""
 
-        await client.set_htr_settings(
+        await client.set_node_settings(
             self._dev_id,
-            self._addr,
+            (self._node_type, self._addr),
             mode=mode,
             stemp=stemp,
             prog=prog,

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -80,8 +80,6 @@ custom_components/termoweb/api.py :: RESTClient.set_acm_boost_state
     Start or stop an accumulator boost session.
 custom_components/termoweb/api.py :: RESTClient.get_node_samples
     Return heater samples as list of {"t", "counter"} dicts.
-custom_components/termoweb/api.py :: RESTClient.set_htr_settings
-    Update heater settings for the specified node.
 custom_components/termoweb/api.py :: RESTClient._resolve_node_descriptor
     Return ``(node_type, addr)`` for the provided descriptor.
 custom_components/termoweb/api.py :: RESTClient._log_non_htr_payload
@@ -100,8 +98,6 @@ custom_components/termoweb/backend/base.py :: HttpClientProto.set_node_settings
     Update node settings for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_samples
     Return historical samples for the specified node.
-custom_components/termoweb/backend/base.py :: HttpClientProto.set_htr_settings
-    Update heater settings for the specified node.
 custom_components/termoweb/backend/base.py :: WsClientProto.start
     Start the websocket client.
 custom_components/termoweb/backend/base.py :: WsClientProto.stop

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1129,7 +1129,7 @@ def test_get_node_samples_logs_for_unknown_type(
     asyncio.run(_run())
 
 
-def test_set_htr_settings_includes_prog_and_ptemp(monkeypatch) -> None:
+def test_set_node_settings_includes_prog_and_ptemp(monkeypatch) -> None:
     async def _run() -> None:
         session = FakeSession()
         client = RESTClient(session, "user", "pw")
@@ -1146,7 +1146,13 @@ def test_set_htr_settings_includes_prog_and_ptemp(monkeypatch) -> None:
 
         prog = [0, 1, 2] * 56
         ptemp = [18.0, 19.0, 20.0]
-        await client.set_htr_settings("dev123", "7", prog=prog, ptemp=ptemp, units="f")
+        await client.set_node_settings(
+            "dev123",
+            ("htr", "7"),
+            prog=prog,
+            ptemp=ptemp,
+            units="f",
+        )
 
         assert received == [
             {
@@ -1241,13 +1247,13 @@ def test_request_final_auth_error_after_retries(monkeypatch) -> None:
     asyncio.run(_run())
 
 
-def test_set_htr_settings_invalid_units() -> None:
+def test_set_node_settings_invalid_units() -> None:
     async def _run() -> None:
         session = FakeSession()
         client = RESTClient(session, "user", "pass")
 
         with pytest.raises(ValueError, match="Invalid units"):
-            await client.set_htr_settings("dev", "1", units="kelvin")
+            await client.set_node_settings("dev", ("htr", "1"), units="kelvin")
 
         assert not session.request_calls
         assert not session.post_calls
@@ -1255,19 +1261,19 @@ def test_set_htr_settings_invalid_units() -> None:
     asyncio.run(_run())
 
 
-def test_set_htr_settings_invalid_program() -> None:
+def test_set_node_settings_invalid_program() -> None:
     async def _run() -> None:
         session = FakeSession()
         client = RESTClient(session, "user", "pass")
 
         with pytest.raises(ValueError, match="prog must be a list of 168"):
-            await client.set_htr_settings("dev", "1", prog=[0, 1, 2])
+            await client.set_node_settings("dev", ("htr", "1"), prog=[0, 1, 2])
 
         with pytest.raises(ValueError, match="prog values must be 0, 1, or 2"):
-            await client.set_htr_settings("dev", "1", prog=[0] * 167 + [5])
+            await client.set_node_settings("dev", ("htr", "1"), prog=[0] * 167 + [5])
 
         with pytest.raises(ValueError, match="prog contains non-integer value"):
-            await client.set_htr_settings("dev", "1", prog=[0] * 167 + ["bad"])
+            await client.set_node_settings("dev", ("htr", "1"), prog=[0] * 167 + ["bad"])
 
         assert not session.request_calls
         assert not session.post_calls
@@ -1275,21 +1281,25 @@ def test_set_htr_settings_invalid_program() -> None:
     asyncio.run(_run())
 
 
-def test_set_htr_settings_invalid_temperatures() -> None:
+def test_set_node_settings_invalid_temperatures() -> None:
     async def _run() -> None:
         session = FakeSession()
         client = RESTClient(session, "user", "pass")
 
         with pytest.raises(ValueError, match="Invalid stemp value"):
-            await client.set_htr_settings("dev", "1", stemp="warm")
+            await client.set_node_settings("dev", ("htr", "1"), stemp="warm")
 
         with pytest.raises(
             ValueError, match="ptemp must be a list of three numeric values"
         ):
-            await client.set_htr_settings("dev", "1", ptemp=[21.0, 19.0])
+            await client.set_node_settings("dev", ("htr", "1"), ptemp=[21.0, 19.0])
 
         with pytest.raises(ValueError, match="ptemp contains non-numeric value"):
-            await client.set_htr_settings("dev", "1", ptemp=[21.0, "bad", 23.0])
+            await client.set_node_settings(
+                "dev",
+                ("htr", "1"),
+                ptemp=[21.0, "bad", 23.0],
+            )
 
         assert not session.request_calls
         assert not session.post_calls
@@ -1504,7 +1514,7 @@ def test_list_devices_unexpected_string_payload(monkeypatch, caplog) -> None:
     assert any("Unexpected /devs shape" in rec.message for rec in caplog.records)
 
 
-def test_set_htr_settings_translates_heat(monkeypatch) -> None:
+def test_set_node_settings_translates_heat(monkeypatch) -> None:
     async def _run() -> None:
         session = FakeSession()
         client = RESTClient(session, "user", "pass")
@@ -1521,7 +1531,7 @@ def test_set_htr_settings_translates_heat(monkeypatch) -> None:
         monkeypatch.setattr(client, "_authed_headers", fake_headers)
         monkeypatch.setattr(client, "_request", fake_request)
 
-        await client.set_htr_settings("dev", 1, mode="heat", stemp=21.0)
+        await client.set_node_settings("dev", ("htr", 1), mode="heat", stemp=21.0)
 
         assert captured["json"]["mode"] == "manual"
         assert captured["json"]["stemp"] == "21.0"
@@ -1740,7 +1750,7 @@ def test_ducaheat_get_node_settings_acm_handles_half_hour_prog(
     asyncio.run(_run())
 
 
-def test_ducaheat_set_htr_settings_invalid_stemp(monkeypatch) -> None:
+def test_ducaheat_set_node_settings_invalid_stemp(monkeypatch) -> None:
     async def _run() -> None:
         session = FakeSession()
         client = DucaheatRESTClient(
@@ -1756,14 +1766,14 @@ def test_ducaheat_set_htr_settings_invalid_stemp(monkeypatch) -> None:
         monkeypatch.setattr(client, "_authed_headers", fake_headers)
 
         with pytest.raises(ValueError) as exc:
-            await client.set_htr_settings("dev", "A1", stemp="bad")
+            await client.set_node_settings("dev", ("htr", "A1"), stemp="bad")
 
         assert "Invalid stemp value" in str(exc.value)
 
     asyncio.run(_run())
 
 
-def test_ducaheat_set_htr_settings_invalid_units(monkeypatch) -> None:
+def test_ducaheat_set_node_settings_invalid_units(monkeypatch) -> None:
     async def _run() -> None:
         session = FakeSession()
         session.queue_request(
@@ -1783,7 +1793,7 @@ def test_ducaheat_set_htr_settings_invalid_units(monkeypatch) -> None:
         monkeypatch.setattr(client, "_authed_headers", fake_headers)
 
         with pytest.raises(ValueError) as exc:
-            await client.set_htr_settings("dev", "A1", stemp=21.0, units="K")
+            await client.set_node_settings("dev", ("htr", "A1"), stemp=21.0, units="K")
 
         assert "Invalid units" in str(exc.value)
 

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -31,25 +31,31 @@ class DummyHttpClient:
         node_type, addr = node
         return {"dev_id": dev_id, "node_type": node_type, "addr": addr}
 
-    async def set_htr_settings(
+    async def set_node_settings(
         self,
         dev_id: str,
-        addr: str | int,
+        node: tuple[str, str | int],
         *,
         mode: str | None = None,
         stemp: float | None = None,
         prog: list[int] | None = None,
         ptemp: list[float] | None = None,
         units: str = "C",
+        boost_time: int | None = None,
+        cancel_boost: bool = False,
     ) -> dict[str, Any]:
+        node_type, addr = node
         return {
             "dev_id": dev_id,
+            "node_type": node_type,
             "addr": addr,
             "mode": mode,
             "stemp": stemp,
             "prog": prog,
             "ptemp": ptemp,
             "units": units,
+            "boost_time": boost_time,
+            "cancel_boost": cancel_boost,
         }
 
     async def get_node_samples(


### PR DESCRIPTION
## Summary
- send heater climate writes through `set_node_settings` with explicit heater descriptors
- remove the redundant `set_htr_settings` alias from the REST client, protocol, and docs while updating supporting stubs
- refresh API and climate tests to expect node descriptors for heater writes

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check *(fails: pre-existing lint violations outside the change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ea51a4cd9c8329855f1150470d2df7