### PR TITLE
Fix Ducaheat mode writes to use status segment

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -163,15 +163,15 @@ class DucaheatRESTClient(RESTClient):
 
             status_payload: dict[str, Any] = {}
             status_includes_mode = False
+            if mode_value is not None:
+                status_payload["mode"] = mode_value
+                status_includes_mode = True
             if stemp is not None:
                 try:
                     status_payload["stemp"] = self._ensure_temperature(stemp)
                 except ValueError as err:
                     raise ValueError(f"Invalid stemp value: {stemp}") from err
                 status_payload["units"] = self._ensure_units(units)
-                if mode_value is not None:
-                    status_payload["mode"] = mode_value
-                    status_includes_mode = True
             elif units is not None and mode is None and prog is None and ptemp is None:
                 status_payload["units"] = self._ensure_units(units)
 


### PR DESCRIPTION
## Summary
- include mode changes in the Ducaheat `/status` payload so heater writes avoid 404 errors
- add a regression test confirming `/status` is used instead of `/mode` when switching modes

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea53e2953c832983fdb75081af91a7