### PR TITLE
Consolidate device display helper coverage

### DIFF
--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -26,17 +26,6 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 EnergyStateCoordinator = coord_module.EnergyStateCoordinator
 StateCoordinator = coord_module.StateCoordinator
-
-
-def test_device_display_name_helper() -> None:
-    """Helpers should trim names and fall back to device id."""
-
-    assert coord_module._device_display_name({"name": " Device "}, "dev") == "Device"
-    assert coord_module._device_display_name({"name": ""}, "dev") == "Device dev"
-    assert coord_module._device_display_name({}, "dev") == "Device dev"
-    assert coord_module._device_display_name({"name": 1234}, "dev") == "1234"
-
-
 def test_ensure_heater_section_helper() -> None:
     """The helper must reuse existing sections or insert defaults."""
 


### PR DESCRIPTION
## Summary
- remove the duplicate _device_display_name helper test from the energy coordinator suite
- rely on the existing coordinator test module for full helper coverage

## Testing
- pytest tests/test_coordinator.py tests/test_energy_coordinator.py -k device_display_name_helper -vv

------
https://chatgpt.com/codex/tasks/task_e_68ea5d73dcb48329b1e755084bd92a0d