### PR TITLE
Normalize websocket base URL handling

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -2132,9 +2132,16 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
         base = self._api_base().rstrip("/")
         parsed = urlsplit(base if base else API_BASE)
         scheme = parsed.scheme or "https"
-        netloc = parsed.netloc or parsed.path
-        path = parsed.path.rstrip("/")
-        return urlunsplit((scheme, netloc, path or "", "", ""))
+        if parsed.netloc:
+            netloc = parsed.netloc
+            path = parsed.path.rstrip("/")
+        else:
+            path_parts = parsed.path.split("/", 1)
+            netloc = path_parts[0]
+            path = ""
+            if len(path_parts) > 1 and path_parts[1]:
+                path = "/" + path_parts[1].rstrip("/")
+        return urlunsplit((scheme, netloc, path, "", ""))
 
 
 __all__ = [

--- a/tests/test_termoweb_ws_socket_base.py
+++ b/tests/test_termoweb_ws_socket_base.py
@@ -1,0 +1,36 @@
+"""Tests for TermoWeb websocket base URL calculation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.termoweb.backend import termoweb_ws
+from custom_components.termoweb.backend.termoweb_ws import TermoWebWSClient
+from custom_components.termoweb.const import API_BASE
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected"),
+    [
+        ("https://example.com/api", "https://example.com/api"),
+        ("https://example.com/api/", "https://example.com/api"),
+        ("example.com", "https://example.com"),
+        ("example.com/api", "https://example.com/api"),
+    ],
+)
+def test_socket_base_normalises_urls(api_base: str, expected: str) -> None:
+    """Ensure the websocket base is normalised for different input forms."""
+
+    client = TermoWebWSClient.__new__(TermoWebWSClient)
+    client._client = SimpleNamespace(api_base=api_base)  # type: ignore[attr-defined]
+
+    assert client._socket_base() == expected
+
+
+def test_socket_base_uses_default_api_base_when_blank() -> None:
+    """Ensure a blank client api_base falls back to the integration default."""
+
+    client = TermoWebWSClient.__new__(TermoWebWSClient)
+    client._client = SimpleNamespace(api_base="")  # type: ignore[attr-defined]
+
+    assert client._socket_base() == termoweb_ws.API_BASE == API_BASE


### PR DESCRIPTION
## Summary
- fix TermoWeb websocket base URL parsing so host-only api_base values resolve correctly
- add unit tests covering websocket base normalisation and default API base fallback

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5d547964832987b30294caa77216