### PR TITLE
Add tests for Ducaheat boost metadata merge behaviour

### DIFF
--- a/tests/test_ducaheat_boost_metadata_merge.py
+++ b/tests/test_ducaheat_boost_metadata_merge.py
@@ -1,0 +1,52 @@
+"""Tests for merging boost metadata payloads."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.termoweb.backend.ducaheat import DucaheatRESTClient
+
+
+def test_merge_boost_metadata_prefers_existing_when_requested() -> None:
+    """Prefer existing boost metadata entries when flagged."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    target: dict[str, object] = {
+        "boost": True,
+        "boost_end_day": 1,
+        "boost_end_min": None,
+    }
+    source = {
+        "boost": False,
+        "boost_end_day": 4,
+        "boost_end_min": 240,
+        "boost_end": {"day": 4, "minute": 240},
+    }
+
+    client._merge_boost_metadata(target, source, prefer_existing=True)
+
+    assert target == {
+        "boost": True,
+        "boost_end_day": 1,
+        "boost_end_min": 240,
+        "boost_end": {"day": 4, "minute": 240},
+    }
+
+
+def test_merge_boost_metadata_nested_mapping_respects_prefer_flags() -> None:
+    """Derived boost end values should obey the explicit prefer flag."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    target: dict[str, object] = {
+        "boost_end_day": 3,
+        "boost_end_min": None,
+    }
+    nested = {"day": 5, "minute": 150}
+
+    client._merge_boost_metadata(target, {"boost_end": nested})
+
+    assert target["boost_end"] == nested
+    assert target["boost_end_day"] == 3
+    assert target["boost_end_min"] == 150


### PR DESCRIPTION
## Summary
- add coverage for boost metadata merging when existing values should be preserved
- ensure nested boost_end mappings respect prefer overrides for derived day/minute fields

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5d4b94148329ad61d3a1ffc5cca1