### PR TITLE
Refactor boost duration validation to share constants

### DIFF
--- a/custom_components/termoweb/backend/sanitize.py
+++ b/custom_components/termoweb/backend/sanitize.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from custom_components.termoweb.boost import ALLOWED_BOOST_MINUTES
+
+_ALLOWED_BOOST_MINUTES_SET = frozenset(ALLOWED_BOOST_MINUTES)
+_ALLOWED_BOOST_MINUTES_MESSAGE = ", ".join(
+    str(option) for option in ALLOWED_BOOST_MINUTES
+)
+
 _BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9\-._~+/]+=*", re.IGNORECASE)
 _TOKEN_QUERY_RE = re.compile(r"(?i)(token|refresh_token|access_token)=([^&\s]+)")
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
@@ -64,10 +71,8 @@ def validate_boost_minutes(value: int | None) -> int | None:
         minutes = int(value)
     except (TypeError, ValueError) as err:  # pragma: no cover - defensive
         raise ValueError(f"Invalid boost_time value: {value!r}") from err
-    if minutes < 60 or minutes > 600 or minutes % 60 != 0:
-        raise ValueError(
-            "boost_time must be between 60 and 600 minutes in 60-minute increments"
-        )
+    if minutes not in _ALLOWED_BOOST_MINUTES_SET:
+        raise ValueError(f"boost_time must be one of: {_ALLOWED_BOOST_MINUTES_MESSAGE}")
     return minutes
 
 

--- a/custom_components/termoweb/boost.py
+++ b/custom_components/termoweb/boost.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import math
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 import logging
-from typing import Any, Callable, Iterable, Iterator, Mapping
+import math
+from typing import Any, Final
 
 from homeassistant.util import dt as dt_util
 
@@ -17,7 +18,6 @@ from .inventory import (
     normalize_node_addr,
     normalize_node_type,
 )
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -294,4 +294,7 @@ def iter_inventory_heater_metadata(
                 node=node,
                 supports_boost=supports_boost(node),
             )
+
+ALLOWED_BOOST_MINUTES: Final[tuple[int, ...]] = tuple(range(60, 601, 60))
+"""Valid boost durations (in minutes) supported by TermoWeb heaters."""
 

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .boost import (
+    ALLOWED_BOOST_MINUTES,
     coerce_boost_bool,
     coerce_boost_minutes,
     coerce_boost_remaining_minutes,
@@ -80,9 +81,9 @@ def _build_boost_button_metadata() -> tuple[BoostButtonMetadata, ...]:
     """Return the configured metadata describing boost helper buttons."""
 
     entries: list[BoostButtonMetadata] = []
-    for hours in range(1, 11):
-        minutes = hours * 60
-        icon_suffix = _BOOST_HOUR_ICON_SUFFIXES.get(hours)
+    for minutes in ALLOWED_BOOST_MINUTES:
+        hours, remainder = divmod(minutes, 60)
+        icon_suffix = _BOOST_HOUR_ICON_SUFFIXES.get(hours) if remainder == 0 else None
         icon = (
             f"mdi:clock-time-{icon_suffix}-outline"
             if icon_suffix is not None
@@ -101,9 +102,7 @@ def _build_boost_button_metadata() -> tuple[BoostButtonMetadata, ...]:
 
 
 BOOST_BUTTON_METADATA: Final[tuple[BoostButtonMetadata, ...]] = _build_boost_button_metadata()
-BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = tuple(
-    option.minutes for option in BOOST_BUTTON_METADATA if option.minutes is not None
-)
+BOOST_DURATION_OPTIONS: Final[tuple[int, ...]] = ALLOWED_BOOST_MINUTES
 
 
 


### PR DESCRIPTION
## Summary
- add an `ALLOWED_BOOST_MINUTES` constant in the boost helpers to centralise valid durations
- reuse the shared boost durations when building heater button metadata and exposed options
- validate backend boost duration payloads against the shared set of allowed values

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5d6e90648329b1abbd700ef16234