### PR TITLE
Unify HandshakeError handling across websocket clients

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -184,10 +184,18 @@ class WSStats:
 class HandshakeError(RuntimeError):
     """Raised when a websocket handshake fails."""
 
-    def __init__(self, status: int, url: str, detail: str) -> None:
+    def __init__(
+        self,
+        status: int,
+        url: str,
+        detail: str,
+        response_snippet: str | None = None,
+    ) -> None:
         super().__init__(f"handshake failed: status={status}, detail={detail}")
         self.status = status
         self.url = url
+        self.detail = detail
+        self.response_snippet = response_snippet if response_snippet is not None else detail
 
 
 class _WsLeaseMixin:

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -152,11 +152,17 @@ def _make_client(
 def test_handshake_error_exposes_fields() -> None:
     """The TermoWeb handshake error should record status, URL and body."""
 
-    error = module.HandshakeError(503, "https://example/ws", "body")
-    assert str(error) == "handshake failed (status=503)"
+    error = module.HandshakeError(
+        503,
+        "https://example/ws",
+        "body",
+        response_snippet="body",
+    )
+    assert str(error) == "handshake failed: status=503, detail=body"
     assert error.status == 503
     assert error.url == "https://example/ws"
-    assert error.body_snippet == "body"
+    assert error.detail == "body"
+    assert error.response_snippet == "body"
 
 
 def test_init_handles_socketio_http_attribute(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -456,10 +456,17 @@ def test_collect_update_addresses_extracts() -> None:
 def test_handshake_error_exposes_status_and_url() -> None:
     """Ensure ``HandshakeError`` forwards the status and URL details."""
 
-    error = base_ws.HandshakeError(470, "https://example/ws", "nope")
-    assert "handshake failed" in str(error)
+    error = base_ws.HandshakeError(
+        470,
+        "https://example/ws",
+        "nope",
+        response_snippet="snippet",
+    )
+    assert str(error) == "handshake failed: status=470, detail=nope"
     assert error.status == 470
     assert error.url == "https://example/ws"
+    assert error.detail == "nope"
+    assert error.response_snippet == "snippet"
 
 
 def test_dispatch_nodes_without_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- extend the shared `HandshakeError` to persist both the detail text and an optional response snippet
- reuse the shared exception in the TermoWeb websocket client and forward the response metadata during handshake failures
- update websocket protocol tests to assert the unified exception attributes

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5d628a84832988f44984501e60b5