### PR TITLE
Ensure Ducaheat segmented planner releases nodes on validation errors

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -161,20 +161,6 @@ class DucaheatRESTClient(RESTClient):
                 if mode_value == "heat":
                     mode_value = "manual"
 
-            status_payload: dict[str, Any] = {}
-            status_includes_mode = False
-            if mode_value is not None:
-                status_payload["mode"] = mode_value
-                status_includes_mode = True
-            if stemp is not None:
-                try:
-                    status_payload["stemp"] = self._ensure_temperature(stemp)
-                except ValueError as err:
-                    raise ValueError(f"Invalid stemp value: {stemp}") from err
-                status_payload["units"] = self._ensure_units(units)
-            elif units is not None and mode is None and prog is None and ptemp is None:
-                status_payload["units"] = self._ensure_units(units)
-
             selection_claimed = False
             try:
                 await self._select_segmented_node(
@@ -185,6 +171,25 @@ class DucaheatRESTClient(RESTClient):
                     select=True,
                 )
                 selection_claimed = True
+
+                status_payload: dict[str, Any] = {}
+                status_includes_mode = False
+                if mode_value is not None:
+                    status_payload["mode"] = mode_value
+                    status_includes_mode = True
+                if stemp is not None:
+                    try:
+                        status_payload["stemp"] = self._ensure_temperature(stemp)
+                    except ValueError as err:
+                        raise ValueError(f"Invalid stemp value: {stemp}") from err
+                    status_payload["units"] = self._ensure_units(units)
+                elif (
+                    units is not None
+                    and mode is None
+                    and prog is None
+                    and ptemp is None
+                ):
+                    status_payload["units"] = self._ensure_units(units)
 
                 segment_plan: list[tuple[str, dict[str, Any]]] = []
                 if status_payload:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1774,10 +1774,20 @@ def test_ducaheat_set_node_settings_invalid_stemp(monkeypatch) -> None:
 
         monkeypatch.setattr(client, "authed_headers", fake_headers)
 
+        selection_calls: list[bool] = []
+
+        async def fake_select_segmented_node(**kwargs: Any) -> None:
+            selection_calls.append(kwargs["select"])
+
+        monkeypatch.setattr(
+            client, "_select_segmented_node", fake_select_segmented_node
+        )
+
         with pytest.raises(ValueError) as exc:
             await client.set_node_settings("dev", ("htr", "A1"), stemp="bad")
 
         assert "Invalid stemp value" in str(exc.value)
+        assert selection_calls == [True, False]
 
     asyncio.run(_run())
 
@@ -1801,10 +1811,20 @@ def test_ducaheat_set_node_settings_invalid_units(monkeypatch) -> None:
 
         monkeypatch.setattr(client, "authed_headers", fake_headers)
 
+        selection_calls: list[bool] = []
+
+        async def fake_select_segmented_node(**kwargs: Any) -> None:
+            selection_calls.append(kwargs["select"])
+
+        monkeypatch.setattr(
+            client, "_select_segmented_node", fake_select_segmented_node
+        )
+
         with pytest.raises(ValueError) as exc:
             await client.set_node_settings("dev", ("htr", "A1"), stemp=21.0, units="K")
 
         assert "Invalid units" in str(exc.value)
+        assert selection_calls == [True, False]
 
     asyncio.run(_run())
 

--- a/tests/test_ducaheat_set.py
+++ b/tests/test_ducaheat_set.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Mapping
 
 import pytest
 
@@ -44,3 +44,112 @@ def test_ducaheat_post_segmented_ignore_statuses(
         assert captured["ignore_statuses"] == (404,)
 
     asyncio.run(_run())
+
+
+@pytest.mark.asyncio
+async def test_set_node_settings_units_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Send only units and verify a single status segment is planned."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    async def fake_headers() -> dict[str, str]:
+        """Return static headers for the request."""
+
+        return {"Authorization": "Bearer token"}
+
+    def fake_ensure_units(units: str) -> str:
+        """Return a predictable units marker."""
+
+        return f"unit:{units}"
+
+    selection_calls: list[bool] = []
+
+    async def fake_select_segmented_node(**kwargs: Any) -> None:
+        """Record selection claims/releases."""
+
+        selection_calls.append(kwargs["select"])
+
+    post_calls: list[dict[str, Any]] = []
+
+    async def fake_post_segmented(
+        path: str,
+        *,
+        headers: Mapping[str, str],
+        payload: Mapping[str, Any],
+        dev_id: str,
+        addr: str,
+        node_type: str,
+    ) -> dict[str, str]:
+        """Capture the payload sent to _post_segmented."""
+
+        post_calls.append(
+            {
+                "path": path,
+                "headers": dict(headers),
+                "payload": dict(payload),
+                "dev_id": dev_id,
+                "addr": addr,
+                "node_type": node_type,
+            }
+        )
+        return {"ok": "yes"}
+
+    monkeypatch.setattr(client, "authed_headers", fake_headers)
+    monkeypatch.setattr(client, "_ensure_units", fake_ensure_units)
+    monkeypatch.setattr(client, "_select_segmented_node", fake_select_segmented_node)
+    monkeypatch.setattr(client, "_post_segmented", fake_post_segmented)
+
+    responses = await client.set_node_settings("dev", ("htr", 1), units="F")
+
+    assert responses == {"status": {"ok": "yes"}}
+    assert post_calls == [
+        {
+            "path": "/api/v2/devs/dev/htr/1/status",
+            "headers": {"Authorization": "Bearer token"},
+            "payload": {"units": "unit:F"},
+            "dev_id": "dev",
+            "addr": "1",
+            "node_type": "htr",
+        }
+    ]
+    assert selection_calls == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_set_node_settings_invalid_stemp_releases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure invalid stemp errors after claiming and releasing the node."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    async def fake_headers() -> dict[str, str]:
+        """Return static headers for the request."""
+
+        return {"Authorization": "Bearer token"}
+
+    def fake_ensure_units(units: str) -> str:
+        """Return a predictable units marker."""
+
+        return f"unit:{units}"
+
+    selection_calls: list[bool] = []
+
+    async def fake_select_segmented_node(**kwargs: Any) -> None:
+        """Record selection claims/releases."""
+
+        selection_calls.append(kwargs["select"])
+
+    async def fake_post_segmented(**kwargs: Any) -> None:
+        """_post_segmented should not be reached for invalid stemp."""
+
+        raise AssertionError("_post_segmented must not be invoked")
+
+    monkeypatch.setattr(client, "authed_headers", fake_headers)
+    monkeypatch.setattr(client, "_ensure_units", fake_ensure_units)
+    monkeypatch.setattr(client, "_select_segmented_node", fake_select_segmented_node)
+    monkeypatch.setattr(client, "_post_segmented", fake_post_segmented)
+
+    with pytest.raises(ValueError) as err:
+        await client.set_node_settings("dev", ("htr", 1), stemp="bad", units="C")
+
+    assert "Invalid stemp value: bad" in str(err.value)
+    assert selection_calls == [True, False]


### PR DESCRIPTION
## Summary
- claim segmented heater nodes before building status payloads so selection release always runs, even when validation fails
- add asynchronous tests that assert the planner only posts a status segment for units-only writes and releases the node after invalid stemp input
- update existing API tests to stub the selection helper and assert the claim/release behaviour

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5d43d5b883299d62efffcd0aa6dc