### PR TITLE
Add defensive checks for Ducaheat legacy settings updates

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -740,6 +740,46 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 return snapshot
         return snapshot
 
+    def _update_legacy_section(
+        self,
+        *,
+        node_type: str,
+        addr: str,
+        section: str,
+        body: Any,
+        dev_map: MutableMapping[str, Any],
+    ) -> bool:
+        """Store legacy section updates with defensive type checks."""
+
+        if not isinstance(dev_map, MutableMapping):
+            return False
+
+        if section == "settings":
+            canonical_type = (
+                normalize_node_type(node_type, use_default_when_falsey=True)
+                or node_type
+            )
+            section_root = dev_map.get("settings")
+            if section_root is not None and not isinstance(section_root, MutableMapping):
+                return False
+            if canonical_type and isinstance(section_root, MutableMapping):
+                existing_section = section_root.get(canonical_type)
+                if existing_section is not None and not isinstance(
+                    existing_section, MutableMapping
+                ):
+                    return False
+
+        from .termoweb_ws import TermoWebWSClient
+
+        return TermoWebWSClient._update_legacy_section(
+            self,
+            node_type=node_type,
+            addr=addr,
+            section=section,
+            body=body,
+            dev_map=dev_map,
+        )
+
     @staticmethod
     def _build_nodes_snapshot(nodes: dict[str, Any]) -> dict[str, Any]:
         """Return a snapshot structure with ``nodes`` and ``nodes_by_type`` buckets."""

--- a/tests/test_ducaheat_ws_legacy_section.py
+++ b/tests/test_ducaheat_ws_legacy_section.py
@@ -1,0 +1,113 @@
+"""Tests for Ducaheat legacy section updates."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.termoweb.backend import ducaheat_ws
+
+
+class DummyREST:
+    """Provide the minimal REST interface required by the websocket client."""
+
+    def __init__(self) -> None:
+        self._session = SimpleNamespace()
+        self._headers = {"Authorization": "Bearer rest-token"}
+
+    async def authed_headers(self) -> dict[str, str]:
+        """Return cached REST headers with an access token."""
+
+        return self._headers
+
+
+def _make_client(coordinator: Any) -> ducaheat_ws.DucaheatWSClient:
+    """Instantiate a websocket client for legacy section tests."""
+
+    hass = HomeAssistant()
+    session = SimpleNamespace(closed=False)
+    return ducaheat_ws.DucaheatWSClient(
+        hass,
+        entry_id="entry",
+        dev_id="device",
+        api_client=DummyREST(),
+        coordinator=coordinator,
+        session=session,
+    )
+
+
+def test_update_legacy_section_normalises_accumulator_settings() -> None:
+    """Accumulator settings updates should normalise addresses and call helpers."""
+
+    apply_helper = MagicMock()
+    now_helper = MagicMock(return_value=1234.5)
+    coordinator = SimpleNamespace(
+        _apply_accumulator_boost_metadata=apply_helper,
+        _device_now_estimate=now_helper,
+    )
+
+    client = _make_client(coordinator)
+    client._nodes_raw = {}
+
+    body = {"mode": "auto", "boost": {"remaining": 3600}}
+    dev_map: dict[str, Any] = {"settings": {}}
+
+    updated = client._update_legacy_section(
+        node_type="acm",
+        addr=" 02 ",
+        section="settings",
+        body=body,
+        dev_map=dev_map,
+    )
+
+    assert updated is True
+    apply_helper.assert_called_once()
+    helper_args = apply_helper.call_args
+    assert helper_args.args[0] == {"mode": "auto", "boost": {"remaining": 3600}}
+    assert helper_args.kwargs == {"now": 1234.5}
+    now_helper.assert_called_once_with()
+
+    settings_bucket = dev_map["settings"].get("acm")
+    assert isinstance(settings_bucket, dict)
+    stored_payload = settings_bucket.get("02")
+    assert stored_payload == {"mode": "auto", "boost": {"remaining": 3600}}
+    assert stored_payload is not body
+
+    raw_payload = client._nodes_raw.get("acm", {}).get("settings", {}).get(" 02 ")
+    assert raw_payload == body
+    assert raw_payload is not body
+
+
+def test_update_legacy_section_rejects_non_mapping_section_map() -> None:
+    """Non-mapping section buckets should be ignored without side effects."""
+
+    coordinator = SimpleNamespace(
+        _apply_accumulator_boost_metadata=MagicMock(),
+        _device_now_estimate=MagicMock(return_value=0.0),
+    )
+
+    client = _make_client(coordinator)
+    existing_raw = {"acm": {"settings": {" 02 ": {"mode": "manual"}}}}
+    client._nodes_raw = deepcopy(existing_raw)
+
+    dev_map: dict[str, Any] = {"settings": {"acm": ["invalid"]}}
+    dev_map_snapshot = deepcopy(dev_map)
+
+    updated = client._update_legacy_section(
+        node_type="acm",
+        addr=" 02 ",
+        section="settings",
+        body={"mode": "auto"},
+        dev_map=dev_map,
+    )
+
+    assert updated is False
+    assert dev_map == dev_map_snapshot
+    assert client._nodes_raw == existing_raw
+    coordinator._apply_accumulator_boost_metadata.assert_not_called()
+    coordinator._device_now_estimate.assert_not_called()
+


### PR DESCRIPTION
## Summary
- add a Ducaheat-specific `_update_legacy_section` wrapper that defers to the TermoWeb implementation while rejecting non-mapping settings buckets
- add regression tests covering accumulator boost metadata propagation and handling of invalid section maps

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea5d4ef9608329a3aa9024e3fb0527