### PR TITLE
Add Ducaheat websocket address handling tests

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -754,6 +754,99 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         snapshot.update(nodes_by_type)
         return snapshot
 
+    def _ensure_type_bucket(
+        self,
+        nodes_by_type: MutableMapping[str, Any],
+        node_type: str,
+        *,
+        dev_map: MutableMapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return the node bucket for ``node_type`` with default sections."""
+
+        if not isinstance(nodes_by_type, MutableMapping):
+            return {}
+
+        normalized_type = normalize_node_type(node_type)
+        if not normalized_type:
+            return {}
+
+        existing = nodes_by_type.get(normalized_type)
+        if isinstance(existing, MutableMapping):
+            bucket = existing
+        elif isinstance(existing, Mapping):
+            bucket = dict(existing)
+            nodes_by_type[normalized_type] = bucket
+        else:
+            bucket = {}
+            nodes_by_type[normalized_type] = bucket
+
+        addrs = bucket.get("addrs")
+        if isinstance(addrs, Iterable) and not isinstance(addrs, (list, str, bytes)):
+            bucket["addrs"] = list(addrs)
+        elif not isinstance(addrs, list):
+            bucket.setdefault("addrs", [])
+
+        for section in ("settings", "samples", "status", "advanced"):
+            section_payload = bucket.get(section)
+            if isinstance(section_payload, MutableMapping):
+                continue
+            if isinstance(section_payload, Mapping):
+                bucket[section] = dict(section_payload)
+            else:
+                bucket[section] = {}
+
+        if isinstance(dev_map, MutableMapping):
+            addresses_section = dev_map.get("addresses_by_type")
+            if isinstance(addresses_section, MutableMapping):
+                addresses_map = addresses_section
+            elif isinstance(addresses_section, Mapping):
+                addresses_map = dict(addresses_section)
+                dev_map["addresses_by_type"] = addresses_map
+            else:
+                addresses_map = {}
+                dev_map["addresses_by_type"] = addresses_map
+
+            if normalized_type in HEATER_NODE_TYPES:
+                addresses = addresses_map.get(normalized_type)
+                if isinstance(addresses, list):
+                    pass
+                elif isinstance(addresses, Iterable) and not isinstance(
+                    addresses, (str, bytes)
+                ):
+                    addresses_map[normalized_type] = list(addresses)
+                else:
+                    addresses_map[normalized_type] = []
+
+            settings_section = dev_map.get("settings")
+            if isinstance(settings_section, MutableMapping):
+                settings_map = settings_section
+            elif isinstance(settings_section, Mapping):
+                settings_map = dict(settings_section)
+                dev_map["settings"] = settings_map
+            else:
+                settings_map = {}
+                dev_map["settings"] = settings_map
+
+            settings_bucket = settings_map.get(normalized_type)
+            if isinstance(settings_bucket, MutableMapping):
+                pass
+            elif isinstance(settings_bucket, Mapping):
+                settings_map[normalized_type] = dict(settings_bucket)
+            else:
+                settings_map[normalized_type] = {}
+
+            nodes_section = dev_map.get("nodes_by_type")
+            if isinstance(nodes_section, MutableMapping):
+                nodes_section.setdefault(normalized_type, bucket)
+            elif isinstance(nodes_section, Mapping):
+                nodes_map = dict(nodes_section)
+                nodes_map.setdefault(normalized_type, bucket)
+                dev_map["nodes_by_type"] = nodes_map
+            else:
+                dev_map["nodes_by_type"] = {normalized_type: bucket}
+
+        return bucket
+
     def _apply_heater_addresses(
         self,
         normalized_map: Mapping[Any, Iterable[Any]] | None,

--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -1,0 +1,125 @@
+"""Tests for websocket heater address helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Iterable, Mapping, MutableMapping
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient, DOMAIN
+from custom_components.termoweb.inventory import (
+    Inventory,
+    build_node_inventory,
+    normalize_node_addr,
+)
+
+
+class DummyREST:
+    """Provide the minimal REST client contract for the websocket client."""
+
+    def __init__(self) -> None:
+        self._session = SimpleNamespace()
+
+    async def authed_headers(self) -> Mapping[str, str]:
+        """Return headers containing an access token."""
+
+        return {"Authorization": "Bearer token"}
+
+
+class DummyCoordinator:
+    """Expose coordinator storage accessed by the websocket client."""
+
+    def __init__(self) -> None:
+        self.data: MutableMapping[str, Any] = {"device": {}}
+        self.update_nodes = MagicMock()
+
+
+def _make_client() -> DucaheatWSClient:
+    """Instantiate a websocket client with stub dependencies."""
+
+    hass = HomeAssistant()
+    hass.data.setdefault(DOMAIN, {})["entry"] = {}
+    coordinator = DummyCoordinator()
+    client = DucaheatWSClient(
+        hass,
+        entry_id="entry",
+        dev_id="device",
+        api_client=DummyREST(),
+        coordinator=coordinator,
+        session=SimpleNamespace(),  # type: ignore[arg-type]
+    )
+    return client
+
+
+def _expected_addresses(values: Iterable[Any]) -> list[str]:
+    """Return normalised, deduplicated addresses for ``values``."""
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for candidate in values:
+        addr = normalize_node_addr(candidate)
+        if not addr or addr in seen:
+            continue
+        seen.add(addr)
+        result.append(addr)
+    return result
+
+
+def test_ensure_type_bucket_registers_defaults() -> None:
+    """Buckets should expose default sections and update the device map."""
+
+    client = _make_client()
+    nodes_by_type: dict[str, dict[str, Any]] = {}
+    dev_map: dict[str, Any] = {"addresses_by_type": {}, "settings": {}}
+
+    bucket = client._ensure_type_bucket(nodes_by_type, "htr", dev_map=dev_map)
+
+    assert nodes_by_type["htr"] is bucket
+    for section in ("settings", "samples", "status", "advanced"):
+        assert isinstance(bucket[section], dict)
+    assert bucket["addrs"] == []
+
+    assert dev_map["nodes_by_type"]["htr"] is bucket
+    assert dev_map["addresses_by_type"]["htr"] == []
+    assert dev_map["settings"]["htr"] == {}
+
+
+def test_apply_heater_addresses_updates_state() -> None:
+    """Heater address normalisation should update entry and coordinator state."""
+
+    client = _make_client()
+    hass = client.hass
+    energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
+    hass.data[DOMAIN]["entry"]["energy_coordinator"] = energy_coordinator
+
+    raw_nodes = {
+        "nodes": [
+            {"type": "htr", "addr": "1"},
+            {"type": "acm", "addr": "2"},
+            {"type": "pmo", "addr": "A1"},
+        ]
+    }
+    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+
+    normalized_map: Mapping[Any, Iterable[Any]] = {
+        "htr": [" 1 ", "01"],
+        "heater": ["003"],
+        "acm": ("2", "02", "2"),
+        "pmo": ["A1", "a1", "B2"],
+        "thm": ["9"],
+    }
+
+    cleaned = client._apply_heater_addresses(normalized_map, inventory=inventory)
+
+    assert cleaned["htr"] == _expected_addresses([" 1 ", "01"])
+    assert normalize_node_addr("003") not in cleaned["htr"]
+    assert cleaned["acm"] == _expected_addresses(["2", "02"])
+    assert cleaned["pmo"] == inventory.power_monitor_address_map[0]["pmo"]
+    assert "thm" not in cleaned
+
+    assert hass.data[DOMAIN]["entry"]["inventory"] is inventory
+    assert client._inventory is inventory
+    energy_coordinator.update_addresses.assert_called_once_with(cleaned)
+


### PR DESCRIPTION
## Summary
- add `_ensure_type_bucket` helper to normalise Ducaheat node buckets and backfill coordinator state
- cover heater and power monitor address handling with dedicated websocket client tests

## Testing
- pytest tests/test_ducaheat_ws_addresses.py

------
https://chatgpt.com/codex/tasks/task_e_68ea5d4d79d48329bbf3d0c4265d3b5a