### PR TITLE
Refactor websocket path translation helper

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, Callable
 from dataclasses import dataclass
 import logging
 import time
@@ -166,6 +166,68 @@ def forward_ws_sample_updates(
             log_prefix,
             exc_info=True,
         )
+
+
+def translate_path_update(
+    payload: Any,
+    *,
+    resolve_section: Callable[[str | None], tuple[str | None, str | None]],
+) -> dict[str, Any] | None:
+    """Translate ``{"path": ..., "body": ...}`` websocket frames into nodes."""
+
+    if not isinstance(payload, Mapping):
+        return None
+    if "nodes" in payload:
+        return None
+    path = payload.get("path")
+    body = payload.get("body")
+    if not isinstance(path, str) or body is None:
+        return None
+
+    path = path.split("?", 1)[0]
+    segments = [segment for segment in path.split("/") if segment]
+    if not segments:
+        return None
+
+    try:
+        devs_idx = segments.index("devs")
+    except ValueError:
+        devs_idx = -1
+
+    if devs_idx >= 0:
+        relevant = segments[devs_idx + 1 :]
+        node_type_idx = 1
+        addr_idx = 2
+        section_idx = 3
+        if len(relevant) <= addr_idx:
+            return None
+    else:
+        relevant = segments
+        node_type_idx = 0
+        addr_idx = 1
+        section_idx = 2
+        if len(relevant) <= addr_idx:
+            return None
+
+    node_type = normalize_node_type(relevant[node_type_idx])
+    addr = normalize_node_addr(relevant[addr_idx])
+    if not node_type or not addr:
+        return None
+
+    section = relevant[section_idx] if len(relevant) > section_idx else None
+    remainder = relevant[section_idx + 1 :] if len(relevant) > section_idx + 1 else []
+
+    target_section, nested_key = resolve_section(section)
+    if target_section is None:
+        return None
+
+    payload_body: Any = body
+    for segment in reversed(remainder):
+        payload_body = {segment: payload_body}
+    if nested_key:
+        payload_body = {nested_key: payload_body}
+
+    return {node_type: {target_section: {addr: payload_body}}}
 
 
 DUCAHEAT_NAMESPACE = "/api/v2/socket_io"
@@ -652,6 +714,7 @@ __all__ = [
     "WSStats",
     "WebSocketClient",
     "forward_ws_sample_updates",
+    "translate_path_update",
     "resolve_ws_update_section",
     "WsHealthTracker",
 ]


### PR DESCRIPTION
## Summary
- add a shared `translate_path_update` helper in `ws_client` and expose it for reuse
- update the TermoWeb and Ducaheat websocket clients to call the helper
- adjust websocket protocol tests to exercise the shared helper rather than the private methods directly

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check custom_components/termoweb/backend/ws_client.py custom_components/termoweb/backend/ducaheat_ws.py custom_components/termoweb/backend/termoweb_ws.py tests/test_ducaheat_ws_protocol.py tests/test_termoweb_ws_protocol.py`


------
https://chatgpt.com/codex/tasks/task_e_68ea6309bb0483298b6f969d85103259