### PR TITLE
Add test for StateCoordinator inventory address cloning

### DIFF
--- a/tests/test_coordinator_inventory_addresses.py
+++ b/tests/test_coordinator_inventory_addresses.py
@@ -1,0 +1,50 @@
+"""Tests for coordinator inventory address cloning."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.termoweb.coordinator import StateCoordinator
+from custom_components.termoweb.inventory import Inventory, build_node_inventory
+
+
+def test_inventory_addresses_by_type_returns_copy() -> None:
+    """StateCoordinator should clone inventory address mappings."""
+
+    raw_nodes = {
+        "nodes": [
+            {"type": "htr", "addr": "1"},
+            {"type": "acm", "addr": "2"},
+            {"type": "pmo", "addr": "9"},
+            {"type": "thm", "addr": "5"},
+        ]
+    }
+    inventory_nodes = build_node_inventory(raw_nodes)
+    inventory = Inventory("device", raw_nodes, inventory_nodes)
+
+    hass = HomeAssistant()
+    coordinator = StateCoordinator(
+        hass,
+        client=AsyncMock(),
+        base_interval=30,
+        dev_id="device",
+        device={},
+        nodes=raw_nodes,
+        inventory=inventory,
+    )
+
+    expected = inventory.addresses_by_type
+    result = coordinator._inventory_addresses_by_type()
+
+    assert result == expected
+    assert result is not expected
+
+    for node_type, addrs in expected.items():
+        assert result[node_type] == addrs
+        assert result[node_type] is not addrs
+
+    result["htr"].append("extra")
+    fresh_expected = inventory.addresses_by_type
+    assert "extra" not in fresh_expected["htr"]


### PR DESCRIPTION
## Summary
- add coverage to ensure `StateCoordinator._inventory_addresses_by_type()` clones inventory address lists

## Testing
- pytest tests/test_coordinator_inventory_addresses.py

------
https://chatgpt.com/codex/tasks/task_e_68ea6a5878288329a21b7aa004cde0cc