### PR TITLE
Normalise coordinator settings map data

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 import logging
@@ -323,15 +324,18 @@ class StateCoordinator(
 
         normalised: dict[str, dict[str, Any]] = {}
         for node_type, bucket in settings_by_type.items():
-            if not isinstance(bucket, Mapping):
+            normalized_type = normalize_node_type(
+                node_type, use_default_when_falsey=True
+            )
+            if not normalized_type or not isinstance(bucket, Mapping):
                 continue
             dest: dict[str, Any] = {}
             for raw_addr, payload in bucket.items():
                 addr = normalize_node_addr(raw_addr, use_default_when_falsey=True)
                 if not addr:
                     continue
-                dest[addr] = payload
-            normalised[node_type] = dest
+                dest[addr] = deepcopy(payload)
+            normalised[normalized_type] = dest
         return normalised
 
     def _assemble_device_record(

--- a/tests/test_coordinator_normalise_settings_map.py
+++ b/tests/test_coordinator_normalise_settings_map.py
@@ -1,0 +1,39 @@
+"""Tests for ``StateCoordinator._normalise_settings_map``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.termoweb.coordinator import StateCoordinator
+
+
+def test_normalise_settings_map_normalises_and_copies() -> None:
+    """Test normalisation of node types, addresses, and payload copies."""
+
+    original_settings: dict[str, dict[Any, Any]] = {
+        " HTR ": {
+            " 01 ": {"foo": ["bar"]},
+            2: {"nested": {"value": 1}},
+        },
+        " ThM ": {
+            " 7 ": {"inner": {"value": 5}},
+        },
+    }
+
+    normalised = StateCoordinator._normalise_settings_map(original_settings)
+
+    assert normalised == {
+        "htr": {
+            "01": {"foo": ["bar"]},
+            "2": {"nested": {"value": 1}},
+        },
+        "thm": {
+            "7": {"inner": {"value": 5}},
+        },
+    }
+
+    normalised["htr"]["01"]["foo"].append("baz")
+    normalised["thm"]["7"]["inner"]["value"] = 9
+
+    assert original_settings[" HTR "][" 01 "] == {"foo": ["bar"]}
+    assert original_settings[" ThM "][" 7 "] == {"inner": {"value": 5}}


### PR DESCRIPTION
## Summary
- normalise coordinator settings map node types, addresses, and payload copies
- add coverage for settings map normalisation with mixed input keys

## Testing
- pytest tests/test_coordinator_normalise_settings_map.py

------
https://chatgpt.com/codex/tasks/task_e_68ea6a5e7f788329b6227e50ac0b3fc6