### PR TITLE
Add test for coordinator inventory cloning independence

### DIFF
--- a/tests/test_coordinator_clone_inventory.py
+++ b/tests/test_coordinator_clone_inventory.py
@@ -1,0 +1,31 @@
+"""Tests for ``StateCoordinator._clone_inventory``."""
+
+from __future__ import annotations
+
+from custom_components.termoweb.coordinator import StateCoordinator
+from custom_components.termoweb.inventory import Inventory, Node
+
+
+def test_clone_inventory_creates_independent_instance() -> None:
+    """Ensure cloning returns a matching but independent inventory."""
+
+    payload = {"nodes": [{"addr": "1"}, {"addr": "2"}]}
+    nodes = [
+        Node(name="Heater", addr="1", node_type="htr"),
+        Node(name="Thermostat", addr="2", node_type="thm"),
+    ]
+    source = Inventory("dev-123", payload, nodes)
+
+    clone = StateCoordinator._clone_inventory(source)
+
+    assert clone is not source
+    assert isinstance(clone, Inventory)
+    assert clone.dev_id == source.dev_id
+    assert clone.payload == source.payload
+    assert clone.nodes == source.nodes
+
+    clone._heater_name_map_cache[1] = {"sentinel": "clone"}
+    clone._heater_name_map_factories[1] = lambda addr: f"Clone {addr}"
+
+    assert source._heater_name_map_cache == {}
+    assert source._heater_name_map_factories == {}


### PR DESCRIPTION
## Summary
- add a regression test for `StateCoordinator._clone_inventory` to ensure cloned inventories match source values while remaining independent

## Testing
- pytest tests/test_coordinator_clone_inventory.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ea6a5af15483299db3f6752441bee0