### PR TITLE
Add unit test for collecting previous settings in coordinator

### DIFF
--- a/tests/test_coordinator_collect_previous_settings.py
+++ b/tests/test_coordinator_collect_previous_settings.py
@@ -1,0 +1,52 @@
+"""Tests for StateCoordinator._collect_previous_settings."""
+
+from custom_components.termoweb.coordinator import StateCoordinator
+
+
+def test_collect_previous_settings_normalises_and_ingests_sections() -> None:
+    """Ensure previous settings are normalised and extended from extra sections."""
+
+    prev_dev = {
+        "dev_id": "dev-1",
+        "name": "Boiler room",
+        "raw": {"ignored": True},
+        "connected": True,
+        "settings": {
+            "htr": {
+                "01": {"target": 21},
+                2: {"target": 19},
+                "": {"target": 15},
+                None: {"target": 12},
+            },
+            "thm": ["not", "a", "mapping"],
+        },
+        "status": {
+            "addrs": [" 05 ", "05"],
+            "settings": {" 05 ": {"online": True}},
+        },
+        "prog": {
+            "settings": {6: {"schedule": "weekday"}},
+        },
+        "inventory": {"ignored": True},
+        "nodes": {},
+    }
+    addr_map = {
+        "htr": ["01", "02", "03"],
+        "status": ["05"],
+        "prog": ["06"],
+    }
+
+    result = StateCoordinator._collect_previous_settings(prev_dev, addr_map)
+
+    assert result == {
+        "htr": {
+            "01": {"target": 21},
+            "2": {"target": 19},
+        },
+        "status": {
+            "05": {"online": True},
+        },
+        "prog": {
+            "6": {"schedule": "weekday"},
+        },
+    }


### PR DESCRIPTION
## Summary
- add coverage for StateCoordinator._collect_previous_settings to confirm address normalisation and section ingestion

## Testing
- pytest tests/test_coordinator_collect_previous_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68ea6a5a420083299b73df5ce67c0883