### PR TITLE
Remove unused stretched poll import from init

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -49,7 +49,6 @@ from .const import (
     DEFAULT_POLL_INTERVAL,
     DOMAIN,
     MIN_POLL_INTERVAL,
-    STRETCHED_POLL_INTERVAL,
     get_brand_api_base,
     get_brand_basic_auth,
     signal_ws_status,


### PR DESCRIPTION
## Summary
- drop the unused `STRETCHED_POLL_INTERVAL` constant from the TermoWeb init import list

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb5028da3483298436482b89694cd8