### PR TITLE
Remove unused HeaterPlatformDetails inline import

### DIFF
--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -866,7 +866,6 @@ def boostable_accumulator_details_for_entry(
     """Return boostable accumulator metadata for a config entry."""
 
     from .heater import (
-        HeaterPlatformDetails,
         heater_platform_details_for_entry,
         iter_boostable_heater_nodes,
         log_skipped_nodes,


### PR DESCRIPTION
## Summary
- drop the HeaterPlatformDetails inline import from boostable_accumulator_details_for_entry while keeping the return annotation relying on the TYPE_CHECKING import

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb506cba388329ad67215e9588f452