### PR TITLE
Remove unused Entity import from termoweb entity mixin

### DIFF
--- a/custom_components/termoweb/entity.py
+++ b/custom_components/termoweb/entity.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
-
-if TYPE_CHECKING:
-    from homeassistant.helpers.entity import Entity
+from typing import Any, Protocol
 
 from .heater import DispatcherSubscriptionHelper
 


### PR DESCRIPTION
## Summary
- remove the TYPE_CHECKING-only Entity import from the gateway dispatcher mixin module

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb505b00988329937fedda9026807b