### PR TITLE
Stop re-exporting throttle helpers from energy module

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -58,6 +58,8 @@ from .coordinator import StateCoordinator
 from .energy import (
     async_import_energy_history as _async_import_energy_history_impl,
     async_register_import_energy_history_service,
+)
+from .throttle import (
     default_samples_rate_limit_state,
     reset_samples_rate_limit_state,
 )

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -21,11 +21,7 @@ from .inventory import (
     parse_heater_energy_unique_id,
     resolve_record_inventory,
 )
-from .throttle import (
-    MonotonicRateLimiter,
-    default_samples_rate_limit_state,
-    reset_samples_rate_limit_state,
-)
+from .throttle import MonotonicRateLimiter
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -22,6 +22,7 @@ from custom_components.termoweb import (
     identifiers as identifiers_module,
     inventory as inventory_module,
 )
+from custom_components.termoweb import throttle as throttle_module
 from custom_components.termoweb.energy import _normalize_heater_sources
 from custom_components.termoweb.inventory import HEATER_NODE_TYPES
 
@@ -519,8 +520,7 @@ async def _load_module(
     reset_cache = getattr(energy_module, "_reset_integration_dependencies_cache", None)
     if reset_cache is not None:
         reset_cache()
-    if hasattr(energy_module, "reset_samples_rate_limit_state"):
-        energy_module.reset_samples_rate_limit_state()
+    throttle_module.reset_samples_rate_limit_state()
 
     if load_coordinator:
         importlib.reload(
@@ -1243,7 +1243,7 @@ def test_import_energy_history_requested_map_filters(
         async def _fake_sleep(_delay: float) -> None:
             return None
 
-        energy_mod.reset_samples_rate_limit_state(
+        throttle_module.reset_samples_rate_limit_state(
             time_module=types.SimpleNamespace(
                 monotonic=lambda: next(monotonic_counter),
                 time=lambda: fake_now,
@@ -1264,7 +1264,9 @@ def test_import_energy_history_requested_map_filters(
             },
         )
 
-        energy_mod.reset_samples_rate_limit_state(time_module=time, sleep=asyncio.sleep)
+        throttle_module.reset_samples_rate_limit_state(
+            time_module=time, sleep=asyncio.sleep
+        )
 
         assert client.get_node_samples.await_count >= 2
         progress = entry.options[energy_mod.OPTION_ENERGY_HISTORY_PROGRESS]


### PR DESCRIPTION
## Summary
- stop importing `default_samples_rate_limit_state` and `reset_samples_rate_limit_state` from the energy helper
- update the integration entry point and tests to pull throttle helpers from `custom_components.termoweb.throttle`

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb504ed3388329930b7b6584f96272