### PR TITLE
Clean up ducaheat websocket handshake and subscription logic

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -337,7 +337,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                 headers={**headers, "Content-Type": "text/plain;charset=UTF-8"},
                 data=payload,
             ) as resp:
-                drain = await resp.read()
+                await resp.read()
                 #                _LOGGER.debug(
                 #                    "WS (ducaheat): POST 40/ns -> status=%s len=%s",
                 #                    resp.status,
@@ -1151,12 +1151,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             coordinator_nodes: Iterable[Any] | None = None
             if isinstance(coordinator_inventory, Inventory):
                 coordinator_nodes = coordinator_inventory.nodes
-
-            nodes_payload: Any | None
-            if isinstance(resolved_nodes, Mapping):
-                nodes_payload = resolved_nodes
-            else:
-                nodes_payload = None
 
             should_resolve = inventory_container is None and (
                 isinstance(nodes, Mapping)


### PR DESCRIPTION
## Summary
- remove the unused polling POST drain variable in the Ducaheat websocket handshake
- drop the dead `nodes_payload` branch from `_subscribe_feeds`

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb5032b94c8329bc749cff29867bcc