### PR TITLE
Avoid duplicating node address maps

### DIFF
--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -983,6 +983,7 @@ def test_dispatch_nodes_with_inventory(monkeypatch: pytest.MonkeyPatch, caplog: 
     assert "nodes" not in payload
     assert payload["addr_map"] == {"htr": ["1"]}
     assert payload["addresses_by_type"] == {"htr": ["1"]}
+    assert payload["addr_map"] is payload["addresses_by_type"]
     assert client._inventory.addresses_by_type["htr"] == ["1"]
 
 
@@ -1009,6 +1010,7 @@ def test_dispatch_nodes_handles_unknown_types(monkeypatch: pytest.MonkeyPatch) -
     assert "nodes" not in payload
     assert payload["addr_map"] == {"foo": []}
     assert payload["addresses_by_type"] == {"foo": []}
+    assert payload["addr_map"] is payload["addresses_by_type"]
     assert payload.get("unknown_types") == ["unknown"]
 
 


### PR DESCRIPTION
## Summary
- forward the inventory-provided addresses_by_type mapping when dispatching websocket node payloads and avoid redundant copies
- ensure downstream websocket handlers reuse the canonical address map when updating coordinator state
- refresh websocket protocol tests to expect the shared address map reference

## Testing
- pytest tests/test_termoweb_ws_protocol.py

------
https://chatgpt.com/codex/tasks/task_e_68eb5812706c83299e6e5cf3b842c53b