### PR TITLE
Refine websocket inventory address handling

### DIFF
--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -1196,9 +1196,16 @@ def test_apply_heater_addresses_normalises_from_inventory(
     normalized = client._apply_heater_addresses(
         {"htr": ["1"], "acm": ["2"]}, inventory=inventory
     )
-    assert normalized["htr"] == ["1"]
-    assert normalized["acm"] == ["2"]
+    heater_map, heater_aliases = inventory.heater_sample_address_map
+    power_map, power_aliases = inventory.power_monitor_sample_address_map
+    assert normalized["htr"] == heater_map["htr"]
+    assert normalized["acm"] == heater_map["acm"]
     assert client._coordinator.data == {"device": {"settings": {}}}
+    record = client.hass.data[module.DOMAIN]["entry"]
+    assert record.get("sample_aliases") == {
+        **heater_aliases,
+        **power_aliases,
+    }
 
 
 def test_apply_heater_addresses_includes_power_monitors(
@@ -1230,6 +1237,8 @@ def test_apply_heater_addresses_includes_power_monitors(
     update_payload = energy_coordinator.update_addresses.call_args[0][0]
     assert update_payload["pmo"] == ["9"]
     assert record.get("inventory") is inventory
+    sample_aliases = record.get("sample_aliases")
+    assert sample_aliases is not None and sample_aliases.get("pmo") == "pmo"
 
 def test_apply_heater_addresses_skips_empty_non_heater(monkeypatch: pytest.MonkeyPatch) -> None:
     """Empty non-heater lists should still yield a heater placeholder."""

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -893,6 +893,9 @@ def test_ws_common_apply_heater_addresses_normalizes_inputs() -> None:
     cleaned = dummy._apply_heater_addresses({"htr": "1", "pmo": "7"})
     assert cleaned["htr"] == ["1"]
     assert cleaned["pmo"] == ["7"]
+    sample_aliases = hass_record["sample_aliases"]
+    assert sample_aliases["htr"] == "htr"
+    assert sample_aliases["pmo"] == "pmo"
     energy_coordinator.update_addresses.assert_called_with(cleaned)
 
     energy_coordinator.update_addresses.reset_mock()
@@ -901,6 +904,9 @@ def test_ws_common_apply_heater_addresses_normalizes_inputs() -> None:
     )
     assert cleaned_iterable["htr"] == ["2"]
     assert cleaned_iterable["pmo"] == ["8"]
+    sample_aliases = hass_record["sample_aliases"]
+    assert sample_aliases["htr"] == "htr"
+    assert sample_aliases["pmo"] == "pmo"
     energy_coordinator.update_addresses.assert_called_with(cleaned_iterable)
 
 


### PR DESCRIPTION
## Summary
- use immutable inventory caches to populate heater and power monitor address/state data in the websocket client
- persist combined sample alias maps for reuse and supplement inventory gaps with normalized fallbacks
- update websocket helper tests to reflect inventory sourced addresses and alias propagation

## Testing
- pytest tests/test_ws_client.py tests/test_termoweb_ws_protocol.py tests/test_ducaheat_ws_addresses.py

------
https://chatgpt.com/codex/tasks/task_e_68eb580dd13483299bae64d4e5f4455b