### PR TITLE
Use inventory address map directly in coordinator

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -197,16 +197,6 @@ class StateCoordinator(
         self._rtc_reference_monotonic: float | None = None
         self.update_nodes(nodes, inventory=inventory)
 
-    def _inventory_addresses_by_type(self) -> dict[str, list[str]]:
-        """Return normalized node addresses derived from inventory metadata."""
-
-        inventory = self._ensure_inventory()
-        if inventory is None:
-            return {}
-
-        addresses = inventory.addresses_by_type
-        return {node_type: list(addrs) for node_type, addrs in addresses.items()}
-
     @staticmethod
     def _collect_previous_settings(
         prev_dev: Mapping[str, Any],
@@ -968,7 +958,7 @@ class StateCoordinator(
                 success = True
                 return
 
-            cache_map = self._inventory_addresses_by_type()
+            cache_map = inventory.addresses_by_type
             cache_bucket = cache_map.setdefault(resolved_type, [])
             if addr not in cache_bucket:
                 cache_bucket.append(addr)
@@ -1037,7 +1027,7 @@ class StateCoordinator(
             _LOGGER.debug("Skipping poll because inventory metadata is unavailable")
             return {}
 
-        addr_map = self._inventory_addresses_by_type()
+        addr_map = inventory.addresses_by_type
         _, reverse_map = inventory.heater_address_map
         reverse = {
             normalize_node_addr(address): set(types)

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -676,8 +676,6 @@ custom_components/termoweb/coordinator.py :: _normalize_energy_payload
     Return canonical energy node address mapping and aliases for ``payload``.
 custom_components/termoweb/coordinator.py :: StateCoordinator.__init__
     Initialize the TermoWeb device coordinator.
-custom_components/termoweb/coordinator.py :: StateCoordinator._inventory_addresses_by_type
-    Return normalized node addresses derived from inventory metadata.
 custom_components/termoweb/coordinator.py :: StateCoordinator._collect_previous_settings
     Return normalised settings carried over from previous poll.
 custom_components/termoweb/coordinator.py :: StateCoordinator._async_fetch_settings_by_address

--- a/tests/test_coordinator_inventory_addresses.py
+++ b/tests/test_coordinator_inventory_addresses.py
@@ -1,50 +1,101 @@
-"""Tests for coordinator inventory address cloning."""
+"""Tests for coordinator inventory address integration."""
 
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from homeassistant.core import HomeAssistant
 
+from custom_components.termoweb import inventory as inventory_module
 from custom_components.termoweb.coordinator import StateCoordinator
 from custom_components.termoweb.inventory import Inventory, build_node_inventory
 
 
-def test_inventory_addresses_by_type_returns_copy() -> None:
-    """StateCoordinator should clone inventory address mappings."""
+def _build_inventory() -> Inventory:
+    """Return inventory metadata for a heater-only device."""
 
-    raw_nodes = {
-        "nodes": [
-            {"type": "htr", "addr": "1"},
-            {"type": "acm", "addr": "2"},
-            {"type": "pmo", "addr": "9"},
-            {"type": "thm", "addr": "5"},
-        ]
-    }
+    raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
     inventory_nodes = build_node_inventory(raw_nodes)
-    inventory = Inventory("device", raw_nodes, inventory_nodes)
+    return Inventory("device", raw_nodes, inventory_nodes)
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_consults_inventory_addresses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Coordinator polling should obtain addresses from the inventory."""
 
     hass = HomeAssistant()
+    client = AsyncMock()
+    client.get_node_settings = AsyncMock(return_value={})
+    inventory = _build_inventory()
     coordinator = StateCoordinator(
         hass,
-        client=AsyncMock(),
+        client=client,
         base_interval=30,
         dev_id="device",
         device={},
-        nodes=raw_nodes,
+        nodes=inventory.payload,
         inventory=inventory,
     )
 
-    expected = inventory.addresses_by_type
-    result = coordinator._inventory_addresses_by_type()
+    original_property = inventory_module.Inventory.addresses_by_type
+    call_count = 0
 
-    assert result == expected
-    assert result is not expected
+    def fake_addresses(self: Inventory) -> dict[str, list[str]]:
+        nonlocal call_count
+        call_count += 1
+        return original_property.fget(self)
 
-    for node_type, addrs in expected.items():
-        assert result[node_type] == addrs
-        assert result[node_type] is not addrs
+    monkeypatch.setattr(
+        inventory_module.Inventory,
+        "addresses_by_type",
+        property(fake_addresses),
+    )
 
-    result["htr"].append("extra")
-    fresh_expected = inventory.addresses_by_type
-    assert "extra" not in fresh_expected["htr"]
+    result = await coordinator._async_update_data()
+
+    assert call_count == 1
+    assert result["device"]["addresses_by_type"]["htr"] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_heater_consults_inventory_addresses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manual heater refresh should read addresses directly from inventory."""
+
+    hass = HomeAssistant()
+    client = AsyncMock()
+    client.get_node_settings = AsyncMock(return_value={})
+    inventory = _build_inventory()
+    coordinator = StateCoordinator(
+        hass,
+        client=client,
+        base_interval=30,
+        dev_id="device",
+        device={},
+        nodes=inventory.payload,
+        inventory=inventory,
+    )
+
+    original_property = inventory_module.Inventory.addresses_by_type
+    call_count = 0
+
+    def fake_addresses(self: Inventory) -> dict[str, list[str]]:
+        nonlocal call_count
+        call_count += 1
+        return original_property.fget(self)
+
+    monkeypatch.setattr(
+        inventory_module.Inventory,
+        "addresses_by_type",
+        property(fake_addresses),
+    )
+
+    await coordinator.async_refresh_heater(("htr", "1"))
+
+    assert call_count == 1
+    assert coordinator.data["device"]["addresses_by_type"]["htr"] == ["1"]


### PR DESCRIPTION
## Summary
- update the state coordinator to pull address maps directly from the inventory container
- refresh the inventory address tests to assert property usage and update the function map documentation

## Testing
- pytest tests/test_coordinator_inventory_addresses.py tests/test_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68eb57fe4718832995d734889ec2ba35