### PR TITLE
Refactor heater refresh to rely on inventory heater maps

### DIFF
--- a/tests/test_coordinator_collect_previous_settings.py
+++ b/tests/test_coordinator_collect_previous_settings.py
@@ -30,11 +30,7 @@ def test_collect_previous_settings_normalises_and_ingests_sections() -> None:
         "inventory": {"ignored": True},
         "nodes": {},
     }
-    addr_map = {
-        "htr": ["01", "02", "03"],
-        "status": ["05"],
-        "prog": ["06"],
-    }
+    addr_map = {"htr": ["01", "02"], "acm": []}
 
     result = StateCoordinator._collect_previous_settings(prev_dev, addr_map)
 


### PR DESCRIPTION
## Summary
- reuse the inventory heater forward/reverse maps when refreshing node data
- keep previous heater settings by relying on the shared inventory map in tests

## Testing
- pytest tests/test_coordinator.py tests/test_coordinator_collect_previous_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68eb5f3b50c08329be0fc6fd9613a41a