### PR TITLE
Remove duplicated websocket address caches

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -901,35 +901,73 @@ class WebSocketClient(_WSCommon):
                 ", ".join(sorted(unknown_types)),
             )
 
-        canonical_map: dict[str, list[str]] | None = None
-        if isinstance(inventory, Inventory):
-            try:
-                candidate_map = inventory.addresses_by_type
-            except Exception:  # pragma: no cover - defensive cache guard
-                candidate_map = None
-            else:
-                candidate_map = candidate_map if isinstance(candidate_map, dict) else None
-            if candidate_map is not None:
-                canonical_map = candidate_map
-
-        if canonical_map is None:
-            canonical_map = addr_map
-        elif canonical_map is not addr_map and isinstance(addr_map, Mapping):
-            for node_type, addrs in addr_map.items():
-                canonical_map.setdefault(node_type, addrs)
-
-        self._apply_heater_addresses(
-            canonical_map,
+        cleaned_map = self._apply_heater_addresses(
+            addr_map,
             inventory=inventory,
             log_prefix="WS",
             logger=_LOGGER,
         )
 
+        addresses_by_type: dict[str, list[str]] = {}
+        if isinstance(inventory, Inventory):
+            try:
+                inventory_map = inventory.addresses_by_type
+            except Exception:  # pragma: no cover - defensive cache guard
+                inventory_map = None
+            else:
+                inventory_map = (
+                    dict(inventory_map) if isinstance(inventory_map, Mapping) else None
+                )
+            if isinstance(inventory_map, Mapping):
+                addresses_by_type = {
+                    node_type: list(addresses)
+                    if isinstance(addresses, Iterable)
+                    and not isinstance(addresses, (str, bytes))
+                    else [
+                        normalised
+                        for normalised in (
+                            normalize_node_addr(
+                                addresses, use_default_when_falsey=True
+                            ),
+                        )
+                        if normalised
+                    ]
+                    for node_type, addresses in inventory_map.items()
+                }
+
+        if not addresses_by_type and isinstance(addr_map, Mapping):
+            addresses_by_type = {
+                node_type: [
+                    normalised
+                    for normalised in (
+                        normalize_node_addr(candidate, use_default_when_falsey=True)
+                        for candidate in addrs
+                    )
+                    if normalised
+                ]
+                for node_type, addrs in addr_map.items()
+            }
+        elif isinstance(addr_map, Mapping):
+            for node_type, addrs in addr_map.items():
+                addresses_by_type.setdefault(
+                    node_type,
+                    [
+                        normalised
+                        for normalised in (
+                            normalize_node_addr(
+                                candidate, use_default_when_falsey=True
+                            )
+                            for candidate in addrs
+                        )
+                        if normalised
+                    ],
+                )
+
         payload_copy: dict[str, Any] = {
             "dev_id": self.dev_id,
             "node_type": None,
-            "addr_map": canonical_map,
-            "addresses_by_type": canonical_map,
+            "addr_map": addresses_by_type,
+            "addresses_by_type": addresses_by_type,
         }
         if unknown_types:  # pragma: no cover - diagnostic payload
             payload_copy["unknown_types"] = sorted(unknown_types)
@@ -953,7 +991,7 @@ class WebSocketClient(_WSCommon):
         else:  # pragma: no cover - legacy hass loop stub
             _send()
 
-        return canonical_map
+        return addresses_by_type or cleaned_map
 
     def _heater_sample_subscription_targets(self) -> list[tuple[str, str]]:
         """Return ordered ``(node_type, addr)`` heater sample subscriptions."""
@@ -1668,13 +1706,11 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
                 cur = dict(self._coordinator.data or {})
                 cur[self.dev_id] = dev_map
                 self._coordinator.data = cur  # type: ignore[attr-defined]
-            dev_map.setdefault("addresses_by_type", {})
             dev_map.setdefault("settings", {})
             if path.endswith("/mgr/nodes"):
                 if isinstance(body, Mapping):
                     type_to_addrs = self._dispatch_nodes(body)
                     if isinstance(type_to_addrs, Mapping):
-                        dev_map["addresses_by_type"] = type_to_addrs
                         for node_type, addrs in type_to_addrs.items():
                             if isinstance(addrs, list):
                                 iterable = addrs

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -1141,9 +1141,7 @@ def test_handle_event_includes_addr_map(monkeypatch: pytest.MonkeyPatch) -> None
     dev_state = client._coordinator.data.get("device")
     assert isinstance(dev_state, Mapping)
     assert "nodes" not in dev_state
-    addresses_by_type = dev_state.get("addresses_by_type")
-    assert isinstance(addresses_by_type, Mapping)
-    assert addresses_by_type.get("htr") == ["2"]
+    assert "addresses_by_type" not in dev_state
 
 
 def test_update_legacy_settings_updates_settings_map(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -812,40 +812,33 @@ def test_ws_common_ensure_type_bucket_populates_dev_map() -> None:
     assert bucket["samples"] == {"temp": 20}
     assert bucket["settings"] == {"mode": "auto"}
     assert bucket["advanced"] == {}
-    assert dev_map["addresses_by_type"]["htr"] == []
     assert dev_map["settings"]["htr"] == {}
     assert dev_map["nodes_by_type"]["htr"] is bucket
 
     dev_map_second = {
-        "addresses_by_type": MappingProxyType({"htr": ("2",)}),
         "settings": {"htr": {"existing": 1}},
         "nodes_by_type": {},
     }
     bucket_again = dummy._ensure_type_bucket({"htr": bucket}, "htr", dev_map=dev_map_second)
     assert bucket_again is bucket
-    assert dev_map_second["addresses_by_type"]["htr"] == ["2"]
     assert dev_map_second["nodes_by_type"]["htr"] is bucket
 
     dev_map_third = {
-        "addresses_by_type": {"htr": ["3"]},
         "settings": {},
         "nodes_by_type": {},
     }
     dummy._ensure_type_bucket({"htr": bucket}, "htr", dev_map=dev_map_third)
-    assert dev_map_third["addresses_by_type"]["htr"] == ["3"]
+    assert "addresses_by_type" not in dev_map_third
 
     dev_map_missing = {
-        "addresses_by_type": {},
         "settings": MappingProxyType({"htr": MappingProxyType({"mode": "sched"})}),
     }
     bucket_missing = dummy._ensure_type_bucket({"htr": bucket}, "htr", dev_map=dev_map_missing)
     assert bucket_missing is bucket
-    assert dev_map_missing["addresses_by_type"]["htr"] == []
     assert dev_map_missing["settings"]["htr"] == {"mode": "sched"}
     assert dev_map_missing["nodes_by_type"]["htr"] is bucket
 
     dev_map_non_mapping_settings = {
-        "addresses_by_type": {},
         "settings": None,
         "nodes_by_type": {},
     }


### PR DESCRIPTION
## Summary
- update shared websocket dispatch helpers to rely on inventory-derived address maps after applying heater address normalization
- adjust TermoWeb and Ducaheat websocket clients to drop redundant address caches while keeping dispatcher payloads intact
- refresh websocket protocol tests to assert against the new canonical inventory sources

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb629ba16883298357b51080c93a5d