### PR TITLE
Use inventory data for energy sensor setup

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -871,7 +871,10 @@ class _WSCommon(_WSStatusMixin):
         )
 
         if hasattr(energy_coordinator, "update_addresses"):
-            energy_coordinator.update_addresses(cleaned_map)
+            if isinstance(inventory_container, Inventory):
+                energy_coordinator.update_addresses(inventory_container)
+            else:
+                energy_coordinator.update_addresses(cleaned_map)
 
         return cleaned_map
 

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -118,12 +118,33 @@ def _normalise_energy_value(coordinator: Any, raw: Any) -> float | None:
     return numeric * scale
 
 
+def _power_monitor_display_name(node: PowerMonitorNode, addr: str) -> str:
+    """Return the display name for a power monitor address."""
+
+    raw_name = getattr(node, "name", None)
+    trimmed = raw_name.strip() if isinstance(raw_name, str) else None
+    if trimmed:
+        return trimmed
+
+    default_factory = getattr(node, "default_name", None)
+    if callable(default_factory):
+        try:
+            fallback = default_factory()
+        except Exception:  # pragma: no cover - defensive fallback
+            fallback = None
+        if isinstance(fallback, str):
+            fallback_trimmed = fallback.strip()
+            if fallback_trimmed:
+                return fallback_trimmed
+
+    return f"Power Monitor {addr}"
+
+
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up sensors for each heater node."""
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
-    inventory = data.get("inventory")
 
     def default_name(addr: str) -> str:
         """Return a placeholder name for heater nodes."""
@@ -133,126 +154,65 @@ async def async_setup_entry(hass, entry, async_add_entities):
         data,
         default_name_simple=default_name,
     )
+    inventory = heater_details.inventory
     addrs_by_type = heater_details.addrs_by_type
 
     energy_coordinator: EnergyStateCoordinator | None = data.get(
         "energy_coordinator",
     )
 
-    def _merge_energy_addresses(source: Mapping[str, Iterable[str]] | None) -> None:
-        if not isinstance(source, Mapping):
-            return
-        for raw_type, values in source.items():
-            canonical_type = normalize_node_type(
-                raw_type,
-                use_default_when_falsey=True,
-            ) or str(raw_type)
-            if isinstance(values, (str, bytes)) or not isinstance(values, Iterable):
-                candidates = [values]
-            else:
-                candidates = list(values)
-            bucket = energy_nodes_map.setdefault(canonical_type, [])
-            seen = set(bucket)
-            for candidate in candidates:
-                addr = normalize_node_addr(candidate, use_default_when_falsey=True)
-                if not addr or addr in seen:
-                    continue
-                seen.add(addr)
-                bucket.append(addr)
-
-    energy_nodes_map: dict[str, list[str]] = {
-        node_type: list(addresses)
-        for node_type, addresses in addrs_by_type.items()
-    }
-    energy_nodes_map.setdefault("htr", list(addrs_by_type.get("htr", [])))
-    energy_nodes_map.setdefault("acm", list(addrs_by_type.get("acm", [])))
-    energy_nodes_map.setdefault("pmo", [])
-
-    power_monitor_names: dict[str, str] = {}
-
-    def _fallback_power_monitor_name(addr: str) -> str:
-        """Return a default label for a power monitor address."""
-
-        try:
-            fallback_node = PowerMonitorNode(name=None, addr=addr)
-            candidate = fallback_node.default_name()
-        except Exception:  # pragma: no cover - defensive fallback
-            candidate = None
-        if isinstance(candidate, str):
-            trimmed = candidate.strip()
-            if trimmed:
-                return trimmed
-        return f"Power Monitor {addr}"
-
-    def _register_power_monitor_node(node: Any) -> None:
-        """Add a named power monitor derived from ``node``."""
-
-        addr = normalize_node_addr(getattr(node, "addr", None), use_default_when_falsey=True)
-        if not addr:
-            return
-        raw_name = getattr(node, "name", None)
-        trimmed = raw_name.strip() if isinstance(raw_name, str) else None
-        if trimmed:
-            power_monitor_names[addr] = trimmed
-            return
-        default_name = None
-        default_factory = getattr(node, "default_name", None)
-        if callable(default_factory):
-            try:
-                default_name = default_factory()
-            except Exception:  # pragma: no cover - defensive fallback
-                default_name = None
-        if isinstance(default_name, str):
-            default_trimmed = default_name.strip()
-            if default_trimmed:
-                power_monitor_names.setdefault(addr, default_trimmed)
-                return
-        power_monitor_names.setdefault(addr, _fallback_power_monitor_name(addr))
-
-    def _integrate_power_monitor_addresses(
-        source: Mapping[str, Iterable[str]] | None,
-    ) -> None:
-        """Merge addresses from ``source`` into the energy map and names."""
-
-        if not isinstance(source, Mapping):
-            return
-        _merge_energy_addresses(source)
-        for values in source.values():
-            if isinstance(values, (str, bytes)) or not isinstance(values, Iterable):
-                candidates = [values]
-            else:
-                candidates = list(values)
-            for candidate in candidates:
-                addr = normalize_node_addr(candidate, use_default_when_falsey=True)
-                if not addr:
-                    continue
-                power_monitor_names.setdefault(addr, _fallback_power_monitor_name(addr))
-
-    if inventory is not None:
-        nodes_by_type_map = getattr(inventory, "nodes_by_type", None)
-        if isinstance(nodes_by_type_map, Mapping):
-            for candidate in nodes_by_type_map.get("pmo", []) or []:
-                _register_power_monitor_node(candidate)
-
-        address_map = getattr(inventory, "power_monitor_address_map", None)
-        if isinstance(address_map, tuple) and address_map:
-            _integrate_power_monitor_addresses(address_map[0])
-
-    sample_map = getattr(inventory, "power_monitor_sample_address_map", None)
-    if isinstance(sample_map, tuple) and sample_map:
-        _integrate_power_monitor_addresses(sample_map[0])
-
-    if power_monitor_names:
-        _merge_energy_addresses({"pmo": list(power_monitor_names)})
-
     if energy_coordinator is None:
         energy_coordinator = EnergyStateCoordinator(
-            hass, data["client"], dev_id, energy_nodes_map
+            hass,
+            data["client"],
+            dev_id,
+            inventory,
         )
         data["energy_coordinator"] = energy_coordinator
         await energy_coordinator.async_config_entry_first_refresh()
     else:
-        energy_coordinator.update_addresses(energy_nodes_map)
+        energy_coordinator.update_addresses(inventory)
+
+    power_monitor_nodes: dict[str, PowerMonitorNode] = {}
+    if isinstance(inventory, Inventory):
+        nodes_by_type = inventory.nodes_by_type
+        power_nodes = nodes_by_type.get("pmo", []) if isinstance(nodes_by_type, Mapping) else []
+        for node in power_nodes or []:
+            if not isinstance(node, PowerMonitorNode):
+                continue
+            addr = normalize_node_addr(
+                getattr(node, "addr", None),
+                use_default_when_falsey=True,
+            )
+            if not addr:
+                continue
+            power_monitor_nodes.setdefault(addr, node)
+
+    power_monitor_addresses: Iterable[str] = ()
+    if isinstance(inventory, Inventory):
+        try:
+            address_map = inventory.power_monitor_address_map
+        except Exception:  # pragma: no cover - defensive cache guard
+            address_map = None
+        if isinstance(address_map, tuple) and address_map:
+            forward_map = address_map[0]
+            if isinstance(forward_map, Mapping):
+                power_monitor_addresses = forward_map.get("pmo", []) or []
+
+    power_monitor_entries: list[tuple[str, str]] = []
+    for addr in power_monitor_addresses:
+        normalized_addr = normalize_node_addr(addr, use_default_when_falsey=True)
+        if not normalized_addr:
+            continue
+        node = power_monitor_nodes.get(normalized_addr)
+        if isinstance(node, PowerMonitorNode):
+            base_name = _power_monitor_display_name(node, normalized_addr)
+        else:
+            base_name = _power_monitor_display_name(
+                PowerMonitorNode(name=None, addr=normalized_addr),
+                normalized_addr,
+            )
+        power_monitor_entries.append((normalized_addr, base_name))
 
     new_entities: list[SensorEntity] = []
     for node_type, _node, addr_str, base_name in iter_heater_nodes(
@@ -290,7 +250,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
         )
 
-    for addr_str, base_name in sorted(power_monitor_names.items()):
+    for addr_str, base_name in sorted(power_monitor_entries):
         energy_unique_id = build_power_monitor_energy_unique_id(dev_id, addr_str)
         power_unique_id = build_power_monitor_power_unique_id(dev_id, addr_str)
         new_entities.append(
@@ -698,44 +658,6 @@ class PowerMonitorSensorBase(CoordinatorEntity, SensorEntity):
 
         return {}
 
-    def _tracked_addresses(self) -> set[str]:
-        """Return addresses tracked for this power monitor."""
-
-        record = self._device_record()
-        if not isinstance(record, Mapping):
-            return set()
-
-        addresses: set[str] = set()
-        candidates = []
-
-        direct_bucket = record.get("pmo")
-        if isinstance(direct_bucket, Mapping):
-            candidates.append(direct_bucket.get("addrs"))
-
-        inventory = record.get("inventory")
-        if isinstance(inventory, Inventory):
-            forward_map, _ = inventory.power_monitor_address_map
-            for values in forward_map.values():
-                candidates.append(values)
-            sample_map = getattr(inventory, "power_monitor_sample_address_map", None)
-            if isinstance(sample_map, tuple) and sample_map:
-                for values in sample_map[0].values():
-                    candidates.append(values)
-
-        for raw in candidates:
-            if isinstance(raw, (str, bytes)):
-                raw_iterable: Iterable[Any] = [raw]
-            elif isinstance(raw, Iterable):
-                raw_iterable = raw
-            else:
-                continue
-            for item in raw_iterable:
-                addr = normalize_node_addr(item, use_default_when_falsey=True)
-                if addr:
-                    addresses.add(addr)
-
-        return addresses
-
     def _coerce_native_value(self, raw: Any) -> float | None:
         """Convert a metric payload value to ``float`` if possible."""
 
@@ -757,7 +679,18 @@ class PowerMonitorSensorBase(CoordinatorEntity, SensorEntity):
         bucket = self._metric_bucket()
         if self._addr in bucket:
             return True
-        return self._addr in self._tracked_addresses()
+        addresses: Iterable[str] = ()
+        accessor = getattr(self.coordinator, "addresses_for_type", None)
+        if callable(accessor):
+            try:
+                addresses = accessor("pmo")
+            except Exception:  # pragma: no cover - defensive safeguard
+                addresses = ()
+        if not addresses:
+            address_map = getattr(self.coordinator, "_addresses_by_type", None)
+            if isinstance(address_map, Mapping):
+                addresses = address_map.get("pmo", ())
+        return self._addr in set(addresses)
 
     @property
     def native_value(self) -> float | None:

--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -99,7 +99,7 @@ def test_apply_heater_addresses_updates_state() -> None:
 
     assert hass.data[DOMAIN]["entry"]["inventory"] is inventory
     assert client._inventory is inventory
-    energy_coordinator.update_addresses.assert_called_once_with(cleaned)
+    energy_coordinator.update_addresses.assert_called_once_with(inventory)
 
     sample_aliases = hass.data[DOMAIN]["entry"].get("sample_aliases")
     assert sample_aliases is not None

--- a/tests/test_heater_energy_sensor.py
+++ b/tests/test_heater_energy_sensor.py
@@ -120,9 +120,7 @@ def test_power_monitor_sensors_register_device_info() -> None:
 
         await async_setup_sensor_entry(hass, entry, added.extend)
 
-        energy_coord.update_addresses.assert_called_once()
-        update_map = energy_coord.update_addresses.call_args[0][0]
-        assert sorted(update_map.get("pmo", [])) == ["P1", "P2"]
+        energy_coord.update_addresses.assert_called_once_with(inventory)
 
         energy_entities = {
             ent._attr_unique_id: ent

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -1231,9 +1231,7 @@ def test_apply_heater_addresses_includes_power_monitors(
     normalized = client._apply_heater_addresses({"htr": ["1"]}, inventory=inventory)
 
     assert normalized["pmo"] == ["9"]
-    energy_coordinator.update_addresses.assert_called_once()
-    update_payload = energy_coordinator.update_addresses.call_args[0][0]
-    assert update_payload["pmo"] == ["9"]
+    energy_coordinator.update_addresses.assert_called_once_with(inventory)
     assert record.get("inventory") is inventory
     sample_aliases = record.get("sample_aliases")
     assert sample_aliases is not None and sample_aliases.get("pmo") == "pmo"


### PR DESCRIPTION
## Summary
- read heater and power monitor addresses directly from the immutable inventory when creating sensors
- allow the energy coordinator to accept an `Inventory` and expose address lookups for power monitor availability
- update websocket helpers and sensor tests to expect inventory-driven address updates

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb69394574832991e3f4e79e2c0b96