### PR TITLE
Refactor heater helpers to rely on inventory

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -22,6 +22,7 @@ from .heater import (
     iter_boostable_heater_nodes,
     log_skipped_nodes,
 )
+from .inventory import Inventory
 from .identifiers import build_heater_entity_unique_id
 from .utils import build_gateway_device_info
 
@@ -60,6 +61,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 unique_id,
                 device_name=base_name,
                 node_type=node_type,
+                inventory=heater_details.inventory,
             )
         )
 
@@ -153,6 +155,7 @@ class HeaterBoostActiveBinarySensor(HeaterNodeBase, BinarySensorEntity):
         *,
         device_name: str | None = None,
         node_type: str | None = None,
+        inventory: Inventory | None = None,
     ) -> None:
         """Initialise the boost activity binary sensor."""
 
@@ -165,6 +168,7 @@ class HeaterBoostActiveBinarySensor(HeaterNodeBase, BinarySensorEntity):
             unique_id,
             device_name=device_name,
             node_type=node_type,
+            inventory=inventory,
         )
 
     @property

--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -29,7 +29,7 @@ from .heater import (
     iter_boost_button_metadata,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import boostable_accumulator_details_for_entry
+from .inventory import Inventory, boostable_accumulator_details_for_entry
 from .utils import build_gateway_device_info
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         StateRefreshButton(coordinator, entry.entry_id, dev_id)
     ]
 
-    _, accumulator_nodes = boostable_accumulator_details_for_entry(
+    heater_details, accumulator_nodes = boostable_accumulator_details_for_entry(
         data,
         default_name_simple=default_name,
         platform_name="button",
@@ -69,6 +69,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 addr_str,
                 base_name,
                 node_type,
+                inventory=heater_details.inventory,
             )
         )
 
@@ -123,6 +124,7 @@ class AccumulatorBoostButtonBase(HeaterNodeBase, ButtonEntity):
         *,
         label: str,
         node_type: str | None = None,
+        inventory: Inventory | None = None,
     ) -> None:
         """Initialise an accumulator boost helper button."""
 
@@ -136,6 +138,7 @@ class AccumulatorBoostButtonBase(HeaterNodeBase, ButtonEntity):
             unique_id,
             device_name=base_name,
             node_type=node_type,
+            inventory=inventory,
         )
         self._label = label
         self._attr_name = label
@@ -205,6 +208,7 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
         node_type: str | None = None,
         label: str | None = None,
         icon: str | None = None,
+        inventory: Inventory | None = None,
     ) -> None:
         """Initialise the boost helper button for a fixed duration."""
 
@@ -219,6 +223,7 @@ class AccumulatorBoostButton(AccumulatorBoostButtonBase):
             unique_id,
             label=label or f"Boost {label_text}",
             node_type=node_type,
+            inventory=inventory,
         )
         if icon is not None:
             self._attr_icon = icon
@@ -260,6 +265,7 @@ class AccumulatorBoostCancelButton(AccumulatorBoostButtonBase):
         node_type: str | None = None,
         label: str | None = None,
         icon: str | None = None,
+        inventory: Inventory | None = None,
     ) -> None:
         """Initialise the helper button that cancels an active boost."""
 
@@ -272,6 +278,7 @@ class AccumulatorBoostCancelButton(AccumulatorBoostButtonBase):
             unique_id,
             label=label or "Cancel boost",
             node_type=node_type,
+            inventory=inventory,
         )
         if icon is not None:
             self._attr_icon = icon
@@ -284,6 +291,8 @@ def _create_boost_button_entities(
     addr: str,
     base_name: str,
     node_type: str,
+    *,
+    inventory: Inventory | None = None,
 ) -> list[ButtonEntity]:
     """Return boost helper buttons described by shared metadata."""
 
@@ -303,6 +312,7 @@ def _create_boost_button_entities(
             base_name,
             node_type,
             unique_prefix,
+            inventory=inventory,
         )
         for metadata in iter_boost_button_metadata()
     ]
@@ -317,6 +327,8 @@ def _build_boost_button(
     base_name: str,
     node_type: str,
     unique_prefix: str,
+    *,
+    inventory: Inventory | None = None,
 ) -> ButtonEntity:
     """Instantiate a boost helper button for ``metadata``."""
 
@@ -332,6 +344,7 @@ def _build_boost_button(
             node_type=node_type,
             label=metadata.label,
             icon=metadata.icon,
+            inventory=inventory,
         )
 
     return AccumulatorBoostButton(
@@ -345,4 +358,5 @@ def _build_boost_button(
         node_type=node_type,
         label=metadata.label,
         icon=metadata.icon,
+        inventory=inventory,
     )

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -19,6 +19,7 @@ from .boost import (
     coerce_boost_bool,
     coerce_boost_minutes,
     coerce_boost_remaining_minutes,
+    iter_inventory_heater_metadata,
     supports_boost,
 )
 from .const import DOMAIN, signal_ws_data
@@ -26,7 +27,6 @@ from .inventory import (
     HEATER_NODE_TYPES,
     Inventory,
     Node,
-    build_node_inventory,
     heater_platform_details_from_inventory,
     normalize_node_addr,
     normalize_node_type,
@@ -111,14 +111,13 @@ class HeaterPlatformDetails:
     """Immutable heater platform metadata resolved from inventory."""
 
     inventory: Inventory
-    address_map: dict[str, list[str]]
-    resolve_name: Callable[[str, str], str]
+    default_name_simple: Callable[[str], str]
 
     def __iter__(self) -> Iterator[Any]:
         """Provide tuple-style iteration compatibility."""
 
         yield self.nodes_by_type
-        yield self.address_map
+        yield self.addrs_by_type
         yield self.resolve_name
 
     @property
@@ -131,12 +130,31 @@ class HeaterPlatformDetails:
     def addrs_by_type(self) -> dict[str, list[str]]:
         """Return heater addresses grouped by node type."""
 
-        return self.address_map
+        forward_map, _ = self.inventory.heater_address_map
+        return forward_map
 
     def addresses_for(self, node_type: str) -> list[str]:
         """Return immutable heater addresses for ``node_type``."""
 
-        return list(self.address_map.get(node_type, ()))
+        return list(self.addrs_by_type.get(node_type, ()))
+
+    def resolve_name(self, node_type: str, addr: str) -> str:
+        """Resolve the friendly name for ``(node_type, addr)``."""
+
+        return self.inventory.resolve_heater_name(
+            node_type,
+            addr,
+            default_factory=self.default_name_simple,
+        )
+
+    def iter_metadata(self) -> Iterator[tuple[str, Node, str, str]]:
+        """Yield heater metadata derived from the inventory."""
+
+        for metadata in iter_inventory_heater_metadata(
+            self.inventory,
+            default_name_simple=self.default_name_simple,
+        ):
+            yield metadata.node_type, metadata.node, metadata.addr, metadata.name
 
 
 def _boost_runtime_store(
@@ -277,25 +295,33 @@ def iter_boostable_heater_nodes(
 ) -> Iterator[tuple[str, Node, str, str]]:
     """Yield heater nodes that expose boost functionality."""
 
-    filtered_types: Iterable[str] | None = node_types
+    if isinstance(details, HeaterPlatformDetails):
+        metadata_iter = details.iter_metadata()
+    elif isinstance(details, Inventory):  # pragma: no cover - compatibility shim
+        metadata_iter = (
+            (meta.node_type, meta.node, meta.addr, meta.name)
+            for meta in iter_inventory_heater_metadata(details)
+        )
+    else:
+        return
 
-    if accumulators_only:
-        accumulator_types: tuple[str, ...] = ("acm",)
-        if filtered_types is None:
-            filtered_types = accumulator_types
-        else:
-            filtered_types = [
-                node_type
-                for node_type in filtered_types
-                if node_type in accumulator_types
-            ]
-            if not filtered_types:
-                return
+    if node_types is None:
+        filter_types: set[str] | None = None
+    elif isinstance(node_types, (str, bytes)):
+        normalized = normalize_node_type(node_types, use_default_when_falsey=True)
+        filter_types = {normalized} if normalized else set()
+    else:
+        filter_types = {
+            normalize_node_type(candidate, use_default_when_falsey=True)
+            for candidate in node_types
+        }
+        filter_types.discard("")
 
-    for node_type, node, addr_str, base_name in iter_heater_nodes(
-        details,
-        node_types=filtered_types,
-    ):
+    for node_type, node, addr_str, base_name in metadata_iter:
+        if filter_types is not None and node_type not in filter_types:
+            continue
+        if accumulators_only and node_type != "acm":
+            continue
         if supports_boost(node):
             yield node_type, node, addr_str, base_name
 
@@ -492,158 +518,6 @@ class DispatcherSubscriptionHelper:
         return self._unsub is not None
 
 
-def _iter_nodes(nodes: Any) -> Iterable[Node]:
-    """Yield :class:`Node` instances from ``nodes`` when possible."""
-
-    if isinstance(nodes, Iterable) and not isinstance(nodes, dict):
-        candidate = list(nodes)
-        if candidate and all(isinstance(node, Node) for node in candidate):
-            yield from candidate
-            return
-        nodes = candidate
-
-    try:
-        inventory = build_node_inventory(nodes)
-    except ValueError:  # pragma: no cover - defensive
-        inventory = []
-
-    yield from inventory
-
-
-def iter_heater_nodes(
-    details: HeaterPlatformDetails,
-    *,
-    node_types: Iterable[str] | None = None,
-) -> Iterator[tuple[str, Node, str, str]]:
-    """Yield heater node metadata for supported node types."""
-
-    if not isinstance(details, HeaterPlatformDetails):
-        return
-
-    resolver = details.resolve_name
-    nodes_by_type = details.nodes_by_type
-
-    requested_types: list[str]
-    if node_types is None:
-        requested_types = list(HEATER_NODE_TYPES)
-    elif isinstance(node_types, (str, bytes)):
-        candidate = normalize_node_type(node_types, use_default_when_falsey=True)
-        requested_types = [candidate] if candidate else []
-    else:
-        requested_types = [
-            normalize_node_type(node_type, use_default_when_falsey=True)
-            for node_type in node_types
-        ]
-
-    for desired_type in requested_types:
-        if not desired_type:
-            continue
-        bucket = nodes_by_type.get(desired_type, [])
-        if not bucket:
-            continue
-        for node in bucket:
-            raw_addr = getattr(node, "addr", "")
-            if raw_addr is None:
-                continue
-            addr_str = normalize_node_addr(raw_addr)
-            if not addr_str or addr_str.lower() == "none":
-                continue
-            resolved_name = resolver(desired_type, addr_str)
-            yield desired_type, node, addr_str, resolved_name
-
-
-def iter_heater_maps(
-    coordinator_cache: Mapping[str, Any] | None,
-    *,
-    map_key: str,
-    node_types: Iterable[str] | None = None,
-    inventory: Inventory | HeaterPlatformDetails | None = None,
-) -> Iterator[dict[str, Any]]:
-    """Yield unique heater map dictionaries for ``map_key``."""
-
-    if not isinstance(map_key, str) or not map_key:
-        return
-
-    cache = coordinator_cache if isinstance(coordinator_cache, Mapping) else {}
-    seen: set[int] = set()
-
-    if node_types is None:
-        if isinstance(inventory, HeaterPlatformDetails):
-            candidate_types = [
-                key for key, values in inventory.addrs_by_type.items() if values
-            ]
-            desired_types = candidate_types or list(HEATER_NODE_TYPES)
-        elif isinstance(inventory, Inventory):
-            forward_map, _ = inventory.heater_address_map
-            candidate_types = [
-                key for key, values in forward_map.items() if values
-            ]
-            desired_types = candidate_types or list(HEATER_NODE_TYPES)
-        else:
-            desired_types = list(HEATER_NODE_TYPES)
-    else:
-        if isinstance(node_types, (str, bytes)):
-            node_iter: Iterable[Any]
-            node_iter = [node_types]
-        else:
-            node_iter = node_types
-        desired_types = [
-            normalize_node_type(candidate, use_default_when_falsey=True)
-            for candidate in node_iter
-        ]
-
-    settings_map = cache.get("settings")
-    if isinstance(settings_map, Mapping) and map_key == "settings":
-        for desired in desired_types:
-            if not desired:
-                continue
-            canonical = normalize_node_type(desired, use_default_when_falsey=True)
-            lookup_keys: tuple[str, ...]
-            if canonical and canonical != desired:
-                lookup_keys = (canonical, desired)
-            elif canonical:
-                lookup_keys = (canonical,)
-            else:
-                lookup_keys = (desired,)
-            for key in lookup_keys:
-                section = settings_map.get(key)
-                if not isinstance(section, Mapping):
-                    continue
-                candidate = section if isinstance(section, dict) else dict(section)
-                ident = id(candidate)
-                if ident in seen:
-                    continue
-                seen.add(ident)
-                yield candidate
-                break
-
-    for desired in desired_types:
-        if not desired:
-            continue
-        canonical = normalize_node_type(desired, use_default_when_falsey=True)
-        lookup_keys: tuple[str, ...]
-        if canonical and canonical != desired:
-            lookup_keys = (canonical, desired)
-        elif canonical:
-            lookup_keys = (canonical,)
-        else:
-            lookup_keys = (desired,)
-        for key in lookup_keys:
-            section = cache.get(key)
-            if not isinstance(section, Mapping):
-                continue
-            candidate = section.get(map_key)
-            if not isinstance(candidate, Mapping):
-                continue
-            mapping = candidate if isinstance(candidate, dict) else dict(candidate)
-            ident = id(mapping)
-            if ident in seen:
-                continue
-            seen.add(ident)
-            yield mapping
-            break
-
-
 def log_skipped_nodes(
     platform_name: str,
     inventory: Inventory | HeaterPlatformDetails | None,
@@ -670,26 +544,16 @@ def log_skipped_nodes(
     if resolved_inventory is None:
         return
 
-    nodes_by_type = resolved_inventory.nodes_by_type
+    addresses_by_type = resolved_inventory.addresses_by_type
 
     for node_type in skipped_types:
         canonical = normalize_node_type(node_type, use_default_when_falsey=True)
         if not canonical:
             continue
-        bucket = nodes_by_type.get(canonical, [])
-        if not bucket:
+        addresses = addresses_by_type.get(canonical, [])
+        if not addresses:
             continue
-        addrs = ", ".join(
-            sorted(
-                filter(
-                    None,
-                    (
-                        normalize_node_addr(getattr(node, "addr", ""))
-                        for node in bucket
-                    ),
-                )
-            )
-        )
+        addrs = ", ".join(sorted(addresses))
         log.debug(
             "Skipping TermoWeb %s nodes for %s: %s",
             canonical,
@@ -698,52 +562,9 @@ def log_skipped_nodes(
         )
 
 
-def build_heater_name_map(
-    nodes: Any, default_factory: Callable[[str], str]
-) -> dict[Any, Any]:
-    """Return a mapping of heater node identifiers to friendly names.
-
-    The mapping exposes multiple lookup styles:
-
-    * ``(node_type, addr)`` -> resolved friendly name
-    * ``"htr"`` -> legacy heater-only mapping of ``addr`` -> friendly name
-    * ``"by_type"`` -> ``{node_type: {addr: name}}`` for all heater nodes
-    """
-
-    by_type: dict[str, dict[str, str]] = {}
-    by_node: dict[tuple[str, str], str] = {}
-
-    for node in _iter_nodes(nodes):
-        node_type = normalize_node_type(getattr(node, "type", ""))
-        if node_type not in HEATER_NODE_TYPES:
-            continue
-
-        addr = normalize_node_addr(getattr(node, "addr", ""))
-        if not addr or addr.lower() == "none":
-            continue
-
-        default_name = default_factory(addr)
-        raw_name = getattr(node, "name", "")
-        resolved = default_name
-        if isinstance(raw_name, str):
-            candidate = raw_name.strip()
-            if candidate:
-                resolved = candidate
-
-        by_node[(node_type, addr)] = resolved
-        bucket = by_type.setdefault(node_type, {})
-        bucket[addr] = resolved
-
-    result: dict[Any, Any] = {"htr": dict(by_type.get("htr", {}))}
-    if by_type:
-        result["by_type"] = {k: dict(v) for k, v in by_type.items()}
-
-    result.update(by_node)
-
-    return result
-
-
-def _extract_inventory(entry_data: Mapping[str, Any] | None) -> Inventory | None:
+def resolve_entry_inventory(
+    entry_data: Mapping[str, Any] | None,
+) -> Inventory | None:
     """Return the shared inventory stored alongside a config entry."""
 
     if not isinstance(entry_data, Mapping):
@@ -753,34 +574,12 @@ def _extract_inventory(entry_data: Mapping[str, Any] | None) -> Inventory | None
     if isinstance(candidate, Inventory):
         return candidate
 
-    hass = entry_data.get("hass")
-    entry_id = entry_data.get("entry_id")
-    domain_data: Mapping[str, Any] | None = None
-    if hass is not None and isinstance(entry_id, str) and entry_id:
-        hass_data = getattr(hass, "data", None)
-        if isinstance(hass_data, Mapping):
-            domain_bucket = hass_data.get(DOMAIN)
-            if isinstance(domain_bucket, Mapping):
-                domain_data = domain_bucket.get(entry_id)
-    if isinstance(domain_data, Mapping):
-        candidate = domain_data.get("inventory")
-        if isinstance(candidate, Inventory):
-            return candidate
-
     coordinator = entry_data.get("coordinator")
     candidate = getattr(coordinator, "inventory", None)
     if isinstance(candidate, Inventory):
         return candidate
 
     return None
-
-
-def resolve_entry_inventory(
-    entry_data: Mapping[str, Any] | None,
-) -> Inventory | None:
-    """Return the shared inventory stored alongside a config entry."""
-
-    return _extract_inventory(entry_data)
 
 
 def heater_platform_details_for_entry(
@@ -790,7 +589,7 @@ def heater_platform_details_for_entry(
 ) -> HeaterPlatformDetails:
     """Return heater platform metadata derived from ``entry_data``."""
 
-    inventory = _extract_inventory(entry_data)
+    inventory = resolve_entry_inventory(entry_data)
     if inventory is None:
         dev_id: str | None = None
         if isinstance(entry_data, Mapping):
@@ -801,14 +600,9 @@ def heater_platform_details_for_entry(
         )
         raise ValueError("TermoWeb inventory unavailable for heater platform")
 
-    _, addrs_by_type, resolve_name = heater_platform_details_from_inventory(
-        inventory,
-        default_name_simple=default_name_simple,
-    )
     return HeaterPlatformDetails(
         inventory=inventory,
-        address_map=addrs_by_type,
-        resolve_name=resolve_name,
+        default_name_simple=default_name_simple,
     )
 
 
@@ -826,6 +620,7 @@ class HeaterNodeBase(CoordinatorEntity):
         *,
         device_name: str | None = None,
         node_type: str | None = None,
+        inventory: Inventory | None = None,
     ) -> None:
         """Initialise a heater entity tied to a TermoWeb device."""
         super().__init__(coordinator)
@@ -848,6 +643,7 @@ class HeaterNodeBase(CoordinatorEntity):
         )
         self._device_name = device_name or name
         self._ws_subscription = DispatcherSubscriptionHelper(self)
+        self._inventory: Inventory | None = inventory
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to websocket updates once the entity is added to hass."""
@@ -935,39 +731,55 @@ class HeaterNodeBase(CoordinatorEntity):
     def _device_available(self, device_entry: dict[str, Any] | None) -> bool:
         """Return True when ``device_entry`` provides heater metadata for this node."""
 
-        if not isinstance(device_entry, Mapping):
+        inventory = self._resolve_inventory()
+        if not isinstance(inventory, Inventory):
             return False
 
         node_type = getattr(self, "_node_type", "htr")
-
-        if self._extract_device_addresses(device_entry, node_type):
-            return True
-
-        resolution = resolve_record_inventory(device_entry)
-        inventory = resolution.inventory if resolution is not None else None
-        supporting_metadata = isinstance(inventory, Inventory)
-
-        settings = device_entry.get("settings")
-        if isinstance(settings, Mapping):
-            node_settings = settings.get(node_type)
-            if isinstance(node_settings, Mapping) and node_settings:
-                return True
-
-        return supporting_metadata
+        forward_map, _ = inventory.heater_address_map
+        return self._addr in forward_map.get(node_type, [])
 
     def _device_record(self) -> dict[str, Any] | None:
         """Return the coordinator cache entry for this device."""
         data = getattr(self.coordinator, "data", {}) or {}
         getter = getattr(data, "get", None)
 
-        if callable(getter):
-            record = getter(self._dev_id)
-        elif isinstance(data, dict):
-            record = dict.get(data, self._dev_id)
-        else:
+        try:
+            if callable(getter):
+                record = getter(self._dev_id)
+            elif isinstance(data, dict):
+                record = dict.get(data, self._dev_id)
+            else:
+                return None
+        except Exception:  # pragma: no cover - defensive
+            _LOGGER.debug(
+                "Failed to resolve device record for %s", self._dev_id, exc_info=True
+            )
             return None
 
         return record if isinstance(record, dict) else None
+
+    def _resolve_inventory(self) -> Inventory | None:
+        """Return the cached inventory for this entity, if available."""
+
+        inventory = getattr(self, "_inventory", None)
+        if isinstance(inventory, Inventory):
+            return inventory
+
+        coordinator_inventory = getattr(self.coordinator, "inventory", None)
+        if isinstance(coordinator_inventory, Inventory):
+            self._inventory = coordinator_inventory
+            return coordinator_inventory
+
+        record = self._device_record()
+        if isinstance(record, Mapping):
+            resolution = resolve_record_inventory(record)
+            candidate = resolution.inventory if resolution is not None else None
+            if isinstance(candidate, Inventory):
+                self._inventory = candidate
+                return candidate
+
+        return None
 
     def _heater_section(self) -> dict[str, Any]:
         """Return the heater-specific metadata cached for this entity."""
@@ -977,7 +789,11 @@ class HeaterNodeBase(CoordinatorEntity):
             return {}
 
         node_type = getattr(self, "_node_type", "htr")
-        addresses = self._extract_device_addresses(record, node_type)
+        addresses: list[str] = []
+        inventory = self._resolve_inventory()
+        if isinstance(inventory, Inventory):
+            forward_map, _ = inventory.heater_address_map
+            addresses = list(forward_map.get(node_type, []))
 
         settings = {}
         cached_settings = record.get("settings")
@@ -987,7 +803,7 @@ class HeaterNodeBase(CoordinatorEntity):
                 settings = node_settings
 
         if not addresses and settings:
-            addresses = list(settings)
+            addresses = [addr for addr in settings if isinstance(addr, str)]
 
         return {"addrs": addresses, "settings": settings}
 
@@ -999,48 +815,6 @@ class HeaterNodeBase(CoordinatorEntity):
             return None
         settings = settings_map.get(self._addr)
         return settings if isinstance(settings, dict) else None
-
-    @staticmethod
-    def _normalise_addresses(addresses: Iterable[Any]) -> list[str]:
-        """Return a list of normalised addresses from ``addresses``."""
-
-        normalised: list[str] = []
-        seen: set[str] = set()
-
-        for candidate in addresses:
-            addr = normalize_node_addr(candidate, use_default_when_falsey=True)
-            if not addr or addr in seen:
-                continue
-            seen.add(addr)
-            normalised.append(addr)
-
-        return normalised
-
-    def _extract_device_addresses(
-        self, device_entry: Mapping[str, Any], node_type: str
-    ) -> list[str]:
-        """Return all known addresses for ``node_type`` from ``device_entry``."""
-
-        addresses: list[str] = []
-        seen: set[str] = set()
-
-        def _add(candidates: Iterable[Any]) -> None:
-            for addr in self._normalise_addresses(candidates):
-                if addr in seen:
-                    continue
-                seen.add(addr)
-                addresses.append(addr)
-
-        resolution = resolve_record_inventory(device_entry)
-        inventory = resolution.inventory if resolution is not None else None
-        if isinstance(inventory, Inventory):
-            forward_map, _ = inventory.heater_address_map
-            _add(forward_map.get(node_type, ()))
-            if not addresses:
-                node_bucket = inventory.nodes_by_type.get(node_type, [])
-                _add(getattr(node, "addr", "") for node in node_bucket)
-
-        return addresses
 
     def _hass_for_runtime(self) -> HomeAssistant | None:
         """Return the best-effort Home Assistant instance for runtime access."""

--- a/custom_components/termoweb/select.py
+++ b/custom_components/termoweb/select.py
@@ -21,7 +21,7 @@ from .heater import (
     set_boost_runtime_minutes,
 )
 from .identifiers import build_heater_entity_unique_id
-from .inventory import boostable_accumulator_details_for_entry
+from .inventory import Inventory, boostable_accumulator_details_for_entry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
     default_name = lambda addr: f"Heater {addr}"
-    _, accumulator_nodes = boostable_accumulator_details_for_entry(
+    heater_details, accumulator_nodes = boostable_accumulator_details_for_entry(
         data,
         default_name_simple=default_name,
         platform_name="select",
@@ -57,6 +57,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 base_name,
                 unique_id,
                 node_type=node_type,
+                inventory=heater_details.inventory,
             )
         )
 
@@ -89,6 +90,7 @@ class AccumulatorBoostDurationSelect(RestoreEntity, HeaterNodeBase, SelectEntity
         unique_id: str,
         *,
         node_type: str | None = None,
+        inventory: Inventory | None = None,
     ) -> None:
         """Initialise the boost duration selector for an accumulator."""
 
@@ -102,6 +104,7 @@ class AccumulatorBoostDurationSelect(RestoreEntity, HeaterNodeBase, SelectEntity
             unique_id,
             device_name=base_name,
             node_type=node_type,
+            inventory=inventory,
         )
         self._attr_name = "Boost duration"
         self._attr_options = list(self._OPTION_MAP.keys())

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -19,6 +19,7 @@ import pytest
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 
 from custom_components.termoweb import (
+    heater as heater_module,
     identifiers as identifiers_module,
     inventory as inventory_module,
 )
@@ -1351,13 +1352,17 @@ def test_energy_polling_matches_import(monkeypatch: pytest.MonkeyPatch) -> None:
             raw_nodes,
             inventory_module.build_node_inventory(raw_nodes),
         )
+        details = heater_module.HeaterPlatformDetails(
+            inventory,
+            lambda addr: f"Node {addr}",
+        )
         total_entity = sensor_mod.InstallationTotalEnergySensor(
             coordinator,
             "entry",
             "dev",
             "Total",
             "total_uid",
-            inventory,
+            details,
         )
 
         assert energy_entity.native_value == pytest.approx(1.3)


### PR DESCRIPTION
## Summary
- rewrite the heater inventory name map to operate directly on sanitized node payloads and expose Inventory.resolve_heater_name
- refactor HeaterPlatformDetails, platform setups, and HeaterNodeBase to share the immutable Inventory instead of rebuilding address/name caches
- update heater platform tests to align with the new helpers and cover the adjusted availability and boost metadata behaviour

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68eb698d57dc8329b3a3573602e740c8