### PR TITLE
Refactor boost metadata iteration to use inventory caches

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -57,21 +57,29 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     default_name_simple = lambda addr: f"Heater {addr}"
     new_entities: list[ClimateEntity] = []
-    for metadata in iter_inventory_heater_metadata(
+    for node_type, addr_str, resolved_name, node in iter_inventory_heater_metadata(
         inventory,
         default_name_simple=default_name_simple,
     ):
-        node_type = metadata.node_type
-        addr_str = metadata.addr
-        resolved_name = metadata.name
         unique_id = build_heater_entity_unique_id(
             dev_id,
             node_type,
             addr_str,
             ":climate",
         )
+        supports = False
+        candidate = getattr(node, "supports_boost", None)
+        if isinstance(candidate, bool):
+            supports = candidate
+        elif callable(candidate):
+            try:
+                supports = bool(candidate())
+            except Exception:  # noqa: BLE001 - defensive
+                _LOGGER.debug(
+                    "Ignoring boost support probe failure for node %s", addr_str, exc_info=True
+                )
         entity_cls: type[HeaterClimateEntity]
-        if node_type == "acm" or metadata.supports_boost:
+        if node_type == "acm" or supports:
             entity_cls = AccumulatorClimateEntity
         else:
             entity_cls = HeaterClimateEntity

--- a/tests/test_boost_additional.py
+++ b/tests/test_boost_additional.py
@@ -95,11 +95,13 @@ def test_iter_inventory_heater_metadata_covers_branch_variants(
 
     results = list(boost_module.iter_inventory_heater_metadata(inventory))
 
-    assert [(item.node_type, item.addr) for item in results] == [
+    assert [
+        (node_type, addr) for node_type, addr, _, _ in results
+    ] == [
         ("htr", "4"),
         ("acm", "5"),
     ]
-    assert results[0].name == "htr:4"
-    assert results[0].supports_boost is False
-    assert results[1].name == "acm:5"
-    assert results[1].supports_boost is True
+    assert results[0][2] == "htr:4"
+    assert boost_module.supports_boost(results[0][3]) is False
+    assert results[1][2] == "acm:5"
+    assert boost_module.supports_boost(results[1][3]) is True

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -652,17 +652,20 @@ def test_iter_inventory_heater_metadata_uses_inventory() -> None:
         )
     )
 
-    pairs = sorted((item.node_type, item.addr) for item in results)
+    pairs = sorted((node_type, addr) for node_type, addr, _, _ in results)
     assert pairs == sorted([
         ("htr", "1"),
         ("acm", "2"),
         ("acm", "3"),
     ])
-    names = {item.addr: item.name for item in results}
+    names = {addr: name for _, addr, name, _ in results}
     assert names["1"] == "Living"
     assert names["2"] == "Accumulator 2"
     assert names["3"] == "Storage"
-    supports = {item.addr: item.supports_boost for item in results}
+    supports = {
+        addr: boost_module.supports_boost(node)
+        for _, addr, _, node in results
+    }
     assert supports == {"1": False, "2": True, "3": True}
 
 
@@ -703,12 +706,12 @@ def test_iter_inventory_heater_metadata_uses_helper(
     )
 
     assert len(results) == 1
-    metadata = results[0]
-    assert metadata.node is node
-    assert metadata.node_type == "acm"
-    assert metadata.addr == "2"
-    assert metadata.name == "Resolved acm 2"
-    assert metadata.supports_boost is True
+    node_type, addr, name, resolved_node = results[0]
+    assert resolved_node is node
+    assert node_type == "acm"
+    assert addr == "2"
+    assert name == "Resolved acm 2"
+    assert boost_module.supports_boost(resolved_node) is True
 
 
 def test_iter_inventory_heater_metadata_handles_missing() -> None:


### PR DESCRIPTION
## Summary
- iterate boost inventory metadata using cached heater maps instead of rebuilding lookups
- update climate setup and unit tests to consume the tuple-based metadata records

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb6f1982e48329abed039c286b13fe