### PR TITLE
Simplify Ducaheat websocket inventory usage

### DIFF
--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -131,4 +131,7 @@ def test_dispatch_nodes_uses_inventory_addresses() -> None:
     dispatched = client._dispatcher.call_args[0][2]
     assert dispatched["addr_map"]["htr"] == ["1"]
     assert dispatched["addresses_by_type"]["htr"] == ["1"]
+    sample_aliases = client.hass.data[DOMAIN][client.entry_id].get("sample_aliases")
+    assert sample_aliases is not None
+    assert sample_aliases.get("htr") == "htr"
 


### PR DESCRIPTION
## Summary
- have the Ducaheat websocket dispatch use the shared Inventory for address lists and alias propagation instead of rebuilding local caches
- source subscription paths directly from Inventory heater targets and capture alias metadata during subscription
- update the websocket tests to assert the new alias handling and coordinator subscription expectations

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68eb6fd252508329ac70be80395273e0