### PR TITLE
Remove websocket inventory fallbacks

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable, Mapping, MutableMapping, Callable
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
 import logging
 import time
@@ -24,14 +24,9 @@ from ..const import (
 )
 from ..inventory import (
     HEATER_NODE_TYPES,
-    NODE_CLASS_BY_TYPE,
     Inventory,
-    addresses_by_node_type,
-    normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
-    normalize_power_monitor_addresses,
-    resolve_record_inventory,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -535,9 +530,7 @@ class NodeDispatchContext:
     """Container for shared node dispatch metadata."""
 
     payload: Any
-    inventory: Inventory
-    addr_map: dict[str, list[str]]
-    unknown_types: set[str]
+    inventory: Inventory | None
     record: MutableMapping[str, Any] | None
 
 
@@ -560,16 +553,6 @@ def _prepare_nodes_dispatch(
         record_raw if isinstance(record_raw, MutableMapping) else None
     )
 
-    dev_id = str(getattr(coordinator, "_dev_id", "") or "")
-    if not dev_id:
-        dev_id = str(getattr(coordinator, "dev_id", "") or "")
-    if not dev_id and isinstance(record_mapping, Mapping):
-        candidate = record_mapping.get("dev_id")
-        if isinstance(candidate, str):
-            dev_id = candidate
-        elif candidate not in (None, ""):
-            dev_id = str(candidate)
-
     inventory_container: Inventory | None = None
     if isinstance(inventory, Inventory):
         inventory_container = inventory
@@ -577,85 +560,20 @@ def _prepare_nodes_dispatch(
         candidate_inventory = record_mapping.get("inventory")
         if isinstance(candidate_inventory, Inventory):
             inventory_container = candidate_inventory
-    else:
-        inventory_container = None
 
     if inventory_container is None and hasattr(coordinator, "inventory"):
-        candidate_inventory = coordinator.inventory
+        candidate_inventory = getattr(coordinator, "inventory", None)
         if isinstance(candidate_inventory, Inventory):
             inventory_container = candidate_inventory
 
-    if inventory_container is None:
-        resolution = resolve_record_inventory(
-            record_mapping,
-            dev_id=dev_id or None,
-            nodes_payload=raw_nodes,
-        )
-        if resolution.inventory is not None:
-            inventory_container = resolution.inventory
-
-    if inventory_container is None:
-        payload_for_inventory = raw_nodes if raw_nodes is not None else {}
-        inventory_container = Inventory(dev_id, payload_for_inventory, [])
-
-    if isinstance(record_mutable, MutableMapping):
+    if isinstance(record_mutable, MutableMapping) and isinstance(
+        inventory_container, Inventory
+    ):
         record_mutable["inventory"] = inventory_container
 
-    normalized_known_types: set[str] = {
-        normalised
-        for normalised in (
-            normalize_node_type(node_type, use_default_when_falsey=True)
-            for node_type in NODE_CLASS_BY_TYPE
-        )
-        if normalised
-    }
-
-    addr_map: dict[str, list[str]]
-    unknown_types: set[str]
-    if isinstance(inventory_container, Inventory):
-        addr_map = {
-            node_type: list(addresses)
-            for node_type, addresses in inventory_container.addresses_by_type.items()
-        }
-        unknown_types = (
-            {
-                node_type
-                for node_type in addr_map
-                if normalized_known_types and node_type not in normalized_known_types
-            }
-            if normalized_known_types
-            else set()
-        )
-    else:
-        nodes_source = getattr(inventory_container, "nodes", ())
-        addr_map_raw, unknown_types = addresses_by_node_type(
-            nodes_source, known_types=NODE_CLASS_BY_TYPE
-        )
-        addr_map = {
-            node_type: list(addrs)
-            for node_type, addrs in addr_map_raw.items()
-        }
-
-    raw_nodes_for_context = raw_nodes if not isinstance(inventory_container, Inventory) else None
-
-    if hasattr(coordinator, "update_nodes"):
-        coordinator.update_nodes(None, inventory_container)
-
-    normalized_unknown: set[str] = {
-        node_str
-        for node_str in (
-            str(node_type).strip()
-            for node_type in unknown_types
-            if node_type is not None
-        )
-        if node_str
-    }
-
     return NodeDispatchContext(
-        payload=raw_nodes_for_context,
+        payload=raw_nodes,
         inventory=inventory_container,
-        addr_map=addr_map,
-        unknown_types=normalized_unknown,
         record=record_mutable,
     )
 
@@ -749,14 +667,14 @@ class _WSCommon(_WSStatusMixin):
 
     def _apply_heater_addresses(
         self,
-        normalized_map: Mapping[Any, Iterable[Any]] | None,
+        _nodes_payload: Any,
         *,
         inventory: Inventory | None = None,
         log_prefix: str = "WS",
         logger: logging.Logger | None = None,
+        prefer_inventory: bool = True,
     ) -> dict[str, list[str]]:
         """Update entry and coordinator state with heater address data."""
-
         record_container = self.hass.data.get(DOMAIN, {})
         record_raw = (
             record_container.get(self.entry_id)
@@ -767,109 +685,83 @@ class _WSCommon(_WSStatusMixin):
         record_mutable: MutableMapping[str, Any] | None = (
             record_raw if isinstance(record_raw, MutableMapping) else None
         )
-
-        if isinstance(inventory, Inventory):
-            inventory_container: Inventory | None = inventory
-        elif inventory is None:
-            inventory_container = (
-                self._inventory if isinstance(self._inventory, Inventory) else None
-            )
-        else:
-            active_logger = logger or _LOGGER
-            active_logger.debug(
-                "%s: ignoring unexpected inventory container (type=%s): %s",
-                log_prefix,
-                type(inventory).__name__,
-                inventory,
-            )
-            inventory_container = None
+        record_mapping = record_raw if isinstance(record_raw, Mapping) else None
 
         active_logger = logger or _LOGGER
 
-        fallback_heater_map, fallback_heater_aliases = normalize_heater_addresses(
-            normalized_map
-        )
-        fallback_power_map, fallback_power_aliases = normalize_power_monitor_addresses(
-            normalized_map
-        )
-
-        if isinstance(inventory_container, Inventory):
-            try:
-                inventory_heater_map, heater_aliases = (
-                    inventory_container.heater_sample_address_map
-                )
-            except Exception:  # pragma: no cover - defensive cache guard
-                active_logger.debug(
-                    "%s: failed to resolve heater sample addresses from inventory",
-                    log_prefix,
-                    exc_info=True,
-                )
-                inventory_heater_map = {}
-                heater_aliases = {}
-            try:
-                inventory_power_map, power_aliases = (
-                    inventory_container.power_monitor_sample_address_map
-                )
-            except Exception:  # pragma: no cover - defensive cache guard
-                active_logger.debug(
-                    "%s: failed to resolve power monitor sample addresses",
-                    log_prefix,
-                    exc_info=True,
-                )
-                inventory_power_map = {}
-                power_aliases = {}
-
-            heater_map: dict[str, list[str]] = dict(inventory_heater_map)
-            power_map: dict[str, list[str]] = dict(inventory_power_map)
-
-            for node_type, addresses in fallback_heater_map.items():
-                if node_type not in heater_map or not heater_map.get(node_type):
-                    if addresses:
-                        heater_map[node_type] = addresses
-
-            if fallback_power_map.get("pmo") and not power_map.get("pmo"):
-                power_map["pmo"] = fallback_power_map["pmo"]
+        inventory_container: Inventory | None = None
+        if isinstance(inventory, Inventory):
+            inventory_container = inventory
         else:
-            heater_map = fallback_heater_map
-            heater_aliases = fallback_heater_aliases
-            power_map = fallback_power_map
-            power_aliases = fallback_power_aliases
+            if inventory is not None:
+                active_logger.debug(
+                    "%s: ignoring unexpected inventory container (type=%s): %s",
+                    log_prefix,
+                    type(inventory).__name__,
+                    inventory,
+                )
+            if prefer_inventory:
+                if isinstance(self._inventory, Inventory):
+                    inventory_container = self._inventory
+                elif isinstance(record_mapping, Mapping):
+                    candidate_inventory = record_mapping.get("inventory")
+                    if isinstance(candidate_inventory, Inventory):
+                        inventory_container = candidate_inventory
+
+        if not isinstance(inventory_container, Inventory):
+            active_logger.error(
+                "%s: missing inventory for heater address update on %s",
+                log_prefix,
+                self.dev_id,
+            )
+            return {}
+
+        try:
+            inventory_heater_map, _ = inventory_container.heater_sample_address_map
+        except Exception:  # pragma: no cover - defensive cache guard
+            active_logger.debug(
+                "%s: failed to resolve heater sample addresses from inventory",
+                log_prefix,
+                exc_info=True,
+            )
+            return {}
+
+        try:
+            inventory_power_map, _ = (
+                inventory_container.power_monitor_sample_address_map
+            )
+        except Exception:  # pragma: no cover - defensive cache guard
+            active_logger.debug(
+                "%s: failed to resolve power monitor sample addresses",
+                log_prefix,
+                exc_info=True,
+            )
+            inventory_power_map = {}
 
         cleaned_map: dict[str, list[str]] = {
-            node_type: addresses
-            for node_type, addresses in heater_map.items()
-            if node_type in HEATER_NODE_TYPES
+            node_type: list(addresses)
+            for node_type, addresses in inventory_heater_map.items()
         }
-        if "htr" not in cleaned_map:
-            cleaned_map["htr"] = heater_map.get("htr", [])
 
-        pmo_addresses = power_map.get("pmo", [])
+        for node_type in HEATER_NODE_TYPES:
+            cleaned_map.setdefault(node_type, [])
+
+        pmo_addresses = inventory_power_map.get("pmo", [])
         if pmo_addresses:
-            cleaned_map["pmo"] = pmo_addresses
+            cleaned_map["pmo"] = list(pmo_addresses)
 
-        if isinstance(inventory_container, Inventory):
-            if isinstance(record_mutable, MutableMapping):
-                record_mutable["inventory"] = inventory_container
-            if not isinstance(self._inventory, Inventory):
-                self._inventory = inventory_container
-
-        sample_aliases = dict(heater_aliases)
-        sample_aliases.update(power_aliases)
-        for alias, target in fallback_heater_aliases.items():
-            sample_aliases.setdefault(alias, target)
-        for alias, target in fallback_power_aliases.items():
-            sample_aliases.setdefault(alias, target)
         if isinstance(record_mutable, MutableMapping):
-            record_mutable["sample_aliases"] = sample_aliases
+            record_mutable["inventory"] = inventory_container
+            record_mutable.pop("sample_aliases", None)
+        if not isinstance(self._inventory, Inventory):
+            self._inventory = inventory_container
 
         energy_coordinator = (
             record.get("energy_coordinator") if isinstance(record, Mapping) else None
         )
 
         if hasattr(energy_coordinator, "update_addresses"):
-            energy_coordinator.update_addresses(
-                inventory_container if isinstance(inventory_container, Inventory) else None
-            )
+            energy_coordinator.update_addresses(inventory_container)
 
         return cleaned_map
 
@@ -883,55 +775,28 @@ class _WSCommon(_WSStatusMixin):
             inventory=self._inventory,
         )
         inventory = context.inventory if isinstance(context.inventory, Inventory) else None
-        normalized_map: Mapping[Any, Iterable[Any]] | None = (
-            context.addr_map if isinstance(context.addr_map, Mapping) else None
-        )
+        if inventory is not None and not isinstance(self._inventory, Inventory):
+            self._inventory = inventory
+
         self._apply_heater_addresses(
-            normalized_map,
+            raw_nodes,
             inventory=inventory,
             log_prefix="WS",
             logger=_LOGGER,
         )
 
-        addresses_by_type: dict[str, list[str]] = {}
-        if inventory is not None:
-            try:
-                inventory_map = inventory.addresses_by_type
-            except Exception:  # pragma: no cover - defensive cache guard
-                _LOGGER.debug(
-                    "WS: failed to resolve inventory addresses; falling back to addr_map",
-                    exc_info=True,
-                )
-                inventory_map = None
-            else:
-                inventory_map = (
-                    dict(inventory_map) if isinstance(inventory_map, Mapping) else None
-                )
-            if isinstance(inventory_map, Mapping):
-                extracted: dict[str, list[str]] = {}
-                for node_type, addresses in inventory_map.items():
-                    if isinstance(addresses, Iterable) and not isinstance(
-                        addresses, (str, bytes)
-                    ):
-                        extracted[node_type] = list(addresses)
-                        continue
-                    normalised = normalize_node_addr(
-                        addresses, use_default_when_falsey=True
-                    )
-                    extracted[node_type] = [normalised] if normalised else []
-                addresses_by_type = extracted
-        if not addresses_by_type and isinstance(normalized_map, Mapping):
-            addresses_by_type = {
-                node_type: [
-                    addr
-                    for addr in (
-                        normalize_node_addr(candidate, use_default_when_falsey=True)
-                        for candidate in addresses
-                    )
-                    if addr
-                ]
-                for node_type, addresses in normalized_map.items()
-            }
+        if not isinstance(inventory, Inventory):
+            _LOGGER.error("WS: missing inventory for dispatch on device %s", self.dev_id)
+            return
+
+        try:
+            addresses_by_type = inventory.addresses_by_type
+        except Exception:  # pragma: no cover - defensive cache guard
+            _LOGGER.debug(
+                "WS: failed to resolve inventory addresses; using empty payload",
+                exc_info=True,
+            )
+            addresses_by_type: dict[str, list[str]] = {}
         payload_copy = {
             "dev_id": self.dev_id,
             "node_type": None,

--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -101,11 +101,7 @@ def test_apply_heater_addresses_updates_state() -> None:
     assert client._inventory is inventory
     energy_coordinator.update_addresses.assert_called_once_with(inventory)
 
-    sample_aliases = hass.data[DOMAIN]["entry"].get("sample_aliases")
-    assert sample_aliases is not None
-    for alias_map in (heater_aliases, power_aliases):
-        for alias, target in alias_map.items():
-            assert sample_aliases.get(alias) == target
+    assert "sample_aliases" not in hass.data[DOMAIN]["entry"]
 
 
 def test_dispatch_nodes_uses_inventory_addresses() -> None:
@@ -131,7 +127,7 @@ def test_dispatch_nodes_uses_inventory_addresses() -> None:
     dispatched = client._dispatcher.call_args[0][2]
     assert dispatched["addr_map"]["htr"] == ["1"]
     assert dispatched["addresses_by_type"]["htr"] == ["1"]
-    sample_aliases = client.hass.data[DOMAIN][client.entry_id].get("sample_aliases")
-    assert sample_aliases is not None
-    assert sample_aliases.get("htr") == "htr"
+    assert (
+        "sample_aliases" not in client.hass.data[DOMAIN][client.entry_id]
+    )
 

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -321,17 +321,12 @@ def test_dispatch_nodes_publishes_inventory_addresses(
     addresses = dispatched["addresses_by_type"]
     assert addresses == expected_addresses
     assert dispatched.get("addr_map", addresses) == addresses
-    coordinator.update_nodes.assert_called_once()
-    update_args = coordinator.update_nodes.call_args[0]
-    assert update_args[0] is None
-    assert update_args[1] is inventory
+    coordinator.update_nodes.assert_not_called()
     assert client._inventory.addresses_by_type["htr"] == ["1"]
 
     record = hass.data[ducaheat_ws.DOMAIN][client.entry_id]
     assert record.get("inventory") is inventory
-    sample_aliases = record.get("sample_aliases")
-    assert sample_aliases is not None
-    assert sample_aliases.get("htr") == "htr"
+    assert "sample_aliases" not in record
     energy_coordinator.update_addresses.assert_called_once_with(inventory)
 
 
@@ -368,7 +363,7 @@ def test_incremental_updates_preserve_address_payload(
     addresses = dispatched["addresses_by_type"]
     assert addresses == expected_addresses
     assert dispatched.get("addr_map", addresses) == addresses
-    assert coordinator.update_nodes.call_count == 2
+    assert coordinator.update_nodes.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -741,11 +736,7 @@ async def test_read_loop_updates_ws_state_on_dev_data(
     assert ws_state["status"] == "healthy"
     assert ws_state["healthy_since"] == base_ts
     assert ws_state["last_event_at"] == base_ts
-    client._coordinator.update_nodes.assert_called_once()
-    update_args, update_kwargs = client._coordinator.update_nodes.call_args
-    assert not update_kwargs
-    assert update_args[0] is None
-    assert isinstance(update_args[1], Inventory)
+    client._coordinator.update_nodes.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- enforce the reuse of shared inventory containers in websocket dispatch helpers and drop payload-derived fallbacks
- simplify the TermoWeb heater subscription target resolution to rely solely on inventory metadata
- update websocket test suites to assert the inventory-only heater and power address flow

## Testing
- `pytest --cov=custom_components.termoweb --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68eb73d1bdbc8329bf173b19388ca4fe