### PR TITLE
Require explicit inventory objects for coordinators

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,42 +24,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
-def _split_inventory_payload(
-    node_inventory: Any,
-) -> tuple["Inventory" | None, list[Any] | None]:
-    """Return the inventory object and node list when ``node_inventory`` is provided."""
-
-    try:
-        from custom_components.termoweb.inventory import Inventory as InventoryType
-    except ImportError:
-        InventoryType = None  # type: ignore[assignment]
-
-    if InventoryType is not None and isinstance(node_inventory, InventoryType):
-        return node_inventory, list(node_inventory.nodes)
-    if node_inventory is None:
-        return None, None
-    return None, list(node_inventory)
-
-
-def _resolve_inventory_container(
-    dev_id: str,
-    inventory: Any,
-    *,
-    payload_override: Mapping[str, Any] | None = None,
-    nodes_override: Iterable[Any] | None = None,
-) -> tuple["Inventory" | None, list[Any]]:
-    """Return normalised inventory container and node list."""
-
-    container, nodes_list = _split_inventory_payload(inventory)
-    if payload_override is None and nodes_override is None:
-        if container is not None:
-            return container, list(nodes_list or [])
-        if nodes_list is not None:
-            return None, list(nodes_list)
-        return None, []
-
-    if container is None and payload_override is None and nodes_override is not None:
-        return None, list(nodes_override)
+def _coerce_inventory(inventory: Any) -> tuple["Inventory" | None, list[Any]]:
+    """Return an ``Inventory`` and cached node list when available."""
 
     try:
         from custom_components.termoweb.inventory import Inventory as InventoryType
@@ -67,40 +33,12 @@ def _resolve_inventory_container(
         InventoryType = None  # type: ignore[assignment]
 
     if InventoryType is None:
-        if container is not None:
-            return container, list(nodes_list or [])
-        if nodes_override is not None:
-            return None, list(nodes_override)
-        if nodes_list is not None:
-            return None, list(nodes_list)
         return None, []
 
-    effective_dev_id = getattr(container, "dev_id", dev_id)
-    if payload_override is not None:
-        payload_value: Any = (
-            dict(payload_override)
-            if isinstance(payload_override, Mapping)
-            else payload_override
-        )
-    elif container is not None:
-        payload_source = getattr(container, "payload", {})
-        payload_value = (
-            dict(payload_source) if isinstance(payload_source, Mapping) else payload_source
-        )
-    else:
-        payload_value = {}
+    if isinstance(inventory, InventoryType):
+        return inventory, list(inventory.nodes)
 
-    if nodes_override is not None:
-        nodes_value: Iterable[Any] = nodes_override
-    elif container is not None:
-        nodes_value = getattr(container, "nodes", ())
-    elif nodes_list is not None:
-        nodes_value = nodes_list
-    else:
-        nodes_value = ()
-
-    new_container = InventoryType(effective_dev_id, payload_value, list(nodes_value))
-    return new_container, list(new_container.nodes)
+    return None, []
 
 
 _frame_module: Any | None = None
@@ -1781,10 +1719,8 @@ class FakeCoordinator:
         dev_id: str = "dev",
         dev: dict[str, Any] | None = None,
         nodes: dict[str, Any] | None = None,
-        inventory: Iterable[Any] | "Inventory" | None = None,
+        inventory: "Inventory" | None = None,
         *,
-        inventory_payload: Mapping[str, Any] | None = None,
-        inventory_nodes: Iterable[Any] | None = None,
         data: dict[str, Any] | None = None,
     ) -> None:
         self.hass = hass
@@ -1793,12 +1729,7 @@ class FakeCoordinator:
         self.dev_id = dev_id
         self.dev = self._normalise_device_record(dev)
         self.nodes = nodes or {}
-        inventory_obj, nodes_list = _resolve_inventory_container(
-            dev_id,
-            inventory,
-            payload_override=inventory_payload,
-            nodes_override=inventory_nodes,
-        )
+        inventory_obj, nodes_list = _coerce_inventory(inventory)
         self.inventory: "Inventory" | None = inventory_obj
         self.node_inventory = list(nodes_list)
         self.update_interval = dt.timedelta(seconds=base_interval or 0)
@@ -1832,21 +1763,13 @@ class FakeCoordinator:
     def update_nodes(
         self,
         nodes: dict[str, Any],
-        inventory: Iterable[Any] | "Inventory" | None = None,
-        *,
-        inventory_payload: Mapping[str, Any] | None = None,
-        inventory_nodes: Iterable[Any] | None = None,
+        inventory: "Inventory" | None = None,
     ) -> None:
         self.nodes = nodes
-        inventory_obj, nodes_list = _resolve_inventory_container(
-            self.dev_id,
-            inventory,
-            payload_override=inventory_payload,
-            nodes_override=inventory_nodes,
-        )
+        inventory_obj, nodes_list = _coerce_inventory(inventory)
         if inventory_obj is not None:
             self.inventory = inventory_obj
-        elif inventory is not None or inventory_payload is not None or inventory_nodes is not None:
+        elif inventory is None:
             self.inventory = None
         self.node_inventory = list(nodes_list)
 

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -1271,11 +1271,17 @@ def test_energy_polling_matches_import(monkeypatch: pytest.MonkeyPatch) -> None:
             )
         )
 
+        raw_nodes = {"nodes": [{"type": "htr", "addr": "A"}]}
+        inventory = inventory_module.Inventory(
+            "dev",
+            raw_nodes,
+            inventory_module.build_node_inventory(raw_nodes),
+        )
         coordinator = coord_mod.EnergyStateCoordinator(
             hass,
             client,
             "dev",
-            ["A"],
+            inventory,
         )
 
         times = iter([10_000.0, 13_600.0])
@@ -1306,12 +1312,6 @@ def test_energy_polling_matches_import(monkeypatch: pytest.MonkeyPatch) -> None:
             "Heater A",
             "uid",
             "Device A",
-        )
-        raw_nodes = {"nodes": [{"type": "htr", "addr": "A"}]}
-        inventory = inventory_module.Inventory(
-            "dev",
-            raw_nodes,
-            inventory_module.build_node_inventory(raw_nodes),
         )
         details = heater_module.HeaterPlatformDetails(
             inventory,

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -316,7 +316,7 @@ def test_state_coordinator_logs_once_for_invalid_nodes(
     assert coordinator._inventory is invalid_inventory or coordinator._inventory is None
     assert sum(
         "Ignoring unexpected nodes payload" in message for message in caplog.messages
-    ) == 0
+    ) == 1
 
 
 def test_utils_normalization_matches_node_inventory() -> None:


### PR DESCRIPTION
## Summary
- stop rebuilding `Inventory` objects inside the state coordinator and require callers to supply cached metadata
- simplify the energy coordinator so it only accepts concrete inventories when refreshing addresses
- refresh coordinator-related tests to construct inventories via helpers and adjust expectations for the new behaviour

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb8ba8d0388329b7c0b467e532ec24