### PR TITLE
Ensure energy import requires inventory inputs

### DIFF
--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -323,7 +323,7 @@ async def _clear_statistics_compat(  # pragma: no cover - compatibility shim
 async def async_import_energy_history(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    nodes: Inventory | Mapping[str, Iterable[str]] | Iterable[str] | None = None,
+    nodes: Inventory | None = None,
     *,
     selection: Mapping[str, Iterable[str]]
     | Iterable[tuple[str, str]]
@@ -352,11 +352,13 @@ async def async_import_energy_history(
     dev_id: str = rec["dev_id"]
     stored_inventory = rec.get("inventory") if isinstance(rec, Mapping) else None
 
-    inventory_override = nodes if isinstance(nodes, Inventory) else None
-    if selection is not None:
-        selection_spec = selection
-    else:
-        selection_spec = None if inventory_override is not None else nodes
+    if nodes is not None and not isinstance(nodes, Inventory):
+        raise TypeError(
+            "async_import_energy_history nodes must be an Inventory instance"
+        )
+
+    inventory_override = nodes
+    selection_spec = selection
 
     inventory_container: Inventory | None
     resolution: Any | None = None

--- a/tests/test_import_energy_history.py
+++ b/tests/test_import_energy_history.py
@@ -827,6 +827,56 @@ def test_async_import_energy_history_skips_without_inventory(
     assert "dev-missing: unable to resolve node inventory" in caplog.text
 
 
+def test_async_import_energy_history_rejects_non_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        (
+            _mod,
+            energy_mod,
+            const,
+            _import_stats,
+            _update_meta,
+            _last_stats,
+            _get_period,
+            _delete_stats,
+            ConfigEntry,
+            HomeAssistant,
+            _ent_reg,
+        ) = await _load_module(monkeypatch)
+
+        hass = HomeAssistant()
+        hass.config_entries = types.SimpleNamespace(
+            async_update_entry=lambda *_args, **_kwargs: None
+        )
+        entry = ConfigEntry("reject")
+        hass.data = {
+            const.DOMAIN: {
+                entry.entry_id: {
+                    "client": AsyncMock(),
+                    "dev_id": "dev",
+                }
+            }
+        }
+
+        limiter = throttle_module.MonotonicRateLimiter(
+            lock=asyncio.Lock(),
+            monotonic=lambda: 0.0,
+            sleep=lambda _wait: asyncio.sleep(0),
+            min_interval=0.0,
+        )
+
+        with pytest.raises(TypeError, match="Inventory"):
+            await energy_mod.async_import_energy_history(
+                hass,
+                entry,
+                nodes={"htr": ["A"]},  # type: ignore[arg-type]
+                rate_limit=limiter,
+            )
+
+    asyncio.run(_run())
+
+
 def test_async_import_energy_history_uses_inventory_nodes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1162,15 +1212,21 @@ def test_import_energy_history_requested_map_filters(
                 {"type": "pmo", "addr": "ignored"},
             ]
         }
+        snapshot_inventory = inventory_module.Inventory(
+            "dev",
+            raw_nodes,
+            inventory_module.build_node_inventory(raw_nodes),
+        )
         snapshot = types.SimpleNamespace(
             dev_id="dev",
             raw_nodes=raw_nodes,
-            inventory=list(inventory_module.build_node_inventory(raw_nodes)),
+            inventory=snapshot_inventory,
         )
         hass.data[const.DOMAIN][entry.entry_id] = {
             "client": client,
             "dev_id": "dev",
-            "node_inventory": list(snapshot.inventory),
+            "inventory": snapshot_inventory,
+            "node_inventory": list(snapshot.inventory.nodes),
             "config_entry": entry,
             "snapshot": snapshot,
         }


### PR DESCRIPTION
## Summary
- require Inventory instances when passing the optional nodes argument to the energy history importer and reject invalid types
- streamline selection handling to rely on heater_sample_targets/address_map derived from the resolved inventory
- update energy history tests to build Inventory fixtures, add coverage for non-Inventory rejection, and adjust snapshot data

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb911876fc83298f13d5dbdf4f9303