### PR TITLE
Use inventory helper for boost binary sensors

### DIFF
--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import types
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -162,6 +163,49 @@ def test_binary_sensor_setup_requires_inventory(heater_hass_data) -> None:
             await async_setup_binary_sensor_entry(hass, entry, lambda _: None)
 
     asyncio.run(_run())
+
+
+def test_iter_boostable_inventory_nodes_uses_inventory_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inventory = Inventory("dev", {"nodes": []}, [])
+
+    meta: list[tuple[str, str, str, Any]] = [
+        (
+            "acm",
+            "01",
+            "Accumulator 01",
+            types.SimpleNamespace(supports_boost=lambda: False),
+        ),
+        (
+            "htr",
+            " 2 ",
+            "Heater 2",
+            types.SimpleNamespace(supports_boost=lambda: True),
+        ),
+        (
+            "",
+            "3",
+            "Invalid",
+            types.SimpleNamespace(supports_boost=lambda: True),
+        ),
+    ]
+
+    def _fake_iter(inv: Inventory):
+        assert inv is inventory
+        yield from meta
+
+    monkeypatch.setattr(
+        binary_sensor_module,
+        "iter_inventory_heater_metadata",
+        _fake_iter,
+    )
+
+    results = list(
+        binary_sensor_module._iter_boostable_inventory_nodes(inventory)
+    )
+
+    assert results == [("htr", "2", "Heater 2")]
 
 
 def test_refresh_button_device_info_and_press(heater_hass_data) -> None:


### PR DESCRIPTION
## Summary
- switch the boost binary sensor inventory loop to iter_inventory_heater_metadata
- add regression coverage verifying the helper is used and filtering works

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb96cb5d208329ac596ebf277ea273