### PR TITLE
Simplify boost heater metadata iteration

### DIFF
--- a/tests/test_boost_additional.py
+++ b/tests/test_boost_additional.py
@@ -74,7 +74,7 @@ def test_iter_inventory_heater_metadata_covers_branch_variants(
         " ": ["1"],
         "acm-empty": [],
         "htr": ["4"],
-        "acm": ["", "5"],
+        "acm": ["", "5", 6],
         "thm": ["7"],
     }
 

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -694,7 +694,7 @@ def test_iter_inventory_heater_metadata_uses_helper(
         assert default_name_simple is default_factory
         return (
             {"acm": [node]},
-            {"acm": ["2"]},
+            {"acm": [None, "2", ""]},
             lambda node_type, addr: f"Resolved {node_type} {addr}",
         )
 


### PR DESCRIPTION
## Summary
- simplify iter_inventory_heater_metadata to walk inventory metadata without intermediate lookup dicts
- extend boost-related tests to cover invalid heater addresses and ensure tuple payloads remain intact

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eb9824e4708329a3586593949ded2a