### PR TITLE
Refine Ducaheat websocket node handling

### DIFF
--- a/tests/test_ducaheat_ws_apply_nodes_raw_cache.py
+++ b/tests/test_ducaheat_ws_apply_nodes_raw_cache.py
@@ -1,0 +1,79 @@
+"""Tests verifying the Ducaheat websocket does not cache node snapshots."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Mapping
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+
+from tests.test_ducaheat_ws_protocol import (
+    QueueWebSocket,
+    _make_client,
+    _run_read_loop,
+)
+
+
+@pytest.mark.asyncio
+async def test_dev_data_snapshot_does_not_populate_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev_data snapshots should rely on the inventory without caching nodes."""
+
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(client, "_subscribe_feeds", AsyncMock(return_value=0))
+    dispatched: list[Mapping[str, Any]] = []
+    client._dispatcher = lambda *_args: dispatched.append(_args[2])
+
+    class DevDataWS(QueueWebSocket):
+        def __init__(self) -> None:
+            super().__init__(
+                [
+                    SimpleNamespace(
+                        type=aiohttp.WSMsgType.TEXT,
+                        data='442["dev_data",{"nodes":{"htr":{"status":{"1":{"power":5}}}}}]',
+                    )
+                ]
+            )
+
+    client._ws = DevDataWS()  # type: ignore[assignment]
+
+    await _run_read_loop(client)
+
+    assert getattr(client, "_nodes_raw", None) is None
+    assert dispatched
+    payload = dispatched[-1]
+    assert payload["addr_map"]["htr"] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_update_events_do_not_cache_nodes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Update events should flow through without retaining prior snapshots."""
+
+    client = _make_client(monkeypatch)
+    dispatched: list[Mapping[str, Any]] = []
+    client._dispatcher = lambda *_args: dispatched.append(_args[2])
+
+    class UpdateWS(QueueWebSocket):
+        def __init__(self) -> None:
+            super().__init__(
+                [
+                    SimpleNamespace(
+                        type=aiohttp.WSMsgType.TEXT,
+                        data='442["update",{"body":{"temp":19},"path":"/api/v2/devs/device/htr/1/status"}]',
+                    )
+                ]
+            )
+
+    client._ws = UpdateWS()  # type: ignore[assignment]
+
+    await _run_read_loop(client)
+
+    assert getattr(client, "_nodes_raw", None) is None
+    assert dispatched
+    payload = dispatched[-1]
+    assert payload["addr_map"]["htr"] == ["1"]

--- a/tests/test_ducaheat_ws_legacy_section.py
+++ b/tests/test_ducaheat_ws_legacy_section.py
@@ -51,7 +51,6 @@ def test_update_legacy_section_normalises_accumulator_settings() -> None:
     )
 
     client = _make_client(coordinator)
-    client._nodes_raw = {}
 
     body = {"mode": "auto", "boost": {"remaining": 3600}}
     dev_map: dict[str, Any] = {"settings": {}}
@@ -77,9 +76,7 @@ def test_update_legacy_section_normalises_accumulator_settings() -> None:
     assert stored_payload == {"mode": "auto", "boost": {"remaining": 3600}}
     assert stored_payload is not body
 
-    raw_payload = client._nodes_raw.get("acm", {}).get("settings", {}).get(" 02 ")
-    assert raw_payload == body
-    assert raw_payload is not body
+    assert getattr(client, "_nodes_raw", None) is None
 
 
 def test_update_legacy_section_rejects_non_mapping_section_map() -> None:
@@ -91,9 +88,6 @@ def test_update_legacy_section_rejects_non_mapping_section_map() -> None:
     )
 
     client = _make_client(coordinator)
-    existing_raw = {"acm": {"settings": {" 02 ": {"mode": "manual"}}}}
-    client._nodes_raw = deepcopy(existing_raw)
-
     dev_map: dict[str, Any] = {"settings": {"acm": ["invalid"]}}
     dev_map_snapshot = deepcopy(dev_map)
 
@@ -107,7 +101,7 @@ def test_update_legacy_section_rejects_non_mapping_section_map() -> None:
 
     assert updated is False
     assert dev_map == dev_map_snapshot
-    assert client._nodes_raw == existing_raw
+    assert getattr(client, "_nodes_raw", None) is None
     coordinator._apply_accumulator_boost_metadata.assert_not_called()
     coordinator._device_now_estimate.assert_not_called()
 


### PR DESCRIPTION
## Summary
- avoid caching `_nodes_raw` during Ducaheat websocket `dev_data` and `update` handling so inventory metadata drives downstream dispatch
- refresh Ducaheat websocket protocol and legacy-section tests and add coverage to ensure node snapshots are no longer cached

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eba86813788329896931042643248d