### PR TITLE
Stop caching websocket node payloads

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -670,60 +670,6 @@ class WebSocketClient(_WSCommon):
         if nodes is None:
             _LOGGER.debug("WS: %s without nodes", event)
             return
-        raw_store = getattr(self, "_nodes_raw", None)
-        if isinstance(raw_store, MutableMapping):
-            if not merge:
-                raw_store.clear()
-            for node_type, type_payload in nodes.items():
-                if not isinstance(node_type, str) or not isinstance(
-                    type_payload, Mapping
-                ):
-                    continue
-                existing_bucket = raw_store.get(node_type)
-                if isinstance(existing_bucket, MutableMapping):
-                    node_bucket = existing_bucket
-                elif isinstance(existing_bucket, Mapping):
-                    node_bucket = dict(existing_bucket)
-                    raw_store[node_type] = node_bucket
-                else:
-                    node_bucket = {}
-                    raw_store[node_type] = node_bucket
-                if not merge:
-                    node_bucket.clear()
-                for section, section_payload in type_payload.items():
-                    if not isinstance(section, str):
-                        continue
-                    if isinstance(section_payload, Mapping):
-                        existing_section = node_bucket.get(section)
-                        if isinstance(existing_section, MutableMapping):
-                            section_bucket = existing_section
-                        elif isinstance(existing_section, Mapping):
-                            section_bucket = dict(existing_section)
-                            node_bucket[section] = section_bucket
-                        else:
-                            section_bucket = {}
-                            node_bucket[section] = section_bucket
-                        if not merge:
-                            section_bucket.clear()
-                        for addr, value in section_payload.items():
-                            if isinstance(value, Mapping):
-                                existing_payload = section_bucket.get(addr)
-                                if isinstance(existing_payload, MutableMapping):
-                                    target_payload = existing_payload
-                                elif isinstance(existing_payload, Mapping):
-                                    target_payload = dict(existing_payload)
-                                    section_bucket[addr] = target_payload
-                                else:
-                                    target_payload = {}
-                                    section_bucket[addr] = target_payload
-                                if not merge:
-                                    target_payload.clear()
-                                for key, item in value.items():
-                                    target_payload[key] = deepcopy(item)
-                            else:
-                                section_bucket[addr] = deepcopy(value)
-                    else:
-                        node_bucket[section] = deepcopy(section_payload)
         normaliser = getattr(self._client, "normalise_ws_nodes", None)
         if callable(normaliser):
             try:

--- a/tests/test_termoweb_ws_apply_nodes_raw_cache.py
+++ b/tests/test_termoweb_ws_apply_nodes_raw_cache.py
@@ -1,4 +1,4 @@
-"""Tests for caching raw websocket node payloads."""
+"""Tests for websocket node payload forwarding without caching."""
 
 from __future__ import annotations
 
@@ -11,8 +11,8 @@ from tests.test_termoweb_ws_protocol import _make_client
 
 
 @pytest.mark.usefixtures("monkeypatch")
-def test_apply_nodes_payload_caches_deep_copy(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Caching should store a deep copy that is isolated from mutations."""
+def test_apply_nodes_payload_does_not_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runtime updates should be forwarded without duplicating node payloads."""
 
     client, _sio, _dispatcher = _make_client(monkeypatch)
     client._dispatch_nodes = MagicMock(return_value={})
@@ -27,47 +27,14 @@ def test_apply_nodes_payload_caches_deep_copy(monkeypatch: pytest.MonkeyPatch) -
                     "1": {"power": 5, "temp": 21},
                     "2": {"power": 3},
                 },
-                "settings": {"1": {"mode": "eco"}},
+                "samples": {"1": {"power": 12}},
             }
         }
     }
 
-    original_status = payload["nodes"]["htr"]["status"]["1"]
     client._apply_nodes_payload(payload, merge=True, event="update")
 
-    cached_status = client._nodes_raw["htr"]["status"]["1"]
-    assert cached_status == {"power": 5, "temp": 21}
-    assert cached_status is not original_status
-
-    payload["nodes"]["htr"]["status"]["1"]["temp"] = 42
-    payload["nodes"]["htr"]["status"]["2"]["power"] = 9
-    payload["nodes"]["htr"]["settings"]["1"]["mode"] = "comfort"
-
-    assert client._nodes_raw["htr"]["status"]["1"]["temp"] == 21
-    assert client._nodes_raw["htr"]["status"]["2"]["power"] == 3
-    assert client._nodes_raw["htr"]["settings"]["1"]["mode"] == "eco"
-
-    # Subsequent updates should merge into the cached copy without sharing references.
-    incremental = {
-        "nodes": {
-            "htr": {
-                "status": {"1": {"temp": 20}},
-                "settings": {"1": {"mode": "comfort"}},
-            }
-        }
-    }
-    client._apply_nodes_payload(incremental, merge=True, event="update")
-
-    assert client._nodes_raw["htr"]["status"]["1"] == {"power": 5, "temp": 20}
-    assert client._nodes_raw["htr"]["settings"]["1"] == {"mode": "comfort"}
-    assert client._nodes_raw["htr"]["status"]["1"] is not incremental["nodes"]["htr"]["status"]["1"]
-    assert (
-        client._nodes_raw["htr"]["settings"]["1"]
-        is not incremental["nodes"]["htr"]["settings"]["1"]
-    )
-
-    # Ensure the cached copy survives mutations of the incremental payload.
-    incremental["nodes"]["htr"]["status"]["1"]["temp"] = -5
-    incremental["nodes"]["htr"]["settings"]["1"]["mode"] = "away"
-    assert client._nodes_raw["htr"]["status"]["1"]["temp"] == 20
-    assert client._nodes_raw["htr"]["settings"]["1"]["mode"] == "comfort"
+    client._dispatch_nodes.assert_called_once_with(payload["nodes"])
+    client._forward_sample_updates.assert_called_once()
+    client._mark_event.assert_called_once()
+    assert client._nodes_raw == {}


### PR DESCRIPTION
## Summary
- stop `WebSocketClient._apply_nodes_payload` from cloning node payloads into `_nodes_raw`
- update the websocket test suite to assert forwarding behaviour without raw caching

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eba8674b3c8329946d4238f7f80059