### PR TITLE
Refactor boost heater metadata iteration

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -134,11 +134,9 @@ class HeaterPlatformDetails:
     def iter_metadata(self) -> Iterator[tuple[str, Node, str, str]]:
         """Yield heater metadata derived from the inventory."""
 
-        for node_type, addr, name, node in iter_inventory_heater_metadata(
-            self.inventory,
-            default_name_simple=self.default_name_simple,
-        ):
-            yield node_type, node, addr, name
+        yield from self.inventory.iter_heater_platform_metadata(
+            self.default_name_simple,
+        )
 
 
 def _boost_runtime_store(

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 from unittest.mock import MagicMock
@@ -675,10 +675,10 @@ def test_iter_inventory_heater_metadata_uses_inventory() -> None:
     assert supports == {"1": False, "2": True, "3": True}
 
 
-def test_iter_inventory_heater_metadata_uses_helper(
+def test_iter_inventory_heater_metadata_uses_inventory_method(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Generator should source node data from inventory helper."""
+    """Generator should source node data from inventory iterator."""
 
     inventory = Inventory("dev", {}, [])
     default_factory = lambda addr: f"Heater {addr}"
@@ -689,20 +689,12 @@ def test_iter_inventory_heater_metadata_uses_helper(
         supports_boost=lambda: "true",
     )
 
-    def _fake_helper(inv, *, default_name_simple):
-        assert inv is inventory
+    def _fake_iter(self: Inventory, default_name_simple: Callable[[str], str]):
+        assert self is inventory
         assert default_name_simple is default_factory
-        return (
-            {"acm": [node]},
-            {"acm": [None, "2", ""]},
-            lambda node_type, addr: f"Resolved {node_type} {addr}",
-        )
+        yield ("acm", node, "2", "Resolved acm 2")
 
-    monkeypatch.setattr(
-        boost_module,
-        "heater_platform_details_from_inventory",
-        _fake_helper,
-    )
+    monkeypatch.setattr(Inventory, "iter_heater_platform_metadata", _fake_iter)
 
     results = list(
         boost_module.iter_inventory_heater_metadata(


### PR DESCRIPTION
## Summary
- add an inventory helper that yields heater metadata without rebuilding lookup tables
- refactor boost helpers to use the streamlined iterator so metadata consumers keep the same payloads
- update boost-related tests to exercise the new helper behaviour

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68eba8592e2c8329a89c8e43d296d7dc