### PR TITLE
Ensure heaters require immutable inventory

### DIFF
--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -2100,6 +2100,7 @@ def test_heater_write_paths_and_errors(
         assert (
             "Optimistic update failed" in caplog.text
             or "Failed to resolve device record" in caplog.text
+            or "missing immutable inventory cache" in caplog.text
         )
         waiter = await _pop_waiter()
         task = heater._refresh_fallback
@@ -2172,6 +2173,7 @@ def test_heater_write_paths_and_errors(
         assert (
             "Optimistic update failed" in caplog.text
             or "Failed to resolve device record" in caplog.text
+            or "missing immutable inventory cache" in caplog.text
         )
         waiter = await _pop_waiter()
         task = heater._refresh_fallback


### PR DESCRIPTION
## Summary
- remove the device-record inventory reconstruction fallback from heater entities and raise when immutable inventory is missing
- adjust heater availability and metadata helpers along with the climate optimistic update tests to reflect the stricter inventory requirement
- update heater platform tests to pass explicit inventory fixtures and cover the missing-inventory log

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ebb07c4cdc83298f48dabc061a994a