### PR TITLE
Refactor websocket inventory handling

### DIFF
--- a/tests/test_termoweb_ws_apply_nodes_raw_cache.py
+++ b/tests/test_termoweb_ws_apply_nodes_raw_cache.py
@@ -18,8 +18,6 @@ def test_apply_nodes_payload_does_not_cache(monkeypatch: pytest.MonkeyPatch) -> 
     client._dispatch_nodes = MagicMock(return_value={})
     client._forward_sample_updates = MagicMock()
     client._mark_event = MagicMock()
-    client._nodes_raw = {}
-
     payload: dict[str, Any] = {
         "nodes": {
             "htr": {
@@ -32,9 +30,11 @@ def test_apply_nodes_payload_does_not_cache(monkeypatch: pytest.MonkeyPatch) -> 
         }
     }
 
+    assert not hasattr(client, "_nodes_raw")
+
     client._apply_nodes_payload(payload, merge=True, event="update")
 
     client._dispatch_nodes.assert_called_once_with(payload["nodes"])
     client._forward_sample_updates.assert_called_once()
     client._mark_event.assert_called_once()
-    assert client._nodes_raw == {}
+    assert not hasattr(client, "_nodes_raw")

--- a/tests/test_termoweb_ws_handle_event_invalid.py
+++ b/tests/test_termoweb_ws_handle_event_invalid.py
@@ -25,6 +25,7 @@ def _make_client() -> TermoWebWSClient:
     client._payload_idle_window = 240.0
     client._mark_event = MagicMock(name="_mark_event")
     client._mark_ws_payload = MagicMock(name="_mark_ws_payload")
+    client._inventory = None
     return client
 
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -477,18 +477,6 @@ def test_ws_state_bucket_initialises_missing_data(
     assert module.DOMAIN in client.hass.data
     assert client.hass.data[module.DOMAIN]["entry"]["ws_state"]["device"] is bucket
 
-
-def test_collect_update_addresses_extracts() -> None:
-    """Ensure update address extraction returns sorted node/type pairs."""
-
-    nodes = {
-        "htr": {"settings": {"1": {"temp": 20}, "2": None}},
-        "aux": {"samples": {"3": 10}},
-    }
-    addresses = module.WebSocketClient._collect_update_addresses(nodes)
-    assert addresses == [("aux", "3"), ("htr", "1")]
-
-
 def test_handshake_error_exposes_status_and_url() -> None:
     """Ensure ``HandshakeError`` forwards the status and URL details."""
 
@@ -839,15 +827,6 @@ async def test_websocket_client_reuses_delegate(
 
     client._delegate = None
     assert await client.ws_url() == ""
-
-
-def test_collect_update_addresses_skips_invalid() -> None:
-    """Non-mapping payloads should be ignored when collecting addresses."""
-
-    nodes: Mapping[str, Any] = {"htr": [1, 2], 10: {"settings": {"1": {}}}}
-    assert module.WebSocketClient._collect_update_addresses(nodes) == []
-
-
 
 def test_ducaheat_brand_headers_include_expected_fields() -> None:
     """Verify Ducaheat brand headers contain required keys."""


### PR DESCRIPTION
## Summary
- drop the legacy websocket node cache and rely on immutable inventory helpers for logging and dispatch
- require cached inventory when building heater sample subscriptions and log when missing
- update websocket tests to exercise the inventory-driven behaviour

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68ebb058d4948329b220ebb411faf9ab