### PR TITLE
Simplify node coordination to rely on inventory

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -1166,29 +1166,6 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             self._inventory = inventory_container
             record_mapping["inventory"] = inventory_container
 
-            alias_map: dict[str, str] = {}
-            try:
-                _, heater_aliases = inventory_container.heater_sample_address_map
-            except Exception:  # pragma: no cover - defensive cache guard
-                _LOGGER.debug(
-                    "WS (ducaheat): failed to resolve heater aliases during subscribe",
-                    exc_info=True,
-                )
-                heater_aliases = {}
-            else:
-                alias_map.update(heater_aliases)
-            try:
-                _, power_aliases = inventory_container.power_monitor_sample_address_map
-            except Exception:  # pragma: no cover - defensive cache guard
-                _LOGGER.debug(
-                    "WS (ducaheat): failed to resolve power monitor aliases during subscribe",
-                    exc_info=True,
-                )
-                power_aliases = {}
-            else:
-                alias_map.update(power_aliases)
-            record_mapping["sample_aliases"] = dict(alias_map)
-
             energy_coordinator = record_mapping.get("energy_coordinator")
             if hasattr(energy_coordinator, "update_addresses"):
                 try:

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -103,8 +103,6 @@ class StateCoordinator(
         self._device = device or {}
         self._inventory: Inventory | None = None
         self._pending_settings: dict[tuple[str, str], PendingSetting] = {}
-        self._invalid_nodes_logged = False
-        self._invalid_inventory_logged = False
         self._rtc_reference: datetime | None = None
         self._rtc_reference_monotonic: float | None = None
         self.update_nodes(nodes, inventory=inventory)
@@ -477,39 +475,16 @@ class StateCoordinator(
 
     def update_nodes(
         self,
-        nodes: Mapping[str, Any] | None,
+        _nodes: Mapping[str, Any] | None = None,
+        *,
         inventory: Inventory | None = None,
     ) -> None:
-        """Update cached node payload and inventory."""
+        """Update cached inventory metadata."""
 
         if isinstance(inventory, Inventory):
             self._inventory = inventory
-            self._invalid_inventory_logged = False
-            self._invalid_nodes_logged = False
-            return
-
-        if inventory is not None and not self._invalid_inventory_logged:
-            _LOGGER.debug(
-                "Ignoring unexpected inventory container (type=%s): %s",
-                type(inventory).__name__,
-                inventory,
-            )
-            self._invalid_inventory_logged = True
-
-        if nodes is not None and not isinstance(nodes, Mapping):
-            if not self._invalid_nodes_logged:
-                _LOGGER.debug(
-                    "Ignoring unexpected nodes payload (type=%s): %s",
-                    type(nodes).__name__,
-                    nodes,
-                )
-                self._invalid_nodes_logged = True
         else:
-            self._invalid_nodes_logged = False
-
-        if inventory is None:
             self._inventory = None
-            self._invalid_inventory_logged = False
 
     def _ensure_inventory(self) -> Inventory | None:
         """Ensure cached inventory metadata is available."""

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -1808,39 +1808,6 @@ async def test_subscribe_feeds_handles_missing_targets(
 
     assert count == 0
     emit_mock.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_subscribe_feeds_ignores_coordinator_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Empty inventories should still populate alias caches without subscriptions."""
-
-    client = _make_client(monkeypatch)
-    payload = {"nodes": []}
-    client.hass.data[ducaheat_ws.DOMAIN]["entry"]["inventory"] = Inventory(
-        "device",
-        payload,
-        build_node_inventory(payload),
-    )
-
-    emissions: list[str] = []
-
-    async def _capture(event: str, path: str) -> None:
-        emissions.append(path)
-
-    monkeypatch.setattr(client, "_emit_sio", _capture)
-
-    count = await client._subscribe_feeds()
-
-    assert count == 0
-    assert emissions == []
-    record = client.hass.data[ducaheat_ws.DOMAIN]["entry"]
-    sample_aliases = record.get("sample_aliases")
-    assert sample_aliases is not None
-    assert sample_aliases.get("htr") == "htr"
-
-
 @pytest.mark.asyncio
 async def test_subscribe_feeds_prefers_coordinator_inventory(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -156,64 +156,8 @@ def test_update_nodes_accepts_inventory_container(
     assert coord._inventory is container
     assert coord._inventory.payload == payload
 
-    coord.update_nodes(None, container)
+    coord.update_nodes(inventory=container)
     assert coord._inventory is container
-
-
-def test_update_nodes_requires_inventory(
-    inventory_builder: Callable[
-        [str, Mapping[str, Any] | None, Iterable[Any] | None], coord_module.Inventory
-    ],
-) -> None:
-    """Coordinator should not rebuild inventory when none is provided."""
-
-    client = types.SimpleNamespace(get_node_settings=AsyncMock())
-    hass = HomeAssistant()
-    payload = {"nodes": [{"addr": "1", "type": "htr"}]}
-    nodes_list = [HeaterNode(name="Heater", addr="1")]
-    container = inventory_builder("dev", payload, nodes_list)
-
-    coord = StateCoordinator(
-        hass,
-        client,
-        30,
-        "dev",
-        {"name": "Device"},
-        container.payload,
-        inventory=container,
-    )
-
-    coord.update_nodes(payload, inventory=None)
-    assert coord._inventory is None
-
-
-def test_update_nodes_ignores_invalid_inventory(
-    inventory_builder: Callable[
-        [str, Mapping[str, Any] | None, Iterable[Any] | None], coord_module.Inventory
-    ],
-) -> None:
-    """Passing a non-inventory object should leave the existing cache in place."""
-
-    client = types.SimpleNamespace(get_node_settings=AsyncMock())
-    hass = HomeAssistant()
-    payload = {"nodes": [{"addr": "2", "type": "htr"}]}
-    nodes_list = [HeaterNode(name="Heater", addr="2")]
-    container = inventory_builder("dev", payload, nodes_list)
-
-    coord = StateCoordinator(
-        hass,
-        client,
-        30,
-        "dev",
-        {"name": "Device"},
-        container.payload,
-        inventory=container,
-    )
-
-    coord.update_nodes(payload, inventory=object())
-    assert coord._inventory is container
-
-
 def test_power_calculation(
     monkeypatch: pytest.MonkeyPatch,
     inventory_from_map: Callable[[Mapping[str, Iterable[str]] | None, str], coord_module.Inventory],
@@ -884,7 +828,7 @@ def test_state_coordinator_async_update_data_reuses_previous() -> None:
             inventory=inventory,
         )
 
-        coord.update_nodes(nodes, inventory)
+        coord.update_nodes(nodes, inventory=inventory)
         coord.data = {
             "dev": {
                 "settings": {
@@ -926,7 +870,7 @@ def test_async_refresh_heater_updates_cache() -> None:
             inventory=inventory,
         )
 
-        coord.update_nodes(nodes, inventory)
+        coord.update_nodes(nodes, inventory=inventory)
 
         await coord.async_refresh_heater("A")
 
@@ -1446,7 +1390,7 @@ def test_state_coordinator_update_nodes_uses_provided_inventory(
         inventory=inventory,
     )
 
-    coord.update_nodes(nodes, provided_inventory)
+    coord.update_nodes(nodes, inventory=provided_inventory)
 
     inventory = coord._inventory
     assert inventory is provided_inventory

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -294,31 +294,6 @@ def test_build_node_inventory_skips_none_type() -> None:
 
 
 
-
-
-def test_state_coordinator_logs_once_for_invalid_nodes(
-    caplog: pytest.LogCaptureFixture,
-    inventory_builder: Callable[..., inventory_module.Inventory],
-) -> None:
-    hass = HomeAssistant()
-    coordinator = _make_state_coordinator(
-        hass,
-        {},
-        inventory_builder=inventory_builder,
-    )
-
-    caplog.clear()
-    invalid_inventory = inventory_builder("dev", ["bad"], [])
-    with caplog.at_level(logging.DEBUG):
-        coordinator.update_nodes(["bad"], invalid_inventory)
-        coordinator.update_nodes("also bad", invalid_inventory)
-
-    assert coordinator._inventory is invalid_inventory or coordinator._inventory is None
-    assert sum(
-        "Ignoring unexpected nodes payload" in message for message in caplog.messages
-    ) == 1
-
-
 def test_utils_normalization_matches_node_inventory() -> None:
     payload = {"nodes": [{"type": " HTR ", "addr": " 01 "}]}
 


### PR DESCRIPTION
## Summary
- ensure the state coordinator only caches the provided Inventory and never falls back to raw node payloads
- stop ducaheat websocket subscriptions from caching alias maps that duplicate Inventory data
- remove legacy tests covering node fallbacks and update remaining tests for the inventory-only workflow

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ebc04a5e84832989e9359c7b93a642