### PR TITLE
Refactor websocket node handling to rely on inventory

### DIFF
--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -528,6 +528,11 @@ def test_extract_dev_data_payload_variants(monkeypatch: pytest.MonkeyPatch) -> N
     """dev_data payload extraction should walk nested containers safely."""
 
     client = _make_client(monkeypatch)
+    client._inventory = Inventory(
+        client.dev_id,
+        {"nodes": [{"type": "htr", "addr": "1"}]},
+        build_node_inventory([{"type": "htr", "addr": "1"}]),
+    )
     nodes = {"nodes": {"htr": {}}}
     wrapper = {"data": nodes}
 
@@ -773,6 +778,11 @@ async def test_read_loop_handles_list_snapshot(
     """List-based dev_data snapshots should be coerced into mapping payloads."""
 
     client = _make_client(monkeypatch)
+    client._inventory = Inventory(
+        client.dev_id,
+        {"nodes": [{"type": "htr", "addr": "1"}]},
+        build_node_inventory([{"type": "htr", "addr": "1"}]),
+    )
     monkeypatch.setattr(client, "_subscribe_feeds", AsyncMock(return_value=2))
     dispatched: list[dict[str, Any]] = []
     client._dispatcher = lambda *_args: dispatched.append(_args[2])


### PR DESCRIPTION
## Summary
- add helpers on Inventory to identify known nodes from raw payload entries
- update TermoWeb and Ducaheat websocket clients to use the shared inventory instead of rebuilding node lists
- adjust websocket protocol tests to remove legacy expectations and rely on the shared inventory metadata

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ebcf6049a483299134c3233d75317c