### PR TITLE
Refactor inventory usage across platforms

### DIFF
--- a/custom_components/termoweb/button.py
+++ b/custom_components/termoweb/button.py
@@ -122,7 +122,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
         StateRefreshButton(coordinator, entry.entry_id, dev_id)
     ]
 
-    inventory = data.get("inventory")
+    try:
+        inventory = Inventory.require_from_context(container=data)
+    except LookupError as err:
+        _LOGGER.error(
+            "TermoWeb button setup missing inventory for device %s", dev_id
+        )
+        raise ValueError("TermoWeb inventory unavailable for button platform") from err
+
     log_skipped_nodes("button", inventory, logger=_LOGGER)
 
     boost_entities: list[ButtonEntity] = []

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -30,7 +30,6 @@ from .heater import (
     log_skipped_nodes,
     register_climate_entity_id,
     resolve_boost_runtime_minutes,
-    resolve_entry_inventory,
 )
 from .identifiers import build_heater_entity_unique_id
 from .inventory import (
@@ -55,14 +54,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = data["coordinator"]
     dev_id = data["dev_id"]
 
-    inventory = resolve_entry_inventory(data)
-
-
-    if not isinstance(inventory, Inventory):
+    try:
+        inventory = Inventory.require_from_context(container=data)
+    except LookupError as err:
         _LOGGER.error(
             "TermoWeb climate setup missing inventory for device %s", dev_id
         )
-        return
+        raise ValueError("TermoWeb inventory unavailable for climate platform") from err
 
     def default_name_simple(addr: str) -> str:
         """Return fallback name for heater nodes."""

--- a/tests/test_ws_sample_invalid_payload.py
+++ b/tests/test_ws_sample_invalid_payload.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb.inventory import Inventory, build_node_inventory
 
 
 class EnergyCoordinatorStub:
@@ -34,7 +35,20 @@ def test_forward_ws_sample_updates_ignores_non_mapping_sections() -> None:
 
     entry_id = "entry"
     coordinator = EnergyCoordinatorStub()
-    hass = SimpleNamespace(data={DOMAIN: {entry_id: {"energy_coordinator": coordinator}}})
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                entry_id: {
+                    "energy_coordinator": coordinator,
+                    "inventory": Inventory(
+                        "dev",
+                        {"nodes": [{"type": "htr", "addr": "1"}]},
+                        build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
+                    ),
+                }
+            }
+        }
+    )
 
     forward_ws_sample_updates(
         hass,

--- a/tests/test_ws_sample_skip_lease_entry.py
+++ b/tests/test_ws_sample_skip_lease_entry.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
+from custom_components.termoweb.inventory import Inventory, build_node_inventory
 
 
 class CoordinatorStub:
@@ -34,7 +35,20 @@ def test_forward_ws_sample_updates_omits_inner_lease_entry() -> None:
 
     entry_id = "entry"
     coordinator = CoordinatorStub()
-    hass = SimpleNamespace(data={DOMAIN: {entry_id: {"energy_coordinator": coordinator}}})
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                entry_id: {
+                    "energy_coordinator": coordinator,
+                    "inventory": Inventory(
+                        "dev",
+                        {"nodes": [{"type": "htr", "addr": "1"}]},
+                        build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
+                    ),
+                }
+            }
+        }
+    )
 
     forward_ws_sample_updates(
         hass,


### PR DESCRIPTION
## Summary
- add Inventory.require_from_context to centralize inventory resolution and update websocket helpers and platforms to use it
- remove legacy fallback handling and align energy, button, climate, and binary sensor setup with guaranteed inventory availability
- update and remove tests to reflect the new inventory contract while keeping sample forwarding and heater address coverage

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ecc66974888329b4fb4d7b5277300c