### PR TITLE
Refactor inventory metadata helpers

### DIFF
--- a/custom_components/termoweb/boost.py
+++ b/custom_components/termoweb/boost.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
 from datetime import UTC, datetime, timedelta
 import logging
 import math
 from typing import Any, Final
 
 from homeassistant.util import dt as dt_util
-
-from .inventory import Inventory, Node
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -174,27 +171,5 @@ def resolve_boost_end_from_fields(
     return selected, minutes_remaining
 
 
-type HeaterInventoryEntry = tuple[str, str, str, Node]
-"""Type alias describing ``(node_type, addr, name, node)`` tuples."""
-
-
-def iter_inventory_heater_metadata(
-    inventory: Inventory | None,
-    *,
-    default_name_simple: Callable[[str], str] | None = None,
-) -> Iterator[HeaterInventoryEntry]:
-    """Yield ``(node_type, addr, name, node)`` tuples for heater nodes."""
-
-    if not isinstance(inventory, Inventory):
-        return
-
-    default_factory = default_name_simple or (lambda addr: f"Heater {addr}")
-
-    for node_type, node, addr, name in inventory.iter_heater_platform_metadata(
-        default_factory
-    ):
-        yield node_type, addr, name, node
-
 ALLOWED_BOOST_MINUTES: Final[tuple[int, ...]] = tuple(range(60, 601, 60))
 """Valid boost durations (in minutes) supported by TermoWeb heaters."""
-

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -494,8 +494,6 @@ custom_components/termoweb/boost.py :: supports_boost
     Return ``True`` when ``node`` exposes boost controls.
 custom_components/termoweb/boost.py :: resolve_boost_end_from_fields
     Translate boost end ``day``/``minute`` fields into a timestamp.
-custom_components/termoweb/boost.py :: iter_inventory_heater_metadata
-    Yield metadata for heater nodes described by ``inventory``.
 custom_components/termoweb/button.py :: async_setup_entry
     Expose hub refresh and accumulator boost helper buttons.
 custom_components/termoweb/button.py :: async_setup_entry.default_name
@@ -992,6 +990,8 @@ custom_components/termoweb/inventory.py :: _collect_snapshot_addresses
     Return mapping of addresses to candidate payloads from ``section``.
 custom_components/termoweb/inventory.py :: _extract_snapshot_name
     Return best candidate name extracted from ``payloads``.
+custom_components/termoweb/inventory.py :: Inventory.iter_nodes_metadata
+    Yield canonical node metadata for the requested types.
 custom_components/termoweb/inventory.py :: _iter_node_payload
     Yield node dictionaries from a payload returned by the API.
 custom_components/termoweb/inventory.py :: _resolve_node_class


### PR DESCRIPTION
## Summary
- add a reusable `Inventory.iter_nodes_metadata` helper that provides canonical node metadata for all inventory consumers
- update platforms and helpers to rely on the new inventory iterator and drop the redundant boost metadata helper
- refresh diagnostics/tests/documentation to consume the shared iterator and remove legacy fallback expectations

## Testing
- `uv run timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68eccc1f441083299143377c554a686d