### PR TITLE
Add hourly samples poller shared across backends

### DIFF
--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -2,10 +2,30 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from asyncio import Task
+from asyncio import CancelledError, Task
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+import logging
 from typing import Any, Protocol
 
-from ..inventory import Inventory, NodeDescriptor
+from homeassistant.util import dt as dt_util
+
+from custom_components.termoweb.backend.sanitize import mask_identifier
+from custom_components.termoweb.inventory import (
+    Inventory,
+    NodeDescriptor,
+    normalize_node_addr,
+    normalize_node_type,
+)
+from custom_components.termoweb.utils import float_or_none
+
+_LOGGER = logging.getLogger(__name__)
+
+_SAMPLE_COUNTER_SCALES: dict[str, float] = {
+    "htr": 1000.0,
+    "acm": 1000.0,
+    "pmo": 3_600_000.0,
+}
 
 
 class HttpClientProto(Protocol):
@@ -86,3 +106,108 @@ class Backend(ABC):
         inventory: Inventory | None = None,
     ) -> WsClientProto:
         """Create a websocket client for the given device."""
+
+    @abstractmethod
+    async def fetch_hourly_samples(
+        self,
+        dev_id: str,
+        nodes: Iterable[tuple[str, str]],
+        start_local: datetime,
+        end_local: datetime,
+    ) -> dict[tuple[str, str], list[dict[str, Any]]]:
+        """Return normalised hourly samples grouped by node descriptor."""
+
+
+def normalise_sample_records(
+    node_type: str,
+    records: Iterable[Mapping[str, Any] | Any],
+) -> list[dict[str, Any]]:
+    """Return sorted sample dictionaries containing ``ts`` and ``energy_wh``."""
+
+    scale = float(_SAMPLE_COUNTER_SCALES.get(node_type, 1000.0) or 1000.0)
+    divider = scale / 1000.0 if scale else 1.0
+    samples: list[dict[str, Any]] = []
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        timestamp = float_or_none(record.get("t"))
+        if timestamp is None:
+            continue
+        counter = float_or_none(record.get("counter"))
+        if counter is None:
+            counter = (
+                float_or_none(record.get("counter_max"))
+                or float_or_none(record.get("counter_min"))
+                or float_or_none(record.get("value"))
+            )
+        if counter is None:
+            continue
+        energy_wh = counter / divider if divider else counter
+        sample: dict[str, Any] = {
+            "ts": datetime.fromtimestamp(timestamp, tz=UTC),
+            "energy_wh": energy_wh,
+        }
+        power = float_or_none(record.get("power"))
+        if power is not None:
+            sample["power_w"] = power
+        samples.append(sample)
+
+    samples.sort(key=lambda item: item.get("ts", datetime.min.replace(tzinfo=UTC)))
+    return samples
+
+
+async def fetch_normalised_hourly_samples(
+    *,
+    client: HttpClientProto,
+    dev_id: str,
+    nodes: Iterable[tuple[str, str]],
+    start_local: datetime,
+    end_local: datetime,
+    logger: logging.Logger = _LOGGER,
+    log_prefix: str = "backend",
+) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    """Return per-node normalised samples for ``nodes`` between ``start`` and ``end``."""
+
+    start_epoch = dt_util.as_utc(start_local).timestamp()
+    end_epoch = dt_util.as_utc(end_local).timestamp()
+    if end_epoch <= start_epoch:
+        return {}
+
+    results: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for node_type, addr in nodes:
+        normalized_type = normalize_node_type(
+            node_type,
+            use_default_when_falsey=True,
+        )
+        normalized_addr = normalize_node_addr(
+            addr,
+            use_default_when_falsey=True,
+        )
+        if not normalized_type or not normalized_addr:
+            continue
+        try:
+            raw_samples = await client.get_node_samples(
+                dev_id,
+                (normalized_type, normalized_addr),
+                start_epoch,
+                end_epoch,
+            )
+        except CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 - log and continue on failure
+            logger.warning(
+                "%s: failed to fetch samples for %s/%s node_type=%s: %s",
+                log_prefix,
+                mask_identifier(dev_id),
+                mask_identifier(normalized_addr),
+                normalized_type,
+                err,
+            )
+            continue
+        if not isinstance(raw_samples, Iterable):
+            continue
+        normalised = normalise_sample_records(normalized_type, raw_samples)
+        if normalised:
+            results[(normalized_type, normalized_addr)] = normalised
+    return results

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -10,17 +10,21 @@ from typing import Any
 
 from aiohttp import ClientResponseError
 
-from ..api import RESTClient
-from ..const import BRAND_DUCAHEAT, WS_NAMESPACE
-from ..inventory import Inventory, NodeDescriptor
-from .base import Backend, WsClientProto
-from .ducaheat_ws import DucaheatWSClient
-from .sanitize import (
+from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.base import (
+    Backend,
+    WsClientProto,
+    fetch_normalised_hourly_samples,
+)
+from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient
+from custom_components.termoweb.backend.sanitize import (
     build_acm_boost_payload,
     mask_identifier,
     redact_text,
     validate_boost_minutes,
 )
+from custom_components.termoweb.const import BRAND_DUCAHEAT, WS_NAMESPACE
+from custom_components.termoweb.inventory import Inventory, NodeDescriptor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1150,6 +1154,25 @@ class DucaheatBackend(Backend):
             coordinator=coordinator,
             namespace=WS_NAMESPACE,
             inventory=inventory,
+        )
+
+    async def fetch_hourly_samples(
+        self,
+        dev_id: str,
+        nodes: Iterable[tuple[str, str]],
+        start_local: datetime,
+        end_local: datetime,
+    ) -> dict[tuple[str, str], list[dict[str, Any]]]:
+        """Return hourly samples for ``nodes`` using the segmented API."""
+
+        return await fetch_normalised_hourly_samples(
+            client=self.client,
+            dev_id=dev_id,
+            nodes=nodes,
+            start_local=start_local,
+            end_local=end_local,
+            logger=_LOGGER,
+            log_prefix="ducaheat",
         )
 
 

--- a/custom_components/termoweb/hourly_poller.py
+++ b/custom_components/termoweb/hourly_poller.py
@@ -1,0 +1,262 @@
+"""Hourly REST poller for historical samples across all backends."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterable
+from contextlib import suppress
+from datetime import datetime, timedelta
+from itertools import chain
+import logging
+import random
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+try:  # pragma: no cover - optional helper on older Home Assistant cores
+    from homeassistant.helpers.event import async_track_time_change
+except ImportError:  # pragma: no cover - tests provide stubbed helpers
+    async_track_time_change = None  # type: ignore[assignment]
+
+from custom_components.termoweb.backend import Backend
+from custom_components.termoweb.backend.sanitize import mask_identifier
+from custom_components.termoweb.coordinator import EnergyStateCoordinator
+from custom_components.termoweb.inventory import (
+    Inventory,
+    normalize_node_addr,
+    normalize_node_type,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HourlySamplesPoller:
+    """Schedule and execute hourly REST polls for canonical sample buckets."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: EnergyStateCoordinator,
+        backend: Backend,
+        inventory: Inventory | Iterable[Inventory],
+    ) -> None:
+        """Initialise the poller with Home Assistant context and dependencies."""
+
+        self._hass = hass
+        self._coordinator = coordinator
+        self._backend = backend
+        if isinstance(inventory, Inventory):
+            self._inventories: tuple[Inventory, ...] = (inventory,)
+        else:
+            validated: list[Inventory] = []
+            for item in inventory:
+                if not isinstance(item, Inventory):
+                    msg = "HourlySamplesPoller requires Inventory instances"
+                    raise TypeError(msg)
+                validated.append(item)
+            if not validated:
+                msg = "At least one Inventory is required for hourly polling"
+                raise ValueError(msg)
+            self._inventories = tuple(validated)
+        self._remove_listener: Callable[[], None] | None = None
+        self._active_task: asyncio.Task[None] | None = None
+        self._semaphore = asyncio.Semaphore(3)
+        self._last_window_end: datetime | None = None
+
+    async def async_setup(self) -> None:
+        """Register the HH:05 local trigger and perform optional catch-up."""
+
+        helper = async_track_time_change
+        if helper is None:
+            _LOGGER.debug("Hourly poller: time-change helper unavailable; scheduling skipped")
+        elif self._remove_listener is None:
+            self._remove_listener = helper(
+                self._hass,
+                self._on_time,
+                minute=5,
+                second=0,
+            )
+
+        now_local = dt_util.now()
+        if now_local.minute < 15:
+            await self._run_for_previous_hour(now_local)
+
+    async def async_shutdown(self) -> None:
+        """Cancel scheduled triggers and pending polling tasks."""
+
+        if callable(self._remove_listener):
+            try:
+                self._remove_listener()
+            except Exception:  # noqa: BLE001 - defensive logging only
+                _LOGGER.debug("Hourly poller: failed to remove time listener", exc_info=True)
+            self._remove_listener = None
+
+        task = self._active_task
+        self._active_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+    def _on_time(self, now: datetime | None) -> None:
+        """Callback invoked by Home Assistant's time tracker."""
+
+        reference = dt_util.as_local(now) if now is not None else dt_util.now()
+        if self._active_task is not None and not self._active_task.done():
+            _LOGGER.debug("Hourly poller: skipping trigger while previous run is active")
+            return
+        task = self._hass.async_create_task(self._run_for_previous_hour(reference))
+        self._active_task = task
+
+        def _finalise(finished: asyncio.Task[None]) -> None:
+            self._active_task = None
+            if finished.cancelled():
+                _LOGGER.debug("Hourly poller task cancelled")
+                return
+            exception = finished.exception()
+            if exception is not None:
+                _LOGGER.exception(
+                    "Hourly poller run raised an exception", exc_info=exception
+                )
+
+        task.add_done_callback(_finalise)
+
+    def _enumerate_nodes(self, inventory: Inventory) -> list[tuple[str, str]]:
+        """Return canonical ``(node_type, addr)`` pairs for ``inventory``."""
+
+        nodes: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
+        for node_type, addr in chain(
+            inventory.heater_sample_targets,
+            inventory.power_monitor_sample_targets,
+        ):
+            normalized_type = normalize_node_type(
+                node_type,
+                use_default_when_falsey=True,
+            )
+            normalized_addr = normalize_node_addr(
+                addr,
+                use_default_when_falsey=True,
+            )
+            if not normalized_type or not normalized_addr:
+                continue
+            pair = (normalized_type, normalized_addr)
+            if pair in seen:
+                continue
+            seen.add(pair)
+            nodes.append(pair)
+        return nodes
+
+    async def _run_for_previous_hour(self, now_local: datetime) -> None:
+        """Fetch and merge samples for the hour preceding ``now_local``."""
+
+        reference = dt_util.as_local(now_local)
+        current_hour_start = reference.replace(minute=0, second=0, microsecond=0)
+        end_local = current_hour_start
+        start_local = end_local - timedelta(hours=1)
+
+        if self._last_window_end is not None and end_local <= self._last_window_end:
+            _LOGGER.debug(
+                "Hourly poller: window %s already processed", end_local.isoformat()
+            )
+            return
+
+        device_nodes: dict[str, list[tuple[str, str]]] = {}
+        total_nodes = 0
+        for container in self._inventories:
+            nodes = self._enumerate_nodes(container)
+            device_nodes[container.dev_id] = nodes
+            total_nodes += len(nodes)
+
+        _LOGGER.info(
+            "Hourly samples poll: window=%s–%s devices=%d nodes=%d",
+            start_local.isoformat(),
+            end_local.isoformat(),
+            len(device_nodes),
+            total_nodes,
+        )
+
+        tasks = [
+            asyncio.create_task(
+                self._poll_device(
+                    dev_id,
+                    nodes,
+                    start_local,
+                    end_local,
+                )
+            )
+            for dev_id, nodes in device_nodes.items()
+            if nodes
+        ]
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
+        self._last_window_end = end_local
+
+    async def _poll_device(
+        self,
+        dev_id: str,
+        nodes: list[tuple[str, str]],
+        start_local: datetime,
+        end_local: datetime,
+    ) -> None:
+        """Fetch samples for ``dev_id`` and merge them into the coordinator."""
+
+        if not nodes:
+            return
+
+        attempt = 1
+        result: dict[tuple[str, str], list[dict[str, Any]]] | None = None
+        while attempt <= 2:
+            try:
+                async with self._semaphore:
+                    result = await self._backend.fetch_hourly_samples(
+                        dev_id,
+                        nodes,
+                        start_local,
+                        end_local,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001 - retry once before giving up
+                delay = random.uniform(0.5, 1.5)
+                _LOGGER.warning(
+                    "Hourly poller: fetch failed for %s (attempt %d/%d): %s",
+                    mask_identifier(dev_id),
+                    attempt,
+                    2,
+                    err,
+                )
+                if attempt >= 2:
+                    return
+                attempt += 1
+                await asyncio.sleep(delay)
+                continue
+            break
+
+        if not result:
+            _LOGGER.debug(
+                "Hourly poller: backend returned no data for %s", mask_identifier(dev_id)
+            )
+            return
+
+        totals = sum(len(bucket) for bucket in result.values())
+        _LOGGER.debug(
+            "Hourly poller: %s merged nodes=%d buckets=%d",
+            mask_identifier(dev_id),
+            len(result),
+            totals,
+        )
+
+        try:
+            await self._coordinator.merge_samples_for_window(dev_id, result)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover - defensive logging
+            _LOGGER.exception(
+                "Hourly poller: coordinator merge failed for %s", mask_identifier(dev_id)
+            )
+
+
+__all__ = ["HourlySamplesPoller"]

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -108,6 +108,12 @@ custom_components/termoweb/backend/base.py :: Backend.client
     Return the HTTP client associated with this backend.
 custom_components/termoweb/backend/base.py :: Backend.create_ws_client
     Create a websocket client for the given device.
+custom_components/termoweb/backend/base.py :: Backend.fetch_hourly_samples
+    Return normalised hourly samples grouped by node descriptor.
+custom_components/termoweb/backend/base.py :: normalise_sample_records
+    Return sorted sample dictionaries containing ``ts`` and ``energy_wh``.
+custom_components/termoweb/backend/base.py :: fetch_normalised_hourly_samples
+    Return per-node normalised samples for ``nodes`` between ``start`` and ``end``.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRequestError.__init__
     Initialise error metadata for logging and diagnostics.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._post_segmented
@@ -118,6 +124,8 @@ custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.get_node_se
     Fetch and normalise node settings for the Ducaheat API.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.set_node_settings
     Write heater settings using the segmented endpoints.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatBackend.fetch_hourly_samples
+    Return hourly samples for ``nodes`` using the segmented API.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.get_node_samples
     Return samples converting epoch seconds to milliseconds for the API.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient.normalise_ws_nodes
@@ -240,6 +248,8 @@ custom_components/termoweb/backend/termoweb.py :: TermoWebBackend._resolve_ws_cl
     Return the websocket client class compatible with this backend.
 custom_components/termoweb/backend/termoweb.py :: TermoWebBackend.create_ws_client
     Instantiate the unified websocket client for TermoWeb.
+custom_components/termoweb/backend/termoweb.py :: TermoWebBackend.fetch_hourly_samples
+    Return hourly samples for ``nodes`` using the REST API.
 custom_components/termoweb/backend/termoweb_ws.py :: HandshakeError.__init__
     Initialise the error with the HTTP response details.
 custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient.__init__
@@ -734,6 +744,22 @@ custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._extract_sam
     Extract ``(timestamp, counter)`` from websocket sample payloads.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.handle_ws_samples
     Update cached heater metrics from websocket ``samples`` payloads.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.merge_samples_for_window
+    Merge normalised hourly samples into the cached energy state.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller.__init__
+    Initialise the poller with Home Assistant context and dependencies.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller.async_setup
+    Register the HH:05 local trigger and perform optional catch-up.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller.async_shutdown
+    Cancel scheduled triggers and pending polling tasks.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._on_time
+    Callback invoked by Home Assistant's time tracker.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._enumerate_nodes
+    Return canonical ``(node_type, addr)`` pairs for ``inventory``.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._run_for_previous_hour
+    Fetch and merge samples for the hour preceding ``now_local``.
+custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._poll_device
+    Fetch samples for ``dev_id`` and merge them into the coordinator.
 custom_components/termoweb/coordinator.py :: _wrap_logger
     Return a logger proxy that exposes ``isEnabledFor`` when missing.
 custom_components/termoweb/diagnostics.py :: async_get_config_entry_diagnostics

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
@@ -69,6 +70,17 @@ class ExampleBackend(Backend):
             }
         )
         return DummyWsClient(hass, entry_id=entry_id, dev_id=dev_id)
+
+    async def fetch_hourly_samples(
+        self,
+        dev_id: str,
+        nodes: Any,
+        start_local: datetime,
+        end_local: datetime,
+    ) -> dict[tuple[str, str], list[dict[str, Any]]]:
+        """Return an empty sample mapping for the dummy backend."""
+
+        return {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_hourly_poller.py
+++ b/tests/test_hourly_poller.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.termoweb.hourly_poller import HourlySamplesPoller
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+
+@pytest.mark.asyncio
+async def test_hourly_poller_runs_previous_hour(
+    inventory_from_map,
+) -> None:
+    """The poller fetches the previous hour window and merges results once."""
+
+    hass = HomeAssistant()
+    inventory = inventory_from_map({"htr": ["A"], "pmo": ["M"]})
+    backend = AsyncMock()
+    backend.fetch_hourly_samples = AsyncMock(
+        return_value={("htr", "A"): [{"ts": datetime.now(timezone.utc), "energy_wh": 1_200.0}]}
+    )
+    coordinator = AsyncMock()
+    coordinator.merge_samples_for_window = AsyncMock()
+    poller = HourlySamplesPoller(hass, coordinator, backend, inventory)
+
+    tz = dt_util.get_time_zone("Europe/Paris")
+    now_local = datetime(2023, 3, 27, 10, 5, tzinfo=tz)
+    original_tz = dt_util.DEFAULT_TIME_ZONE
+    dt_util.set_default_time_zone(tz)
+    try:
+        await poller._run_for_previous_hour(now_local)
+
+        call = backend.fetch_hourly_samples.await_args
+        assert call.args[0] == inventory.dev_id
+        assert set(call.args[1]) == {("htr", "A"), ("pmo", "M")}
+        start_arg = call.args[2]
+        end_arg = call.args[3]
+        assert start_arg.tzinfo is not None
+        assert end_arg.tzinfo is not None
+        local_start = dt_util.as_local(start_arg)
+        local_end = dt_util.as_local(end_arg)
+        assert local_start.tzinfo == dt_util.DEFAULT_TIME_ZONE
+        assert local_end.tzinfo == dt_util.DEFAULT_TIME_ZONE
+        assert local_start.hour == 9 and local_start.minute == 0
+        assert local_end.hour == 10 and local_end.minute == 0
+        coordinator.merge_samples_for_window.assert_awaited_once_with(
+            inventory.dev_id,
+            backend.fetch_hourly_samples.return_value,
+        )
+
+        backend.fetch_hourly_samples.reset_mock()
+        coordinator.merge_samples_for_window.reset_mock()
+        await poller._run_for_previous_hour(now_local)
+        backend.fetch_hourly_samples.assert_not_called()
+        coordinator.merge_samples_for_window.assert_not_called()
+    finally:
+        dt_util.set_default_time_zone(original_tz)
+
+    await poller.async_shutdown()


### PR DESCRIPTION
## Summary
- add an HourlySamplesPoller that schedules HH:05 local REST fetches and wires into integration shutdown
- expose Backend.fetch_hourly_samples with shared normalization helper and implement TermoWeb/Ducaheat adapters
- merge hourly windows via the energy coordinator and extend fixtures/tests to cover the new poller path

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/hourly_poller.py tests/test_hourly_poller.py tests/conftest.py tests/test_energy_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68ecd59d861c83298114520b16cdc99f