### PR TITLE
Improve coverage pragma filtering

### DIFF
--- a/tests/test_force_coverage.py
+++ b/tests/test_force_coverage.py
@@ -25,7 +25,8 @@ def _collect_executable_lines(path: Path) -> set[int]:
             stripped = line.strip()
             if not stripped:
                 continue
-            if stripped.startswith("# pragma: no cover"):
+            lowered = stripped.lower()
+            if "pragma: no cover" in lowered:
                 continue
             candidates.add(index)
     return candidates


### PR DESCRIPTION
## Summary
- tighten the TermoWeb coverage helper to ignore any line tagged with a no-cover pragma

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ecde0e8e288329aeee6cb7e50724af