### PR TITLE
Guard TermoWeb sensor setup without power monitors

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1066,12 +1066,8 @@ custom_components/termoweb/sensor.py :: async_setup_entry
     Set up sensors for each heater node.
 custom_components/termoweb/sensor.py :: async_setup_entry.default_name
     Return a placeholder name for heater nodes.
-custom_components/termoweb/sensor.py :: async_setup_entry._fallback_power_monitor_name
-    Return a default label for a power monitor address.
-custom_components/termoweb/sensor.py :: async_setup_entry._register_power_monitor_node
-    Add a named power monitor derived from ``node``.
-custom_components/termoweb/sensor.py :: async_setup_entry._integrate_power_monitor_addresses
-    Merge addresses from ``source`` into the energy map and names.
+custom_components/termoweb/sensor.py :: _power_monitor_display_name
+    Return the display name for a power monitor address.
 custom_components/termoweb/sensor.py :: HeaterTemperatureSensor.__init__
     Initialise the heater temperature sensor entity.
 custom_components/termoweb/sensor.py :: HeaterTemperatureSensor.native_value

--- a/tests/test_sensor_normalise_energy.py
+++ b/tests/test_sensor_normalise_energy.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import importlib
 from types import SimpleNamespace
 from typing import Callable
+from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.coordinator import EnergyStateCoordinator
+from custom_components.termoweb.inventory import Inventory, build_node_inventory
 from custom_components.termoweb.sensor import _normalise_energy_value
+from homeassistant.core import HomeAssistant
 
 
 class _ScaleStub(SimpleNamespace):
@@ -74,3 +78,75 @@ def test_normalise_energy_value(
 
     coordinator = coordinator_factory()
     assert _normalise_energy_value(coordinator, raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_handles_missing_power_monitors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sensor setup should tolerate inventories without power monitors."""
+
+    module = importlib.import_module("custom_components.termoweb.sensor")
+    hass = HomeAssistant()
+    hass.data = {DOMAIN: {}}
+    entry = SimpleNamespace(entry_id="entry-1")
+    raw_nodes = [{"type": "htr", "addr": "1", "name": "Heater"}]
+    node_inventory = build_node_inventory({"nodes": raw_nodes})
+    inventory = Inventory("dev-1", {"nodes": raw_nodes}, node_inventory)
+    assert "pmo" not in inventory.nodes_by_type
+
+    heater_details = SimpleNamespace(
+        inventory=inventory,
+        iter_metadata=lambda: iter([("htr", object(), "1", "Heater 1")]),
+    )
+    monkeypatch.setattr(
+        module,
+        "heater_platform_details_for_entry",
+        lambda _data, **_kwargs: heater_details,
+    )
+    monkeypatch.setattr(module, "iter_boostable_heater_nodes", lambda _details: [])
+    monkeypatch.setattr(module, "log_skipped_nodes", lambda *args, **kwargs: None)
+
+    def _unexpected_power_monitor(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("power monitor sensors should not be created")
+
+    monkeypatch.setattr(module, "PowerMonitorEnergySensor", _unexpected_power_monitor)
+    monkeypatch.setattr(module, "PowerMonitorPowerSensor", _unexpected_power_monitor)
+
+    def _create_heater_sensors_stub(*_args: object, **_kwargs: object) -> tuple[str, ...]:
+        return ("temp-sensor", "energy-sensor", "power-sensor")
+
+    monkeypatch.setattr(module, "_create_heater_sensors", _create_heater_sensors_stub)
+    monkeypatch.setattr(module, "_create_boost_sensors", lambda *a, **k: ())
+
+    class _DummyTotalEnergy:
+        """Placeholder installation energy sensor for setup tests."""
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return
+
+    monkeypatch.setattr(module, "InstallationTotalEnergySensor", _DummyTotalEnergy)
+
+    energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
+    data_record = {
+        "coordinator": object(),
+        "dev_id": "dev-1",
+        "client": object(),
+        "energy_coordinator": energy_coordinator,
+    }
+    hass.data[DOMAIN][entry.entry_id] = data_record
+
+    added_entities: list[object] = []
+
+    def _async_add_entities(entities: list[object]) -> None:
+        added_entities.extend(entities)
+
+    await module.async_setup_entry(hass, entry, _async_add_entities)
+
+    energy_coordinator.update_addresses.assert_called_once_with(inventory)
+    assert added_entities[:3] == [
+        "temp-sensor",
+        "energy-sensor",
+        "power-sensor",
+    ]
+    assert any(isinstance(entity, _DummyTotalEnergy) for entity in added_entities)


### PR DESCRIPTION
## Summary
- prevent power monitor sensor setup when the inventory contains no power monitors and log the skip path
- add a regression test covering heater-only inventories during sensor setup
- update the function map documentation for the new power monitor helper

## Testing
- `ruff check custom_components/termoweb/sensor.py tests/test_sensor_normalise_energy.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68ecde718c2883298b02799817a9fb17