### PR TITLE
Fix hourly poller scheduling from threads

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -753,7 +753,7 @@ custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller.async_setup
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller.async_shutdown
     Cancel scheduled triggers and pending polling tasks.
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._on_time
-    Callback invoked by Home Assistant's time tracker.
+    Callback invoked by Home Assistant's time tracker in a thread-safe way.
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._enumerate_nodes
     Return canonical ``(node_type, addr)`` pairs for ``inventory``.
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._run_for_previous_hour


### PR DESCRIPTION
## Summary
- schedule hourly poller runs via the Home Assistant loop to avoid cross-thread async_create_task usage
- exercise the new scheduling behaviour with a regression unit test
- document the updated HourlySamplesPoller._on_time behaviour in the function map

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ecec1fbac48329965e5a6770ab8655