### PR TITLE
Handle import_energy_history targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ See instructions in custom_components/termoweb/assets, to install the card and c
 - Live energy samples now arrive via the websocket connection, with the hourly
   REST poll remaining as a fallback if the push feed is unavailable.
 - Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration.
+- Target specific heaters by setting `target.entity_id`, `target.device_id`, or `target.area_id` (or the matching keys under `data:`); omit the target to refresh every TermoWeb config entry.
 - No extra configuration is required beyond selecting the sensors in the Energy Dashboard.
 
 ---

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -88,7 +88,7 @@
     },
     "import_energy_history": {
       "name": "Import energy history",
-      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics.",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Target entities, devices, or areas to limit the import, or omit the target to refresh every TermoWeb config entry.",
       "fields": {
         "reset_progress": {
           "name": "Reset progress",

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -92,7 +92,7 @@
     },
     "import_energy_history": {
       "name": "Import energy history",
-      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics.",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Target entities, devices, or areas to limit the import, or omit the target to refresh every TermoWeb config entry.",
       "fields": {
         "reset_progress": {
           "name": "Reset progress",


### PR DESCRIPTION
## Summary
- update the import_energy_history service handler to resolve entity, device, or area targets via Home Assistant's extraction helper while still honoring explicit entity_id lists
- document the new targeting capabilities in the README and service descriptions
- extend the service tests and stubs to cover helper-based target resolution

## Testing
- `uv run ruff format custom_components/termoweb/energy.py tests/conftest.py tests/test_import_energy_history.py`
- `uv run ruff check custom_components/termoweb/energy.py --extend-ignore PLW0603,PLC0415,C901,BLE001,G201,TRY401`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ed03ca44b48329ae5467bf2a589353