### PR TITLE
Fix hourly poller test cleanup to avoid warnings

### DIFF
--- a/tests/test_hourly_poller.py
+++ b/tests/test_hourly_poller.py
@@ -97,6 +97,10 @@ def test_hourly_poller_on_time_threadsafe(inventory_from_map) -> None:
         def trigger(self) -> None:
             for callback in list(self._callbacks):
                 callback(self)
+            try:
+                self.coro.close()
+            except Exception:  # pragma: no cover - defensive cleanup
+                pass
 
     created_tasks: list[FakeTask] = []
 

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -969,7 +969,10 @@ def test_async_setup_entry_auth_error(
     stub_hass.config_entries.add(entry)
 
     async def _run() -> None:
-        await termoweb_init.async_setup_entry(stub_hass, entry)
+        try:
+            await termoweb_init.async_setup_entry(stub_hass, entry)
+        finally:
+            await _drain_tasks(stub_hass)
 
     with pytest.raises(ConfigEntryAuthFailed):
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
- close the fake hourly poller coroutine in the thread-safety test to prevent un-awaited warnings
- drain Home Assistant stub tasks after the auth-error setup test to leave no pending work

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ed14bf839c83298edbb0a6313b55f0