### PR TITLE
Allow energy history import without target selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See instructions in custom_components/termoweb/assets, to install the card and c
 - Live energy samples now arrive via the websocket connection, with the hourly
   REST poll remaining as a fallback if the push feed is unavailable.
 - Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration.
-- Target specific heaters by setting `target.entity_id`, `target.device_id`, or `target.area_id` (or the matching keys under `data:`); omit the target to refresh every TermoWeb config entry.
+- Select specific energy sensors (or provide their `entity_id` values) to limit the import, or leave the picker empty to refresh every TermoWeb config entry.
 - No extra configuration is required beyond selecting the sensors in the Energy Dashboard.
 
 ---

--- a/custom_components/termoweb/services.yaml
+++ b/custom_components/termoweb/services.yaml
@@ -110,10 +110,17 @@ import_energy_history:
   description: >-
     Import historical hourly energy counters for TermoWeb heaters up to one
     year ago into Home Assistant statistics.
-  target:
-    entity:
-      integration: termoweb
   fields:
+    entity_id:
+      name: Energy sensors
+      description: >-
+        Restrict the import to the selected TermoWeb energy sensors. Leave
+        empty to refresh every configured heater.
+      selector:
+        entity:
+          integration: termoweb
+          domain: sensor
+          multiple: true
     reset_progress:
       name: Reset progress
       description: >-

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -88,8 +88,12 @@
     },
     "import_energy_history": {
       "name": "Import energy history",
-      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Target entities, devices, or areas to limit the import, or omit the target to refresh every TermoWeb config entry.",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Select specific sensors or leave the picker empty to refresh every TermoWeb config entry.",
       "fields": {
+        "entity_id": {
+          "name": "Energy sensors",
+          "description": "Restrict the import to the selected TermoWeb energy sensors. Leave empty to refresh every configured heater."
+        },
         "reset_progress": {
           "name": "Reset progress",
           "description": "Clear stored progress and re-import history from scratch."

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -92,8 +92,12 @@
     },
     "import_energy_history": {
       "name": "Import energy history",
-      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Target entities, devices, or areas to limit the import, or omit the target to refresh every TermoWeb config entry.",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Select specific sensors or leave the picker empty to refresh every TermoWeb config entry.",
       "fields": {
+        "entity_id": {
+          "name": "Energy sensors",
+          "description": "Restrict the import to the selected TermoWeb energy sensors. Leave empty to refresh every configured heater."
+        },
         "reset_progress": {
           "name": "Reset progress",
           "description": "Clear stored progress and re-import history from scratch."


### PR DESCRIPTION
## Summary
- remove the mandatory target selector from the import_energy_history service so it can run against all heaters
- expose an optional energy sensor picker in the service UI and refresh documentation strings accordingly
- clarify the README instructions to mention selecting sensors is optional

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ed21b65b6c8329a98ae9b16f58083a