### PR TITLE
Fix energy import service entity extraction compatibility

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -768,6 +768,8 @@ custom_components/termoweb/energy.py :: _resolve_recorder_imports
     Return cached recorder helper imports.
 custom_components/termoweb/energy.py :: _resolve_statistics_helpers
     Return the recorder statistics helpers for compatibility shims.
+custom_components/termoweb/energy.py :: _async_extract_selected_entities
+    Resolve referenced entities using available Home Assistant helpers.
 custom_components/termoweb/energy.py :: _normalize_heater_sources
     Return canonical heater node address map for ``addrs``.
 custom_components/termoweb/energy.py :: _iso_date


### PR DESCRIPTION
## Summary
- add a compatibility wrapper that uses the new target helper when extracting service entities while falling back to the legacy helper
- document the new helper in the function map index

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ed248a25ac8329b0c82ab9abec518a