### PR TITLE
Import energy history for all nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ See instructions in custom_components/termoweb/assets, to install the card and c
 - Add these sensors in **Settings → Dashboards → Energy** to include them in Home Assistant’s Energy Dashboard.
 - Live energy samples now arrive via the websocket connection, with the hourly
   REST poll remaining as a fallback if the push feed is unavailable.
-- Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration.
-- Select specific energy sensors (or provide their `entity_id` values) to limit the import, or leave the picker empty to refresh every TermoWeb config entry.
+- Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration. The service always refreshes every configured TermoWeb node.
 - No extra configuration is required beyond selecting the sensors in the Energy Dashboard.
 
 ---

--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -283,10 +283,6 @@ async def async_list_devices(client: RESTClient) -> Any:
 async def _async_import_energy_history(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    selection: Mapping[str, Iterable[str]]
-    | Iterable[tuple[str, str]]
-    | Iterable[str]
-    | None = None,
     *,
     reset_progress: bool = False,
     max_days: int | None = None,
@@ -297,7 +293,6 @@ async def _async_import_energy_history(
     await _async_import_energy_history_impl(
         hass,
         entry,
-        selection=selection,
         reset_progress=reset_progress,
         max_days=max_days,
         rate_limit=rate_state,

--- a/custom_components/termoweb/services.yaml
+++ b/custom_components/termoweb/services.yaml
@@ -109,18 +109,8 @@ import_energy_history:
   name: Import energy history
   description: >-
     Import historical hourly energy counters for TermoWeb heaters up to one
-    year ago into Home Assistant statistics.
+    year ago into Home Assistant statistics for every configured heater.
   fields:
-    entity_id:
-      name: Energy sensors
-      description: >-
-        Restrict the import to the selected TermoWeb energy sensors. Leave
-        empty to refresh every configured heater.
-      selector:
-        entity:
-          integration: termoweb
-          domain: sensor
-          multiple: true
     reset_progress:
       name: Reset progress
       description: >-

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -88,12 +88,8 @@
     },
     "import_energy_history": {
       "name": "Import energy history",
-      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Select specific sensors or leave the picker empty to refresh every TermoWeb config entry.",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics for every configured heater.",
       "fields": {
-        "entity_id": {
-          "name": "Energy sensors",
-          "description": "Restrict the import to the selected TermoWeb energy sensors. Leave empty to refresh every configured heater."
-        },
         "reset_progress": {
           "name": "Reset progress",
           "description": "Clear stored progress and re-import history from scratch."

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -92,12 +92,8 @@
     },
     "import_energy_history": {
       "name": "Import energy history",
-      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics. Select specific sensors or leave the picker empty to refresh every TermoWeb config entry.",
+      "description": "Import historical hourly energy counters for TermoWeb heaters up to one year ago into Home Assistant statistics for every configured heater.",
       "fields": {
-        "entity_id": {
-          "name": "Energy sensors",
-          "description": "Restrict the import to the selected TermoWeb energy sensors. Leave empty to refresh every configured heater."
-        },
         "reset_progress": {
           "name": "Reset progress",
           "description": "Clear stored progress and re-import history from scratch."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,9 @@ coordinators already consume.【F:custom_components/termoweb/inventory.py†L181
   caches, and broadcasts dispatcher signals. `DucaheatWSClient` layers brand-
   specific logging atop the shared implementation.【F:custom_components/termoweb/backend/ws_client.py†L40-L193】【F:custom_components/termoweb/backend/ducaheat_ws.py†L188-L386】
 - **Energy services** – the energy helper enforces a shared rate limiter for
-  historical sample queries, performs targeted imports based on entity
-  selection, and registers the `import_energy_history` service only once per
-  Home Assistant instance.【F:custom_components/termoweb/energy.py†L150-L177】【F:custom_components/termoweb/energy.py†L421-L512】【F:custom_components/termoweb/energy.py†L841-L919】
+  historical sample queries, iterates the immutable inventory to import every
+  node's history, and registers the `import_energy_history` service only once
+  per Home Assistant instance.【F:custom_components/termoweb/energy.py†L150-L177】【F:custom_components/termoweb/energy.py†L344-L523】【F:custom_components/termoweb/energy.py†L720-L774】
 
 - **Power monitor coverage** – `pmo` nodes are discovered from `dev_data`, expose read payloads via `/pmo/{addr}`
   and energy counters via `/pmo/{addr}/samples`. No WebSocket `status` deltas are observed, so consumers must poll REST or fetch

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -768,8 +768,6 @@ custom_components/termoweb/energy.py :: _resolve_recorder_imports
     Return cached recorder helper imports.
 custom_components/termoweb/energy.py :: _resolve_statistics_helpers
     Return the recorder statistics helpers for compatibility shims.
-custom_components/termoweb/energy.py :: _async_extract_selected_entities
-    Resolve referenced entities using available Home Assistant helpers.
 custom_components/termoweb/energy.py :: _normalize_heater_sources
     Return canonical heater node address map for ``addrs``.
 custom_components/termoweb/energy.py :: _iso_date


### PR DESCRIPTION
## Summary
- expand the energy import helper to iterate the full inventory instead of heater-only targets
- refresh documentation to explain that the service now backfills every configured node
- extend the import history tests to cover power monitor samples and progress tracking

## Testing
- `ruff check custom_components/termoweb/energy.py tests/test_import_energy_history.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ed273d2f3c8329a5a883cd9bf0361b