### PR TITLE
Improve energy history import resilience and observability

### DIFF
--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_BRAND, DEFAULT_BRAND, DOMAIN, get_brand_label
+from .energy import SUMMARY_KEY_LAST_RUN
 from .inventory import Inventory
 from .utils import async_get_integration_version
 
@@ -102,6 +103,15 @@ async def async_get_config_entry_diagnostics(
 
     if time_zone_str is not None:
         diagnostics["home_assistant"]["time_zone"] = time_zone_str
+
+    last_import = record.get(SUMMARY_KEY_LAST_RUN)
+    energy_section: dict[str, Any] = {}
+    if isinstance(last_import, Mapping):
+        energy_section["last_run"] = dict(last_import)
+    elif last_import is not None:
+        energy_section["last_run"] = last_import
+    if energy_section:
+        diagnostics["energy_import"] = energy_section
 
     _LOGGER.debug(
         "Diagnostics inventory cache for %s: raw=%d, filtered=%d",

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -809,7 +809,7 @@ custom_components/termoweb/energy.py :: _get_last_statistics_compat
 custom_components/termoweb/energy.py :: _clear_statistics_compat
     Clear statistics using whichever helper is available.
 custom_components/termoweb/energy.py :: async_import_energy_history
-    Fetch historical hourly samples and insert statistics.
+    Fetch historical hourly samples and insert statistics with filters.
 custom_components/termoweb/energy.py :: async_register_import_energy_history_service
     Register the import_energy_history service if it is missing.
 custom_components/termoweb/energy.py :: async_register_import_energy_history_service._service_import_energy_history


### PR DESCRIPTION
## Summary
- add optional node and address filters plus configurable day chunking to the energy import service
- harden async_import_energy_history with Inventory-driven filtering, duplicate avoidance, reset handling, per-run summaries, and diagnostics export
- document the service options and update the function map entry

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ee6a5130b48329a2a7f2ec21ba1927