### PR TITLE
Import energy history through current minute

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -57,6 +57,7 @@ The integration exposes the `termoweb.import_energy_history` service to backfill
 
 - Inventory drives the target selection. Filters are applied *after* expanding the Inventory and before de-duplication.
 - Sample timestamps always use seconds-since-epoch normalization performed by the REST adapter.
+- Imports request history through the current minute to ensure today’s samples are merged with existing statistics.
 - The importer clears overlapping statistics whenever recorder helpers are available; otherwise it logs a one-time INFO message and continues safely.
 - Device resets are detected when the cumulative counter drops by more than **0.2 kWh**. The integration starts a new accumulation segment without breaking the monotonic sum expected by Home Assistant.
 - Duplicate timestamps are discarded to avoid redundant statistics writes.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ See instructions in custom_components/termoweb/assets, to install the card and c
 - Add these sensors in **Settings → Dashboards → Energy** to include them in Home Assistant’s Energy Dashboard.
 - Live energy samples now arrive via the websocket connection, with the hourly
   REST poll remaining as a fallback if the push feed is unavailable.
-- Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration. The service always refreshes every configured TermoWeb node.
+- Use the `termoweb.import_energy_history` service (Developer Tools → Services) to backfill past consumption after installing the integration. The service always refreshes every configured TermoWeb node and reconciles all samples through the current minute with any existing statistics.
 - No extra configuration is required beyond selecting the sensors in the Energy Dashboard.
 
 ---

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -394,7 +394,6 @@ async def _clear_statistics_compat(  # pragma: no cover - compatibility shim
     return "delete"  # pragma: no cover - dependent on async helper availability
 
 
-
 async def async_import_energy_history(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -523,9 +522,7 @@ async def async_import_energy_history(
     target_pairs = [
         pair
         for pair in all_pairs
-        if (
-            normalized_type_filters is None or pair[0] in normalized_type_filters
-        )
+        if (normalized_type_filters is None or pair[0] in normalized_type_filters)
         and (
             normalized_address_filters is None or pair[1] in normalized_address_filters
         )
@@ -561,8 +558,8 @@ async def async_import_energy_history(
 
     now_dt = datetime_mod.now(UTC)
     run_started_iso = now_dt.isoformat()
-    start_of_today = now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
-    now_ts = int(start_of_today.timestamp()) - 1
+    current_minute = now_dt.replace(second=0, microsecond=0)
+    now_ts = int(current_minute.timestamp())
     if max_days is None:
         raw_max_days = entry.options.get(OPTION_MAX_HISTORY_RETRIEVED)
         try:
@@ -611,7 +608,9 @@ async def async_import_energy_history(
     )
 
     filters_snapshot = {
-        "node_types": sorted(normalized_type_filters) if normalized_type_filters else [],
+        "node_types": sorted(normalized_type_filters)
+        if normalized_type_filters
+        else [],
         "addresses": sorted(normalized_address_filters)
         if normalized_address_filters
         else [],
@@ -824,7 +823,9 @@ async def async_import_energy_history(
                 if before_values:
                     sorted_before = sorted(
                         before_values,
-                        key=lambda row: cast(datetime, _statistics_row_get(row, "start")),
+                        key=lambda row: cast(
+                            datetime, _statistics_row_get(row, "start")
+                        ),
                     )
                     last_before = sorted_before[-1]
         else:
@@ -840,7 +841,10 @@ async def async_import_energy_history(
                     if vals:
                         candidate = vals[0]
                         start_dt = _statistics_row_get(candidate, "start")
-                        if isinstance(start_dt, datetime) and start_dt < import_start_dt:
+                        if (
+                            isinstance(start_dt, datetime)
+                            and start_dt < import_start_dt
+                        ):
                             last_before = candidate
             except async_mod.CancelledError:  # pragma: no cover - allow cancellation
                 raise
@@ -1103,6 +1107,7 @@ async def async_register_import_energy_history_service(
 
     logger = _LOGGER
     async_mod = asyncio
+
     async def _service_import_energy_history(call) -> None:
         """Handle the import_energy_history service call."""
 

--- a/docs/termoweb_api.md
+++ b/docs/termoweb_api.md
@@ -141,7 +141,7 @@ Observed cadence for `htr`: ~3600 s.
 - Each heater’s `counter` value maps to a Home Assistant **Energy** sensor, and an aggregate sensor sums all heater counters for whole-home tracking.
 - Add these sensors in **Settings → Dashboards → Energy** so they appear in the Energy Dashboard.
 - The integration polls this endpoint hourly. When the cloud emits optional `htr/samples` WebSocket events, sensors update as those pushes arrive.
-- Call the `termoweb.import_energy_history` service to backfill past samples into Home Assistant’s statistics database.
+- Call the `termoweb.import_energy_history` service to backfill past samples into Home Assistant’s statistics database. The importer now extends through the current minute and reconciles with any previously recorded totals.
 
 
 

--- a/tests/test_energy_history_import.py
+++ b/tests/test_energy_history_import.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.termoweb import energy
+from custom_components.termoweb.energy import OPTION_ENERGY_HISTORY_PROGRESS
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[str, str], int, int]] = []
+
+    async def get_node_samples(
+        self,
+        dev_id: str,
+        node: tuple[str, str],
+        start: int,
+        stop: int,
+    ) -> list[dict[str, Any]]:
+        self.calls.append((dev_id, node, start, stop))
+        return []
+
+
+class _ImmediateRateLimiter:
+    async def async_throttle(self, on_wait=None):  # type: ignore[override]
+        if callable(on_wait):
+            on_wait(0.0)
+        return 0.0
+
+
+class _FixedDatetime(datetime):
+    _NOW = datetime(2024, 1, 2, 15, 45, 33, tzinfo=UTC)
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        base = cls._NOW
+        if tz is None:
+            tz = base.tzinfo
+        return cls(
+            base.year,
+            base.month,
+            base.day,
+            base.hour,
+            base.minute,
+            base.second,
+            base.microsecond,
+            tzinfo=tz,
+        )
+
+
+class _StubConfigEntry:
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+        self.data: dict[str, Any] = {}
+        self.options: dict[str, Any] = {}
+
+
+class _StubConfigEntries:
+    def __init__(self) -> None:
+        self._entries: dict[str, _StubConfigEntry] = {}
+        self.updated_entries: list[
+            tuple[_StubConfigEntry, dict[str, Any] | None, dict[str, Any] | None]
+        ] = []
+
+    def add(self, entry: _StubConfigEntry) -> None:
+        self._entries[entry.entry_id] = entry
+
+    def async_update_entry(
+        self,
+        entry: _StubConfigEntry,
+        *,
+        data: dict[str, Any] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        if data is not None:
+            entry.data = data
+        if options is not None:
+            entry.options = options
+        self.updated_entries.append((entry, data, options))
+
+
+@pytest.fixture
+def stub_hass() -> SimpleNamespace:
+    """Return a minimal Home Assistant stub for energy history tests."""
+
+    config_entries = _StubConfigEntries()
+    return SimpleNamespace(data={}, config_entries=config_entries)
+
+
+@pytest.mark.asyncio
+async def test_import_energy_history_fetches_until_current_minute(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_hass,
+    inventory_from_map,
+) -> None:
+    """Importer should request history through the current minute."""
+
+    entry = _StubConfigEntry("entry")
+    stub_hass.config_entries.add(entry)
+
+    inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-1")
+    client = _RecordingClient()
+
+    stub_hass.data.setdefault(energy.DOMAIN, {})[entry.entry_id] = {
+        "client": client,
+        "dev_id": "dev-1",
+        "inventory": inventory,
+    }
+
+    monkeypatch.setattr(energy, "datetime", _FixedDatetime, raising=False)
+    monkeypatch.setattr(energy.er, "async_get", lambda hass: None, raising=False)
+
+    await energy.async_import_energy_history(
+        stub_hass,
+        entry,
+        rate_limit=_ImmediateRateLimiter(),
+        max_days=1,
+    )
+
+    assert client.calls
+    _, node, start, stop = client.calls[0]
+    assert node == ("htr", "A")
+
+    expected_stop = int(
+        _FixedDatetime._NOW.replace(second=0, microsecond=0).timestamp()
+    )
+    assert stop == expected_stop
+    assert start == expected_stop - 24 * 3600
+
+    assert stub_hass.config_entries.updated_entries
+    last_update = stub_hass.config_entries.updated_entries[-1]
+    _, _, options = last_update
+    assert isinstance(options, dict)
+    assert OPTION_ENERGY_HISTORY_PROGRESS in options


### PR DESCRIPTION
## Summary
- update the energy history importer to request samples through the current minute so new data is reconciled with recorded statistics
- add a unit test that verifies the importer queries up to "now" and persists progress updates
- document the importer’s behaviour changes in README, API notes, and DEBUG guidance

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68ee8a0c42e48329b8fd6539d53ae8cb