### PR TITLE
Remove resolve_record_inventory helper

### DIFF
--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -49,7 +49,6 @@ __all__ = [
     "HeaterNode",
     "Inventory",
     "InventoryNodeMetadata",
-    "InventoryResolution",
     "Node",
     "NodeDescriptor",
     "PowerMonitorNode",
@@ -67,7 +66,6 @@ __all__ = [
     "normalize_power_monitor_addresses",
     "parse_heater_energy_unique_id",
     "power_monitor_sample_subscription_targets",
-    "resolve_record_inventory",
 ]
 
 
@@ -79,16 +77,6 @@ HEATER_NODE_TYPES: frozenset[str] = frozenset({"htr", "acm"})
 
 if TYPE_CHECKING:
     from .heater import HeaterPlatformDetails
-
-
-@dataclass(frozen=True, slots=True)
-class InventoryResolution:
-    """Describe the origin of an ``Inventory`` resolution attempt."""
-
-    inventory: Inventory | None
-    source: str
-    raw_count: int
-    filtered_count: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -856,29 +844,6 @@ class Inventory:
                 f"{context or 'inventory'} record is unavailable; cached inventory missing"
             )
         return candidate
-
-
-def resolve_record_inventory(
-    record: Mapping[str, Any] | None,
-    *,
-    dev_id: str | None = None,
-    nodes_payload: Any | None = None,
-    node_list: Iterable[Node] | None = None,
-) -> InventoryResolution:
-    """Return the ``Inventory`` for ``record`` and describe its origin."""
-
-    mapping: Mapping[str, Any] | None = record if isinstance(record, Mapping) else None
-
-    if mapping is None:
-        return InventoryResolution(None, "missing", 0, 0)
-
-    candidate = mapping.get("inventory")
-    if isinstance(candidate, Inventory):
-        node_count = len(candidate.nodes)
-        return InventoryResolution(candidate, "inventory", node_count, node_count)
-
-    _LOGGER.error("Inventory metadata missing for record %s", mapping.get("dev_id"))
-    return InventoryResolution(None, "missing", 0, 0)
 
 
 def _normalize_node_identifier(

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -359,36 +359,6 @@ def test_inventory_heater_sample_targets_filters_invalid(
     targets = heater_inventory.heater_sample_targets
     assert targets == [("htr", "1")]
     assert ("acm", "2") not in targets
-def test_resolve_record_inventory_prefers_existing_container() -> None:
-    """Resolution should return stored inventory without rebuilding."""
-
-    raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
-    container = Inventory(
-        "device",
-        raw_nodes,
-        inventory_module.build_node_inventory(raw_nodes),
-    )
-    record: dict[str, Any] = {"inventory": container}
-
-    resolution = inventory_module.resolve_record_inventory(record)
-
-    assert resolution.inventory is container
-    assert resolution.source == "inventory"
-    assert resolution.filtered_count == 1
-    assert resolution.raw_count == 1
-
-
-def test_resolve_record_inventory_missing_inventory_logs_error(caplog: pytest.LogCaptureFixture) -> None:
-    """Missing inventory should return a descriptive resolution."""
-
-    record: dict[str, Any] = {"dev_id": "device"}
-
-    resolution = inventory_module.resolve_record_inventory(record)
-
-    assert resolution.inventory is None
-    assert resolution.source == "missing"
-    assert resolution.filtered_count == 0
-    assert "device" in caplog.text
 
 
 def test_heater_platform_details_default_name(

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -525,11 +525,6 @@ def test_dispatch_nodes_reuses_record_inventory(monkeypatch: pytest.MonkeyPatch)
     dispatcher = MagicMock()
     monkeypatch.setattr(base_ws, "async_dispatcher_send", dispatcher)
 
-    def _fail(*_: Any, **__: Any) -> Any:
-        raise AssertionError("resolve_record_inventory should not be called")
-
-    monkeypatch.setattr(base_ws, "resolve_record_inventory", _fail, raising=False)
-
     class DummyCommon(base_ws._WSCommon):
         def __init__(self) -> None:
             self.hass = hass
@@ -577,11 +572,6 @@ def test_prepare_nodes_dispatch_resolves_record_dev_id_and_coordinator_inventory
     hass_record: dict[str, Any] = {"dev_id": "raw", "inventory": inventory}
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": hass_record}})
     coordinator = SimpleNamespace(update_nodes=MagicMock())
-
-    def _fail(*_: Any, **__: Any) -> Any:
-        raise AssertionError("resolve_record_inventory should not be called")
-
-    monkeypatch.setattr(base_ws, "resolve_record_inventory", _fail, raising=False)
 
     context = base_ws._prepare_nodes_dispatch(
         hass,
@@ -1350,8 +1340,6 @@ def test_ws_common_dispatch_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
     coordinator = SimpleNamespace(update_nodes=MagicMock(), dev_id="dev")
     dispatcher = MagicMock()
     monkeypatch.setattr(base_ws, "async_dispatcher_send", dispatcher)
-
-    monkeypatch.setattr(base_ws, "resolve_record_inventory", lambda *_, **__: None, raising=False)
 
     class Dummy(base_ws._WSCommon):
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- drop the unused `resolve_record_inventory` helper and its `InventoryResolution` dataclass from the inventory module
- update inventory exports to reflect the removal and tidy dependent unit tests

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef81711f348329ab56fa143daa1752