### PR TITLE
Remove unused heater energy unique ID helper

### DIFF
--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -65,7 +65,6 @@ __all__ = [
     "normalize_node_addr",
     "normalize_node_type",
     "normalize_power_monitor_addresses",
-    "parse_heater_energy_unique_id",
     "power_monitor_sample_subscription_targets",
     "resolve_record_inventory",
 ]
@@ -948,25 +947,6 @@ def normalize_node_addr(
         use_default_when_falsey=use_default_when_falsey,
         lowercase=False,
     )
-
-
-def parse_heater_energy_unique_id(unique_id: str) -> tuple[str, str, str] | None:
-    """Parse a heater energy sensor unique ID into its components."""
-
-    if not isinstance(unique_id, str):
-        return None
-    stripped = unique_id.strip()
-    if not stripped or not stripped.startswith(f"{DOMAIN}:"):
-        return None
-    try:
-        domain, dev, node, address, metric = stripped.split(":", 4)
-    except ValueError:
-        return None
-    if domain != DOMAIN or metric != "energy":
-        return None
-    if not dev or not node or not address:
-        return None
-    return dev, node, address
 
 
 def addresses_by_node_type(

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -988,8 +988,6 @@ custom_components/termoweb/inventory.py :: normalize_node_type
     Return ``value`` as a normalised node type string.
 custom_components/termoweb/inventory.py :: normalize_node_addr
     Return ``value`` as a normalised node address string.
-custom_components/termoweb/inventory.py :: parse_heater_energy_unique_id
-    Parse a heater energy sensor unique ID into its components.
 custom_components/termoweb/inventory.py :: addresses_by_node_type
     Return mapping of node type to address list, tracking unknown types.
 custom_components/termoweb/inventory.py :: build_heater_address_map

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,6 @@ from custom_components.termoweb.inventory import (
     normalize_heater_addresses,
     normalize_node_addr,
     normalize_node_type,
-    parse_heater_energy_unique_id,
 )
 from custom_components.termoweb.utils import (
     _entry_gateway_record,
@@ -270,7 +269,6 @@ def test_build_heater_energy_unique_id_round_trip(
     unique_id = build_heater_energy_unique_id(" dev ", " ACM ", " 01 ")
 
     assert unique_id == f"{DOMAIN}:dev:acm:01:energy"
-    assert parse_heater_energy_unique_id(unique_id) == ("dev", "acm", "01")
     assert calls == [
         ("addr", " dev ", {}),
         ("type", " ACM ", {}),
@@ -293,22 +291,6 @@ def test_build_heater_energy_unique_id_requires_components(
 ) -> None:
     with pytest.raises(ValueError):
         build_heater_energy_unique_id(dev_id, node_type, addr)
-
-
-@pytest.mark.parametrize(
-    "value",
-    [
-        None,
-        "",
-        "not-domain:dev:htr:01:energy",
-        f"{DOMAIN}:dev:htr:01:power",
-        f"{DOMAIN}:dev:htr:energy",
-        f"{DOMAIN}:dev:htr",
-        f"{DOMAIN}:dev::01:energy",
-    ],
-)
-def test_parse_heater_energy_unique_id_invalid(value) -> None:
-    assert parse_heater_energy_unique_id(value) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- remove the unused `parse_heater_energy_unique_id` helper from the inventory module
- update tests and the function map to reflect the helper removal

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef81656d8883299f2cb9c27d31bbc6