### PR TITLE
Remove unused stretched poll interval constant

### DIFF
--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -125,7 +125,6 @@ def signal_ws_status(entry_id: str) -> str:
 DEFAULT_POLL_INTERVAL: Final = 120  # seconds
 MIN_POLL_INTERVAL: Final = 30  # seconds
 MAX_POLL_INTERVAL: Final = 3600  # seconds
-STRETCHED_POLL_INTERVAL: Final = 2700  # seconds (45 minutes) when WS healthy ≥5 minutes
 
 # Heater energy polling interval when relying on push updates
 HTR_ENERGY_UPDATE_INTERVAL: Final = timedelta(hours=1)


### PR DESCRIPTION
## Summary
- remove the unused `STRETCHED_POLL_INTERVAL` constant from `custom_components/termoweb/const.py`

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef814c8128832986efb8aefd067ae0