### PR TITLE
Remove unused time_mod alias from backend ws_client

### DIFF
--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -801,9 +801,6 @@ __all__ = [
     "translate_path_update",
 ]
 
-time_mod = time.monotonic
-
-
 def __getattr__(name: str) -> Any:
     """Lazily expose backend websocket client implementations."""
 


### PR DESCRIPTION
## Summary
- remove the unused time_mod alias from backend ws_client to prevent exporting unused symbols

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef814233888329bd520f8784927311