### PR TITLE
Remove power monitor device unique ID helper

### DIFF
--- a/custom_components/termoweb/identifiers.py
+++ b/custom_components/termoweb/identifiers.py
@@ -59,12 +59,6 @@ def build_power_monitor_unique_id(
     return build_heater_unique_id(dev_id, "pmo", addr, suffix=suffix)
 
 
-def build_power_monitor_device_unique_id(dev_id: Any, addr: Any) -> str:
-    """Return the canonical unique ID for a power monitor device."""
-
-    return build_power_monitor_unique_id(dev_id, addr)
-
-
 def build_power_monitor_energy_unique_id(dev_id: Any, addr: Any) -> str:
     """Return the canonical unique ID for a power monitor energy sensor."""
 

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -930,8 +930,6 @@ custom_components/termoweb/identifiers.py :: build_heater_energy_unique_id
     Return the canonical unique ID for a heater energy sensor.
 custom_components/termoweb/identifiers.py :: build_power_monitor_unique_id
     Return the canonical unique ID for a power monitor node or entity.
-custom_components/termoweb/identifiers.py :: build_power_monitor_device_unique_id
-    Return the canonical unique ID for a power monitor device.
 custom_components/termoweb/identifiers.py :: build_power_monitor_energy_unique_id
     Return the canonical unique ID for a power monitor energy sensor.
 custom_components/termoweb/identifiers.py :: build_power_monitor_instant_power_unique_id

--- a/tests/test_identifiers_unique_ids.py
+++ b/tests/test_identifiers_unique_ids.py
@@ -9,7 +9,6 @@ from custom_components.termoweb import identifiers as identifiers_module
 from custom_components.termoweb.identifiers import (
     build_heater_entity_unique_id,
     build_heater_unique_id,
-    build_power_monitor_device_unique_id,
     build_power_monitor_energy_unique_id,
     build_power_monitor_power_unique_id,
     build_power_monitor_unique_id,
@@ -51,7 +50,7 @@ def test_power_monitor_helpers_defers_to_heater_unique_id(monkeypatch: pytest.Mo
     monkeypatch.setattr(identifiers_module, "build_heater_unique_id", _record)
 
     assert build_power_monitor_unique_id("dev", "03", suffix="daily") == "uid"
-    assert build_power_monitor_device_unique_id("dev", "03") == "uid"
+    assert build_power_monitor_unique_id("dev", "03") == "uid"
     assert build_power_monitor_energy_unique_id("dev", "03") == "uid"
     assert build_power_monitor_power_unique_id("dev", "03") == "uid"
     assert calls == [


### PR DESCRIPTION
## Summary
- remove the unused `build_power_monitor_device_unique_id` helper from the identifiers module
- adjust the unique ID tests to cover the remaining power monitor helpers
- update the function map documentation to reflect the removal

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef81394f688329b3c6e9f15528aef8