### PR TITLE
Remove unused boost duration label helper

### DIFF
--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -50,20 +50,6 @@ class BoostButtonMetadata:
     label: str
     icon: str
     action: str = "start"
-
-
-def format_boost_duration_label(minutes: int) -> str:
-    """Return a human-readable label for boost durations."""
-
-    if minutes <= 0:
-        return "0 minutes"
-    if minutes % 60:
-        return f"{minutes} minutes"
-    hours = minutes // 60
-    suffix = "hour" if hours == 1 else "hours"
-    return f"{hours} {suffix}"
-
-
 def _build_boost_button_metadata() -> tuple[BoostButtonMetadata, ...]:
     """Return the configured metadata describing boost helper buttons."""
 

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -828,8 +828,6 @@ custom_components/termoweb/entity.py :: GatewayDispatcherEntity.async_will_remov
     Unsubscribe from dispatcher updates before removal.
 custom_components/termoweb/entity.py :: GatewayDispatcherEntity._handle_gateway_dispatcher
     Handle dispatcher payloads targeting the entity.
-custom_components/termoweb/heater.py :: format_boost_duration_label
-    Return a human-readable label for boost durations.
 custom_components/termoweb/heater.py :: _build_boost_button_metadata
     Return the configured metadata describing boost helper buttons.
 custom_components/termoweb/heater.py :: HeaterPlatformDetails.__iter__


### PR DESCRIPTION
## Summary
- remove the unused `format_boost_duration_label` helper from the heater helpers module
- drop the corresponding documentation entry from `docs/function_map.txt`

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef8133838c8329aeaae7b14b0073f2