### PR TITLE
Refactor boost minute coercion helper

### DIFF
--- a/custom_components/termoweb/boost.py
+++ b/custom_components/termoweb/boost.py
@@ -61,6 +61,12 @@ def coerce_boost_bool(value: Any) -> bool | None:
 def coerce_boost_minutes(value: Any) -> int | None:
     """Return ``value`` as positive minutes when possible."""
 
+    return _coerce_positive_minutes(value)
+
+
+def _coerce_positive_minutes(value: Any) -> int | None:
+    """Return ``value`` as a positive integer minute count when possible."""
+
     if value is None or isinstance(value, bool):
         return None
 
@@ -69,19 +75,6 @@ def coerce_boost_minutes(value: Any) -> int | None:
         return None
 
     return minutes
-
-
-def coerce_boost_remaining_minutes(value: Any) -> int | None:
-    """Return ``value`` as a positive integer minute count when possible."""
-
-    if value is None or isinstance(value, bool):
-        return None
-
-    candidate = coerce_int(value)
-    if candidate is None or candidate <= 0:
-        return None
-
-    return candidate
 
 
 def supports_boost(node: Any) -> bool:

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -14,12 +14,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .boost import (
-    coerce_boost_bool,
-    coerce_boost_minutes,
-    coerce_boost_remaining_minutes,
-    supports_boost,
-)
+from .boost import coerce_boost_bool, coerce_boost_minutes, supports_boost
 from .const import DOMAIN, signal_ws_data
 from .inventory import (
     HEATER_NODE_TYPES,
@@ -616,7 +611,7 @@ def derive_boost_state(
             boost_minutes = resolved_minutes
 
     if boost_minutes is None:
-        boost_minutes = coerce_boost_remaining_minutes(source.get("boost_remaining"))
+        boost_minutes = coerce_boost_minutes(source.get("boost_remaining"))
 
     if boost_minutes is None and boost_end_dt is not None:
         delta_seconds = (boost_end_dt - dt_util.now()).total_seconds()

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -506,7 +506,7 @@ custom_components/termoweb/boost.py :: coerce_boost_bool
     Return ``value`` as a boolean when possible.
 custom_components/termoweb/boost.py :: coerce_boost_minutes
     Return ``value`` as positive minutes when possible.
-custom_components/termoweb/boost.py :: coerce_boost_remaining_minutes
+custom_components/termoweb/boost.py :: _coerce_positive_minutes
     Return ``value`` as a positive integer minute count when possible.
 custom_components/termoweb/boost.py :: supports_boost
     Return ``True`` when ``node`` exposes boost controls.

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -666,14 +666,11 @@ def test_coerce_boost_minutes_edge_cases() -> None:
     assert coerce("90") == 90
     assert coerce(120.7) == 120
 
-    remaining = boost_module.coerce_boost_remaining_minutes
-    assert remaining(0) is None
 
+def test_coerce_boost_minutes_filters_non_positive() -> None:
+    """Ensure boost minute coercion rejects falsey and negative values."""
 
-def test_coerce_boost_remaining_minutes_filters_non_positive() -> None:
-    """Ensure remaining minute coercion rejects falsey and negative values."""
-
-    coerce = boost_module.coerce_boost_remaining_minutes
+    coerce = boost_module.coerce_boost_minutes
     assert coerce(None) is None
     assert coerce(False) is None
     assert coerce(0) is None
@@ -682,10 +679,10 @@ def test_coerce_boost_remaining_minutes_filters_non_positive() -> None:
     assert coerce("15") == 15
 
 
-def test_coerce_boost_remaining_minutes_non_positive() -> None:
-    """Ensure boost remaining coercion rejects non-positive values."""
+def test_coerce_boost_minutes_non_positive_values() -> None:
+    """Ensure boost minute coercion rejects non-positive values."""
 
-    coerce = boost_module.coerce_boost_remaining_minutes
+    coerce = boost_module.coerce_boost_minutes
     assert coerce(None) is None
     assert coerce(False) is None
     assert coerce(0) is None


### PR DESCRIPTION
## Summary
- collapse the boost minute coercion logic into a single implementation
- update heater boost processing and documentation to reference the unified helper
- refresh unit tests to cover the remaining coercion helper

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef81202b208329a4c28079d0b75c25