### PR TITLE
Add heater energy unique ID parser

### DIFF
--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.loader import async_get_integration as loader_async_get_integration
 
 from .const import DOMAIN
-from .inventory import normalize_node_addr
+from .inventory import normalize_node_addr, normalize_node_type
 
 
 async def async_get_integration(*args, **kwargs):
@@ -171,3 +171,28 @@ def float_or_none(value: Any) -> float | None:
         return None
 
 
+def parse_heater_energy_unique_id(value: Any) -> tuple[str, str, str] | None:
+    """Return the ``dev_id``, ``node_type`` and ``addr`` from a heater energy ID."""
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+
+    parts = cleaned.split(":")
+    if len(parts) != 5:
+        return None
+
+    domain, dev_id, node_type, addr, suffix = parts
+    if domain != DOMAIN or suffix != "energy":
+        return None
+
+    dev_id = normalize_node_addr(dev_id)
+    node_type = normalize_node_type(node_type)
+    addr = normalize_node_addr(addr)
+
+    if not dev_id or not node_type or not addr:
+        return None
+
+    return dev_id, node_type, addr

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1220,6 +1220,8 @@ custom_components/termoweb/utils.py :: build_power_monitor_device_info
     Return canonical ``DeviceInfo`` for a TermoWeb power monitor.
 custom_components/termoweb/utils.py :: float_or_none
     Return value as ``float`` if possible, else ``None``.
+custom_components/termoweb/utils.py :: parse_heater_energy_unique_id
+    Return the ``dev_id``, ``node_type`` and ``addr`` from a heater energy ID.
 scripts/generate_function_map.py :: DocExtractor.__init__
     Initialise the extractor for ``file_path``.
 scripts/generate_function_map.py :: DocExtractor.visit_ClassDef

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from custom_components.termoweb.utils import (
     async_get_integration_version,
     build_gateway_device_info,
     float_or_none,
+    parse_heater_energy_unique_id,
 )
 
 
@@ -303,6 +304,12 @@ def test_build_heater_energy_unique_id_requires_components(
 )
 def test_parse_heater_energy_unique_id_invalid(value) -> None:
     assert parse_heater_energy_unique_id(value) is None
+
+
+def test_parse_heater_energy_unique_id_valid() -> None:
+    unique_id = build_heater_energy_unique_id(" Dev ", " ACM ", " 01 ")
+
+    assert parse_heater_energy_unique_id(unique_id) == ("Dev", "acm", "01")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a parser helper for heater energy sensor unique IDs and normalise the extracted components
- exercise the parser through new tests and document the helper in the function map

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68ef84af5aa48329b0464dc661412f80