### PR TITLE
Fix hassfest failure by relocating fallback translations

### DIFF
--- a/custom_components/termoweb/fallback_translations.py
+++ b/custom_components/termoweb/fallback_translations.py
@@ -1,0 +1,122 @@
+"""Fallback translation strings for the TermoWeb integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+FALLBACK_TRANSLATIONS: dict[str, dict[str, str]] = {
+    "cs": {
+        "heater_name": "Topidlo {addr}",
+        "node_name": "Uzel {addr}",
+        "power_monitor_name": "Monitor energie {addr}",
+        "never": "Nikdy",
+    },
+    "de": {
+        "heater_name": "Heizgerät {addr}",
+        "node_name": "Knoten {addr}",
+        "power_monitor_name": "Leistungsmonitor {addr}",
+        "never": "Nie",
+    },
+    "el": {
+        "heater_name": "Θερμαντικό {addr}",
+        "node_name": "Κόμβος {addr}",
+        "power_monitor_name": "Μετρητής ενέργειας {addr}",
+        "never": "Ποτέ",
+    },
+    "en": {
+        "heater_name": "Heater {addr}",
+        "node_name": "Node {addr}",
+        "power_monitor_name": "Power Monitor {addr}",
+        "never": "Never",
+    },
+    "es": {
+        "heater_name": "Calefactor {addr}",
+        "node_name": "Nodo {addr}",
+        "power_monitor_name": "Monitor de potencia {addr}",
+        "never": "Nunca",
+    },
+    "fr": {
+        "heater_name": "Radiateur {addr}",
+        "node_name": "Nœud {addr}",
+        "power_monitor_name": "Surveillance d’énergie {addr}",
+        "never": "Jamais",
+    },
+    "hr": {
+        "heater_name": "Grijač {addr}",
+        "node_name": "Čvor {addr}",
+        "power_monitor_name": "Mjerač energije {addr}",
+        "never": "Nikada",
+    },
+    "it": {
+        "heater_name": "Riscaldatore {addr}",
+        "node_name": "Nodo {addr}",
+        "power_monitor_name": "Monitor di potenza {addr}",
+        "never": "Mai",
+    },
+    "pl": {
+        "heater_name": "Grzejnik {addr}",
+        "node_name": "Węzeł {addr}",
+        "power_monitor_name": "Monitor mocy {addr}",
+        "never": "Nigdy",
+    },
+    "pt-pt": {
+        "heater_name": "Aquecedor {addr}",
+        "node_name": "Nó {addr}",
+        "power_monitor_name": "Monitor de energia {addr}",
+        "never": "Nunca",
+    },
+    "ro": {
+        "heater_name": "Încălzitor {addr}",
+        "node_name": "Nod {addr}",
+        "power_monitor_name": "Monitor de energie {addr}",
+        "never": "Niciodată",
+    },
+    "ru": {
+        "heater_name": "Обогреватель {addr}",
+        "node_name": "Узел {addr}",
+        "power_monitor_name": "Монитор энергии {addr}",
+        "never": "Никогда",
+    },
+    "sk": {
+        "heater_name": "Ohrievač {addr}",
+        "node_name": "Uzol {addr}",
+        "power_monitor_name": "Monitor energie {addr}",
+        "never": "Nikdy",
+    },
+    "tr": {
+        "heater_name": "Isıtıcı {addr}",
+        "node_name": "Düğüm {addr}",
+        "power_monitor_name": "Güç izleyicisi {addr}",
+        "never": "Asla",
+    },
+    "uk": {
+        "heater_name": "Обігрівач {addr}",
+        "node_name": "Вузол {addr}",
+        "power_monitor_name": "Лічильник енергії {addr}",
+        "never": "Ніколи",
+    },
+}
+
+
+def language_candidates(language: str) -> list[str]:
+    """Return ordered fallback language candidates for ``language``."""
+    normalized = (language or "").strip()
+    if not normalized:
+        return ["en"]
+    normalized = normalized.replace("_", "-").lower()
+    candidates: list[str] = [normalized]
+    if "-" in normalized:
+        base = normalized.split("-", 1)[0]
+        candidates.append(base)
+    if "en" not in candidates:
+        candidates.append("en")
+    return candidates
+
+
+def get_fallback_translations(language: str) -> Mapping[str, str]:
+    """Return fallback translation strings for ``language``."""
+    for candidate in language_candidates(language):
+        data = FALLBACK_TRANSLATIONS.get(candidate)
+        if data:
+            return dict(data)
+    return FALLBACK_TRANSLATIONS["en"]

--- a/custom_components/termoweb/i18n.py
+++ b/custom_components/termoweb/i18n.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+
 try:  # pragma: no cover - fallback for stripped Home Assistant stubs in tests
     from homeassistant.helpers.translation import async_get_translations
 except ImportError:  # pragma: no cover - executed in unit test stubs
@@ -17,7 +18,9 @@ except ImportError:  # pragma: no cover - executed in unit test stubs
 
         return {}
 
+
 from .const import DOMAIN
+from .fallback_translations import get_fallback_translations
 
 FALLBACK_TRANSLATIONS_KEY = "fallback_translations"
 COORDINATOR_FALLBACK_ATTR = "_termoweb_fallback_translations"
@@ -54,13 +57,7 @@ async def async_get_fallback_translations(
     if not language:
         language = getattr(hass.config, "default_language", None) or "en"
 
-    strings = await async_get_translations(hass, language, DOMAIN)
-    prefix = f"component.{DOMAIN}."
-    fallbacks = {
-        key[len(prefix) :]: value
-        for key, value in strings.items()
-        if key.startswith(f"{prefix}fallbacks.")
-    }
+    fallbacks = get_fallback_translations(language)
 
     if isinstance(entry_data, MutableMapping):
         entry_data[FALLBACK_TRANSLATIONS_KEY] = fallbacks
@@ -103,10 +100,10 @@ def attach_fallbacks(target: Any, fallbacks: Mapping[str, str] | None) -> None:
 
 
 __all__ = [
-    "attach_fallbacks",
     "COORDINATOR_FALLBACK_ATTR",
     "FALLBACK_TRANSLATIONS_KEY",
     "_tr",
     "async_get_fallback_translations",
+    "attach_fallbacks",
     "format_fallback",
 ]

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -27,12 +27,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Heater {addr}",
-    "node_name": "Node {addr}",
-    "power_monitor_name": "Power Monitor {addr}",
-    "never": "Never"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/cs.json
+++ b/custom_components/termoweb/translations/cs.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Topidlo {addr}",
-    "node_name": "Uzel {addr}",
-    "power_monitor_name": "Monitor energie {addr}",
-    "never": "Nikdy"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/de.json
+++ b/custom_components/termoweb/translations/de.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Heizgerät {addr}",
-    "node_name": "Knoten {addr}",
-    "power_monitor_name": "Leistungsmonitor {addr}",
-    "never": "Nie"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/el.json
+++ b/custom_components/termoweb/translations/el.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Θερμαντικό {addr}",
-    "node_name": "Κόμβος {addr}",
-    "power_monitor_name": "Μετρητής ενέργειας {addr}",
-    "never": "Ποτέ"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Heater {addr}",
-    "node_name": "Node {addr}",
-    "power_monitor_name": "Power Monitor {addr}",
-    "never": "Never"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/es.json
+++ b/custom_components/termoweb/translations/es.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Calefactor {addr}",
-    "node_name": "Nodo {addr}",
-    "power_monitor_name": "Monitor de potencia {addr}",
-    "never": "Nunca"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/fr.json
+++ b/custom_components/termoweb/translations/fr.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Radiateur {addr}",
-    "node_name": "Nœud {addr}",
-    "power_monitor_name": "Surveillance d’énergie {addr}",
-    "never": "Jamais"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/hr.json
+++ b/custom_components/termoweb/translations/hr.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Grijač {addr}",
-    "node_name": "Čvor {addr}",
-    "power_monitor_name": "Mjerač energije {addr}",
-    "never": "Nikada"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/it.json
+++ b/custom_components/termoweb/translations/it.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Riscaldatore {addr}",
-    "node_name": "Nodo {addr}",
-    "power_monitor_name": "Monitor di potenza {addr}",
-    "never": "Mai"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/pl.json
+++ b/custom_components/termoweb/translations/pl.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Grzejnik {addr}",
-    "node_name": "Węzeł {addr}",
-    "power_monitor_name": "Monitor mocy {addr}",
-    "never": "Nigdy"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/pt-PT.json
+++ b/custom_components/termoweb/translations/pt-PT.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Aquecedor {addr}",
-    "node_name": "Nó {addr}",
-    "power_monitor_name": "Monitor de energia {addr}",
-    "never": "Nunca"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/ro.json
+++ b/custom_components/termoweb/translations/ro.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Încălzitor {addr}",
-    "node_name": "Nod {addr}",
-    "power_monitor_name": "Monitor de energie {addr}",
-    "never": "Niciodată"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/ru.json
+++ b/custom_components/termoweb/translations/ru.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Обогреватель {addr}",
-    "node_name": "Узел {addr}",
-    "power_monitor_name": "Монитор энергии {addr}",
-    "never": "Никогда"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/sk.json
+++ b/custom_components/termoweb/translations/sk.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Ohrievač {addr}",
-    "node_name": "Uzol {addr}",
-    "power_monitor_name": "Monitor energie {addr}",
-    "never": "Nikdy"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/tr.json
+++ b/custom_components/termoweb/translations/tr.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Isıtıcı {addr}",
-    "node_name": "Düğüm {addr}",
-    "power_monitor_name": "Güç izleyicisi {addr}",
-    "never": "Asla"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/uk.json
+++ b/custom_components/termoweb/translations/uk.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Обігрівач {addr}",
-    "node_name": "Вузол {addr}",
-    "power_monitor_name": "Лічильник енергії {addr}",
-    "never": "Ніколи"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -854,6 +854,10 @@ custom_components/termoweb/entity.py :: GatewayDispatcherEntity.async_will_remov
     Unsubscribe from dispatcher updates before removal.
 custom_components/termoweb/entity.py :: GatewayDispatcherEntity._handle_gateway_dispatcher
     Handle dispatcher payloads targeting the entity.
+custom_components/termoweb/fallback_translations.py :: language_candidates
+    Return ordered fallback language candidates for ``language``.
+custom_components/termoweb/fallback_translations.py :: get_fallback_translations
+    Return fallback translation strings for ``language``.
 custom_components/termoweb/heater.py :: _build_boost_button_metadata
     Return the configured metadata describing boost helper buttons.
 custom_components/termoweb/heater.py :: HeaterPlatformDetails.__iter__


### PR DESCRIPTION
## Summary
- move the fallback translation strings into a dedicated Python helper so they no longer sit in hassfest-managed JSON
- update the i18n helper to read from the new fallback cache and remove the unsupported keys from strings.json and the locale files
- document the new helper functions in docs/function_map.txt

## Testing
- uv run ruff format custom_components/termoweb/i18n.py custom_components/termoweb/fallback_translations.py
- uv run ruff check --fix custom_components/termoweb/i18n.py custom_components/termoweb/fallback_translations.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68efa5ac71fc83298c0edb2ab95d005b