### PR TITLE
Fix invalid translation JSON after merge conflict

### DIFF
--- a/custom_components/termoweb/translations/bg.json
+++ b/custom_components/termoweb/translations/bg.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Нагревател {addr}",
-    "node_name": "Възел {addr}",
-    "power_monitor_name": "Монитор на захранването {addr}",
-    "never": "Никога"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/cs.json
+++ b/custom_components/termoweb/translations/cs.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Ohřívač {addr}",
-    "node_name": "Uzel {addr}",
-    "power_monitor_name": "Monitor napájení {addr}",
-    "never": "Nikdy"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/da.json
+++ b/custom_components/termoweb/translations/da.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Varmeapparat {addr}",
-    "node_name": "Knudepunkt {addr}",
-    "power_monitor_name": "Strømovervågning {addr}",
-    "never": "Aldrig"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/de.json
+++ b/custom_components/termoweb/translations/de.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Heizgerät {addr}",
-    "node_name": "Knoten {addr}",
-    "power_monitor_name": "Leistungsmonitor {addr}",
-    "never": "Niemals"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/el.json
+++ b/custom_components/termoweb/translations/el.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Θερμαντήρας {addr}",
-    "node_name": "Κόμβος {addr}",
-    "power_monitor_name": "Παρακολούθηση ισχύος {addr}",
-    "never": "Ποτέ"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/es.json
+++ b/custom_components/termoweb/translations/es.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Calentador {addr}",
-    "node_name": "Nodo {addr}",
-    "power_monitor_name": "Monitor de potencia {addr}",
-    "never": "Nunca"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/et.json
+++ b/custom_components/termoweb/translations/et.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Kütteseade {addr}",
-    "node_name": "Sõlm {addr}",
-    "power_monitor_name": "Võimsusmonitor {addr}",
-    "never": "Mitte kunagi"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/fi.json
+++ b/custom_components/termoweb/translations/fi.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Lämmitin {addr}",
-    "node_name": "Solmu {addr}",
-    "power_monitor_name": "Tehonvalvonta {addr}__",
-    "never": "Ei koskaan"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/fr.json
+++ b/custom_components/termoweb/translations/fr.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Chauffage {addr}",
-    "node_name": "Nœud {addr}",
-    "power_monitor_name": "Moniteur de puissance {addr}",
-    "never": "Jamais"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/hu.json
+++ b/custom_components/termoweb/translations/hu.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Fűtés {addr}",
-    "node_name": "Csomópont {addr}",
-    "power_monitor_name": "Teljesítményfigyelő {addr}",
-    "never": "Soha"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/lt.json
+++ b/custom_components/termoweb/translations/lt.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Šildytuvas {addr}",
-    "node_name": "Mazgas {addr}",
-    "power_monitor_name": "Maitinimo monitorius {addr}",
-    "never": "Niekada"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/lv.json
+++ b/custom_components/termoweb/translations/lv.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Sildītājs {addr}",
-    "node_name": "Mezgls {addr}",
-    "power_monitor_name": "Enerģijas monitora {addr}",
-    "never": "Nekad"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/nb.json
+++ b/custom_components/termoweb/translations/nb.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Varmeapparat {addr}",
-    "node_name": "Knutepunkt {addr}",
-    "power_monitor_name": "Strømovervåkning {addr}",
-    "never": "Aldri"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/nl.json
+++ b/custom_components/termoweb/translations/nl.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Verwarming {addr}",
-    "node_name": "Knooppunt {addr}",
-    "power_monitor_name": "Vermogensmonitor {addr}",
-    "never": "Nooit"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/sl.json
+++ b/custom_components/termoweb/translations/sl.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Grelnik {addr}",
-    "node_name": "Vozlišče {addr}",
-    "power_monitor_name": "Monitor moči {addr}",
-    "never": "Nikoli"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {

--- a/custom_components/termoweb/translations/sv.json
+++ b/custom_components/termoweb/translations/sv.json
@@ -31,12 +31,6 @@
       }
     }
   },
-  "fallbacks": {
-    "heater_name": "Värmeelement {addr}",
-    "node_name": "Nod {addr}",
-    "power_monitor_name": "Strömövervakning {addr}",
-    "never": "Aldrig"
-  },
   "entity": {
     "binary_sensor": {
       "gateway_online": {


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from the localized translation files so hassfest accepts them again

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68efe0b6cc48832980d632de1c34fb46