### PR TITLE
Deduplicate hourly statistics inserts

### DIFF
--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -1119,7 +1119,10 @@ async def async_import_energy_history(
                 continue
 
             running_sum += delta
-            stats.append({"start": start_dt, "sum": running_sum})
+            if stats and stats[-1]["start"] == start_dt:
+                stats[-1]["sum"] = running_sum
+            else:
+                stats.append({"start": start_dt, "sum": running_sum})
             previous_kwh = kwh
 
         first_iso = datetime_mod.fromtimestamp(first_ts_val, UTC).isoformat()

--- a/tests/test_energy_history_import.py
+++ b/tests/test_energy_history_import.py
@@ -551,6 +551,124 @@ async def test_import_skips_duplicate_sample_timestamps(
 
 
 @pytest.mark.asyncio
+async def test_import_coalesces_samples_within_hour(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_hass,
+    inventory_from_map,
+) -> None:
+    """Importer should merge multiple samples that fall within one hour."""
+
+    entry = _StubConfigEntry("entry")
+    stub_hass.config_entries.add(entry)
+
+    base_ts = 1_700_300_000
+    samples = [
+        {"t": base_ts, "counter": 1_000},
+        {"t": base_ts + 60, "counter": 1_300},
+        {"t": base_ts + 120, "counter": 1_600},
+        {"t": base_ts + 3_600, "counter": 2_600},
+    ]
+
+    class _SampleClient:
+        def __init__(self, payload: list[dict[str, int]]) -> None:
+            self.payload = payload
+
+        async def get_node_samples(self, dev_id, node, start, stop):
+            return self.payload
+
+    client = _SampleClient(samples)
+
+    inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-merge")
+    stub_hass.data.setdefault(energy.DOMAIN, {})[entry.entry_id] = {
+        "client": client,
+        "dev_id": "dev-merge",
+        "inventory": inventory,
+    }
+
+    entity_id = "sensor.merge_energy"
+    external_id = "sensor:merge_energy"
+
+    class _Registry:
+        def async_get_entity_id(self, domain, platform, unique_id):
+            if domain == "sensor" and platform == energy.DOMAIN:
+                return entity_id
+            return None
+
+        def async_get(self, requested):
+            if requested == entity_id:
+                return SimpleNamespace(original_name="Merge Energy")
+            return None
+
+    registry = _Registry()
+    monkeypatch.setattr(energy.er, "async_get", lambda hass: registry, raising=False)
+
+    async def _fake_stats_period(hass, start_time, end_time, statistic_ids):
+        ids = set(statistic_ids)
+        if ids == {entity_id, external_id}:
+            return {entity_id: [], external_id: []}
+        if ids == {external_id}:
+            return {external_id: []}
+        return {}
+
+    async def _fake_clear_statistics(
+        hass,
+        statistic_id: str,
+        *,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> str:
+        return "clear"
+
+    stored_payloads: list[list[dict[str, Any]]] = []
+
+    async def _capture_store(
+        hass, metadata: dict[str, Any], stats: list[dict[str, Any]]
+    ) -> None:
+        stored_payloads.append(stats)
+
+    async def _noop_enforce(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        energy,
+        "_statistics_during_period_compat",
+        _fake_stats_period,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        energy,
+        "_clear_statistics_compat",
+        _fake_clear_statistics,
+        raising=False,
+    )
+    monkeypatch.setattr(energy, "_store_statistics", _capture_store, raising=False)
+    monkeypatch.setattr(energy, "_enforce_monotonic_sum", _noop_enforce, raising=False)
+
+    await energy.async_import_energy_history(
+        stub_hass,
+        entry,
+        rate_limit=_ImmediateRateLimiter(),
+        max_days=1,
+    )
+
+    assert stored_payloads, "No statistics were recorded"
+    stats = stored_payloads[0]
+    assert len(stats) == 2
+
+    first_start = datetime.fromtimestamp(base_ts, UTC).replace(
+        minute=0, second=0, microsecond=0
+    )
+    second_start = datetime.fromtimestamp(base_ts + 3_600, UTC).replace(
+        minute=0, second=0, microsecond=0
+    )
+
+    assert stats[0]["start"] == first_start
+    assert stats[1]["start"] == second_start
+    assert stats[0]["sum"] == pytest.approx(0.6)
+    assert stats[1]["sum"] == pytest.approx(1.6)
+
+
+@pytest.mark.asyncio
 async def test_import_skips_negative_deltas_after_reset(
     monkeypatch: pytest.MonkeyPatch,
     stub_hass,


### PR DESCRIPTION
## Summary
- coalesce intra-hour energy samples so only one statistics row is written per hour
- add a regression test covering multiple samples arriving in the same hour

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68effdc6e3f083299fdd3f5914bd54cd