### PR TITLE
Refine Ducaheat websocket subscription paths

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -1166,15 +1166,11 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                         exc_info=True,
                     )
 
-            targets = [tuple(target) for target in inventory_container.heater_sample_targets]
-            if not targets:
-                return 0
-
-            paths: set[str] = {
-                f"/{node_type}/{addr}/{section}"
-                for node_type, addr in targets
-                for section in ("status", "samples")
-            }
+            paths: set[str] = set()
+            for node_type, addr in inventory_container.heater_sample_targets:
+                base_path = f"/{node_type}/{addr}"
+                paths.add(f"{base_path}/status")
+                paths.add(f"{base_path}/samples")
 
             if not paths:
                 return 0

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -1728,6 +1728,7 @@ async def test_subscribe_feeds_stores_inventory_only(
 
     assert count == 2
     assert {path for _evt, path in emissions} == {"/htr/1/samples", "/htr/1/status"}
+    assert client._subscription_paths == {"/htr/1/samples", "/htr/1/status"}
     bucket = client.hass.data[ducaheat_ws.DOMAIN]["entry"]
     stored = bucket.get("inventory")
     assert stored is inventory
@@ -1762,6 +1763,7 @@ async def test_subscribe_feeds_uses_inventory_cache(
         ("subscribe", "/htr/7/samples"),
         ("subscribe", "/htr/7/status"),
     ]
+    assert client._subscription_paths == {"/htr/7/samples", "/htr/7/status"}
     record = client.hass.data[ducaheat_ws.DOMAIN]["entry"]
     inventory = record.get("inventory")
     assert isinstance(inventory, Inventory)
@@ -1796,6 +1798,7 @@ async def test_subscribe_feeds_uses_record_inventory_cache(
 
     assert count == 2
     assert set(emissions) == {"/htr/9/samples", "/htr/9/status"}
+    assert client._subscription_paths == {"/htr/9/samples", "/htr/9/status"}
 
 
 @pytest.mark.asyncio
@@ -1818,6 +1821,7 @@ async def test_subscribe_feeds_handles_missing_targets(
 
     assert count == 0
     emit_mock.assert_not_awaited()
+    assert client._subscription_paths == set()
 @pytest.mark.asyncio
 async def test_subscribe_feeds_prefers_coordinator_inventory(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- iterate heater sample targets directly when building Ducaheat websocket subscription paths
- retain only computed subscription paths for replay and extend protocol tests to assert the cached set

## Testing
- pytest tests/test_ducaheat_ws_protocol.py tests/test_ducaheat_ws_apply_nodes_raw_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68f09521d44c832988b060d76cb3d908