### PR TITLE
Streamline websocket heater subscriptions

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -375,7 +375,7 @@ custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient._apply_heat
 custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient._heater_sample_subscription_targets
     Return ordered ``(node_type, addr)`` heater sample subscriptions.
 custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient._heater_sample_subscription_targets._bind_inventory
-    Cache ``container`` across runtime state helpers.
+    Yield subscription targets sourced from the inventory cache.
 custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient._subscribe_heater_samples
     Subscribe to heater and accumulator sample updates.
 custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient._mark_event

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -1188,7 +1188,7 @@ def test_heater_sample_subscription_targets(monkeypatch: pytest.MonkeyPatch) -> 
     )
     client._inventory = inventory
 
-    targets = client._heater_sample_subscription_targets()
+    targets = list(client._heater_sample_subscription_targets())
 
     assert targets == inventory.heater_sample_targets
 
@@ -1208,7 +1208,7 @@ def test_heater_sample_subscription_targets_use_coordinator_inventory(
     client._inventory = None
     client._coordinator.inventory = inventory
 
-    targets = client._heater_sample_subscription_targets()
+    targets = list(client._heater_sample_subscription_targets())
 
     assert targets == inventory.heater_sample_targets
     assert client._inventory is inventory
@@ -1225,7 +1225,7 @@ def test_heater_sample_subscription_targets_logs_missing_inventory(
     client._coordinator.inventory = None
 
     with caplog.at_level(logging.ERROR):
-        targets = client._heater_sample_subscription_targets()
+        targets = list(client._heater_sample_subscription_targets())
 
     assert not targets
     assert any(
@@ -1244,7 +1244,7 @@ def test_heater_sample_targets_do_not_rebuild_from_record(monkeypatch: pytest.Mo
     client._inventory = None
     client._coordinator.inventory = None
 
-    targets = client._heater_sample_subscription_targets()
+    targets = list(client._heater_sample_subscription_targets())
 
     assert targets == []
     assert client._inventory is None


### PR DESCRIPTION
## Summary
- iterate heater subscription targets lazily to avoid copying inventory data
- ensure websocket debug logging consumes address metadata without intermediate lists
- update websocket protocol tests and documentation map for the new iterable behavior

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68f0952082b4832983161d69b2267c85