### PR TITLE
Use inventory snapshot for diagnostics

### DIFF
--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -47,19 +47,10 @@ async def async_get_config_entry_diagnostics(
         record,
         context=f"diagnostics for config entry {entry.entry_id}",
     )
-    raw_count = len(inventory.nodes)
-    metadata = list(inventory.iter_nodes_metadata())
-    filtered_count = len(metadata)
-
-    node_inventory = [
-        {
-            "name": meta.name,
-            "addr": meta.addr,
-            "type": meta.node_type,
-        }
-        for meta in metadata
-    ]
-    node_inventory.sort(key=lambda item: (str(item["addr"]), str(item["type"])))
+    snapshot = inventory.snapshot()
+    raw_count = snapshot.raw_count
+    filtered_count = snapshot.filtered_count
+    node_inventory = list(snapshot.node_inventory)
 
     assert record is not None  # Inventory.require_from_record guarantees mapping
 

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1078,6 +1078,10 @@ custom_components/termoweb/inventory.py :: _extract_snapshot_name
     Return best candidate name extracted from ``payloads``.
 custom_components/termoweb/inventory.py :: Inventory.iter_nodes_metadata
     Yield canonical node metadata for the requested types.
+custom_components/termoweb/inventory.py :: Inventory.snapshot
+    Return a serialisable snapshot of node metadata.
+custom_components/termoweb/inventory.py :: InventorySnapshot.filtered_count
+    Return the number of nodes included in the snapshot.
 custom_components/termoweb/inventory.py :: _iter_node_payload
     Yield node dictionaries from a payload returned by the API.
 custom_components/termoweb/inventory.py :: _resolve_node_class


### PR DESCRIPTION
## Summary
- add an `InventorySnapshot` helper and expose `Inventory.snapshot()` for serialisable metadata
- switch the diagnostics payload builder to use the cached snapshot instead of rebuilding lists
- update diagnostics tests to assert snapshot usage and refresh the function map documentation

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check custom_components/termoweb/diagnostics.py custom_components/termoweb/inventory.py tests/test_diagnostics.py` *(fails: existing TRY004/PLC0415 violations)*

------
https://chatgpt.com/codex/tasks/task_e_68f094ff07648329bd2d3d62d4aaa5ad