### PR TITLE
Refactor hourly poller node iteration

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -800,8 +800,6 @@ custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller.async_shutdow
     Cancel scheduled triggers and pending polling tasks.
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._on_time
     Callback invoked by Home Assistant's time tracker in a thread-safe way.
-custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._enumerate_nodes
-    Return canonical ``(node_type, addr)`` pairs for ``inventory``.
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._run_for_previous_hour
     Fetch and merge samples for the hour preceding ``now_local``.
 custom_components/termoweb/hourly_poller.py :: HourlySamplesPoller._poll_device


### PR DESCRIPTION
## Summary
- iterate hourly poller nodes directly from inventory sample targets and normalize per device fetch
- drop the private enumeration helper and rely on inventory-provided ordering for logging and backend calls
- extend hourly poller tests to cover empty inventories and new node tuple expectations

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68f094e3ecec83299ce55d96dc35db0f