### PR TITLE
Refactor energy coordinator to rely on inventory targets

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -775,11 +775,17 @@ custom_components/termoweb/coordinator.py :: StateCoordinator._async_update_data
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.__init__
     Initialize the heater energy coordinator.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.update_addresses
-    Replace the tracked heater addresses with ``addrs``.
+    Replace the tracked nodes using immutable inventory metadata.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._iter_energy_targets
+    Yield normalised energy node targets from ``inventory``.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._targets_by_type
+    Return energy node addresses grouped by canonical type.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._prefill_energy_buckets
+    Seed energy and power buckets from cached coordinator state.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._poll_recent_samples
+    Fetch recent energy samples for every tracked node.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._process_energy_sample
     Update cached energy and derived power for ``addr``.
-custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._seed_cached_energy_and_power
-    Return energy and power buckets pre-populated from cached data.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._async_update_data
     Fetch recent heater energy samples and derive totals and power.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._should_skip_poll

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -1382,12 +1382,13 @@ def test_energy_state_coordinator_requires_inventory(
     inventory = inventory_from_map({"htr": ["A"], "acm": ["B"], "pmo": ["M"]})
     coord = EnergyStateCoordinator(hass, client, "dev", inventory)
 
-    assert coord._tracked_address_map() == {
-        "htr": ("A",),
-        "acm": ("B",),
-        "pmo": ("M",),
-    }
-    assert coord._alias_map() == {
+    resolved = coord._resolve_inventory()
+    targets = list(coord._iter_energy_targets(resolved))
+    assert targets == [("htr", "A"), ("acm", "B"), ("pmo", "M")]
+    assert resolved.sample_alias_map(
+        include_types=coord_module.ENERGY_NODE_TYPES,
+        restrict_to=coord_module.ENERGY_NODE_TYPES,
+    ) == {
         "htr": "htr",
         "acm": "acm",
         "pmo": "pmo",


### PR DESCRIPTION
## Summary
- remove the cached energy address maps and iterate Inventory sample targets directly
- simplify poll, websocket, and merge paths to reuse immutable inventory metadata
- refresh tests and function map documentation for the streamlined helpers

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68f094dcacbc83298a6e5a2bb4eb02f2