### PR TITLE
Refactor boost value restoration helper

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1094,6 +1094,8 @@ custom_components/termoweb/inventory.py :: _normalise_with_fallback
     Return the first non-empty normalised value from ``candidates``.
 custom_components/termoweb/inventory.py :: build_node_inventory
     Return a list of :class:`Node` instances for the provided payload.
+custom_components/termoweb/number.py :: _restore_boost_value
+    Restore a boost preference from cache, state, or settings.
 custom_components/termoweb/number.py :: async_setup_entry
     Set up boost configuration number entities for accumulator nodes.
 custom_components/termoweb/number.py :: AccumulatorBoostDurationNumber.__init__


### PR DESCRIPTION
## Summary
- introduce a shared `_restore_boost_value` helper to consolidate cached/state/settings restoration logic
- switch the duration and temperature number entities to use the helper and record the docstring in the function map
- expand the number platform tests to cover cache misses that fall back to last state and cached settings

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check custom_components/termoweb/number.py tests/test_number.py`


------
https://chatgpt.com/codex/tasks/task_e_68f09a38c3888329b545392d61165aa4