### PR TITLE
Refactor inventory sample address helpers

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1002,6 +1002,8 @@ custom_components/termoweb/inventory.py :: Inventory.heater_address_map
     Return forward and reverse heater address mappings.
 custom_components/termoweb/inventory.py :: Inventory.power_monitor_address_map
     Return forward and reverse power monitor address mappings.
+custom_components/termoweb/inventory.py :: Inventory._ensure_sample_addresses
+    Return cached normalised sample addresses for the provided inputs.
 custom_components/termoweb/inventory.py :: Inventory._ensure_heater_sample_addresses
     Return cached normalised heater address data for samples.
 custom_components/termoweb/inventory.py :: Inventory._ensure_power_monitor_sample_addresses
@@ -1014,6 +1016,8 @@ custom_components/termoweb/inventory.py :: Inventory.power_monitor_sample_addres
     Return normalised power monitor addresses and compatibility aliases.
 custom_components/termoweb/inventory.py :: Inventory.power_monitor_sample_targets
     Return ordered power monitor sample subscription targets.
+custom_components/termoweb/inventory.py :: Inventory._validate_sample_targets
+    Return deduplicated and sanitised sample target pairs.
 custom_components/termoweb/inventory.py :: Inventory.heater_name_map
     Return cached heater name mapping for ``default_factory``.
 custom_components/termoweb/inventory.py :: _normalize_node_iterable


### PR DESCRIPTION
## Summary
- consolidate duplicated sample address caching with a shared helper
- reuse a validator to strip and deduplicate sample targets for heaters and power monitors
- expand inventory tests and function map entries for the new helpers

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/inventory.py tests/test_inventory.py *(fails: existing TRY004/PLC0415 in untouched code)*

------
https://chatgpt.com/codex/tasks/task_e_68f09a30418483298a67d5cb8fe392fd