### PR TITLE
Use inventory membership for energy import filtering

### DIFF
--- a/tests/test_energy_service_registration.py
+++ b/tests/test_energy_service_registration.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 
+from custom_components.termoweb import energy
 from custom_components.termoweb.energy import (
     async_register_import_energy_history_service,
 )
@@ -15,18 +18,21 @@ from custom_components.termoweb.energy import (
 class _StubServices:
     """Stub Home Assistant service registry for testing."""
 
-    def __init__(self) -> None:
-        self.registrations: list[tuple[str, str]] = []
+    def __init__(self, *, existing: bool = True) -> None:
+        self._existing = existing
+        self.registrations: list[
+            tuple[str, str, Any]
+        ] = []
 
     def has_service(self, domain: str, service: str) -> bool:
         """Pretend the service is already registered."""
 
-        return True
+        return self._existing
 
     def async_register(self, domain: str, service: str, handler) -> None:  # pragma: no cover - defensive
         """Record registrations for inspection."""
 
-        self.registrations.append((domain, service))
+        self.registrations.append((domain, service, handler))
 
 
 @pytest.mark.asyncio
@@ -40,3 +46,88 @@ async def test_async_register_import_energy_history_service_skips_registration()
 
     import_fn.assert_not_called()
     assert hass.services.registrations == []
+
+
+@pytest.mark.asyncio
+async def test_service_handler_forwards_filters(
+    inventory_from_map,
+) -> None:
+    """Service handler should normalise filter inputs for the importer."""
+
+    services = _StubServices(existing=False)
+    hass = SimpleNamespace(
+        services=services,
+        data={energy.DOMAIN: {}},
+    )
+    entry = SimpleNamespace(entry_id="entry-filter")
+    inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-filter")
+    hass.data[energy.DOMAIN][entry.entry_id] = {
+        "config_entry": entry,
+        "inventory": inventory,
+        "dev_id": "dev-filter",
+    }
+
+    import_fn = AsyncMock()
+
+    await async_register_import_energy_history_service(hass, import_fn)
+
+    assert services.registrations
+    _, _, handler = services.registrations[0]
+
+    call = SimpleNamespace(
+        data={
+            "node_types": {"htr", "HTR"},
+            "addresses": {"A", 1},
+            "day_chunk_hours": "12",
+            "max_history_retrieval": 5,
+            "reset_progress": True,
+        }
+    )
+
+    await handler(call)
+
+    import_fn.assert_awaited_once()
+    args, kwargs = import_fn.await_args
+    assert args == (hass, entry)
+    assert kwargs["reset_progress"] is True
+    assert kwargs["max_days"] == 5
+    assert isinstance(kwargs["node_types"], tuple)
+    assert set(kwargs["node_types"]) == {"htr", "HTR"}
+    assert isinstance(kwargs["addresses"], tuple)
+    assert set(kwargs["addresses"]) == {"A", "1"}
+    assert kwargs["day_chunk_hours"] == 12
+
+
+@pytest.mark.asyncio
+async def test_service_logs_rejected_filters(
+    inventory_from_map, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Service handler should log when the importer rejects its filters."""
+
+    services = _StubServices(existing=False)
+    hass = SimpleNamespace(
+        services=services,
+        data={energy.DOMAIN: {}},
+    )
+    entry = SimpleNamespace(entry_id="entry-invalid")
+    inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-invalid")
+    hass.data[energy.DOMAIN][entry.entry_id] = {
+        "config_entry": entry,
+        "inventory": inventory,
+        "dev_id": "dev-invalid",
+    }
+
+    import_fn = AsyncMock(side_effect=ValueError("bad filters"))
+
+    await async_register_import_energy_history_service(hass, import_fn)
+
+    assert services.registrations
+    _, _, handler = services.registrations[0]
+
+    call = SimpleNamespace(data={"node_types": ["invalid"]})
+
+    with caplog.at_level(logging.ERROR):
+        await handler(call)
+
+    import_fn.assert_called_once()
+    assert "import_energy_history task failed" in caplog.text


### PR DESCRIPTION
## Summary
- update energy import filtering to rely on Inventory membership rather than cached type/address sets
- add importer tests for invalid node types and unknown addresses along with service handler coverage for filter plumbing

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68f0986ea8e88329b0f7f8639fcbcf3d