### PR TITLE
Refine energy import target selection

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1008,12 +1008,34 @@ custom_components/termoweb/inventory.py :: Inventory._ensure_power_monitor_sampl
     Return cached normalised power monitor address data for samples.
 custom_components/termoweb/inventory.py :: Inventory.heater_sample_address_map
     Return normalised heater addresses and compatibility aliases.
+custom_components/termoweb/inventory.py :: Inventory._ensure_heater_sample_targets
+    Return cached heater sample targets.
 custom_components/termoweb/inventory.py :: Inventory.heater_sample_targets
     Return ordered ``(node_type, addr)`` sample subscription targets.
+custom_components/termoweb/inventory.py :: Inventory.iter_heater_sample_targets
+    Yield heater sample subscription targets.
 custom_components/termoweb/inventory.py :: Inventory.power_monitor_sample_address_map
     Return normalised power monitor addresses and compatibility aliases.
+custom_components/termoweb/inventory.py :: Inventory._ensure_power_monitor_sample_targets
+    Return cached power monitor sample targets.
 custom_components/termoweb/inventory.py :: Inventory.power_monitor_sample_targets
     Return ordered power monitor sample subscription targets.
+custom_components/termoweb/inventory.py :: Inventory.iter_power_monitor_sample_targets
+    Yield power monitor sample subscription targets.
+custom_components/termoweb/inventory.py :: Inventory._ensure_canonical_node_types
+    Return cached canonical node types.
+custom_components/termoweb/inventory.py :: Inventory._ensure_canonical_node_addresses
+    Return cached canonical node addresses.
+custom_components/termoweb/inventory.py :: Inventory.canonical_node_types
+    Return canonical node types present in the inventory.
+custom_components/termoweb/inventory.py :: Inventory.canonical_node_addresses
+    Return canonical node addresses present in the inventory.
+custom_components/termoweb/inventory.py :: Inventory.canonical_node_type
+    Return canonical node type for ``candidate`` when available.
+custom_components/termoweb/inventory.py :: Inventory.canonical_node_address
+    Return canonical node address for ``candidate`` when available.
+custom_components/termoweb/inventory.py :: Inventory.canonical_sample_pair
+    Return canonical ``(node_type, addr)`` when the pair exists.
 custom_components/termoweb/inventory.py :: Inventory.heater_name_map
     Return cached heater name mapping for ``default_factory``.
 custom_components/termoweb/inventory.py :: _normalize_node_iterable

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -34,6 +34,34 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 EnergyStateCoordinator = coord_module.EnergyStateCoordinator
 StateCoordinator = coord_module.StateCoordinator
+
+
+def test_inventory_canonical_helpers() -> None:
+    """Inventory should expose canonical node metadata helpers."""
+
+    nodes = {
+        "nodes": [
+            {"addr": "A", "type": "htr"},
+            {"addr": "B", "type": "acm"},
+            {"addr": "01", "type": "pmo"},
+        ]
+    }
+    inventory = _inventory_from_nodes("dev", nodes)
+
+    assert list(inventory.iter_heater_sample_targets()) == inventory.heater_sample_targets
+    assert list(inventory.iter_power_monitor_sample_targets()) == (
+        inventory.power_monitor_sample_targets
+    )
+    assert set(inventory.canonical_node_types) == {"acm", "htr", "pmo"}
+    assert set(inventory.canonical_node_addresses) == {"01", "A", "B"}
+    assert inventory.canonical_node_type("HTR") == "htr"
+    assert inventory.canonical_node_type("unknown") is None
+    assert inventory.canonical_node_address(" B ") == "B"
+    assert inventory.canonical_node_address(" 999 ") is None
+    assert inventory.canonical_sample_pair("htr", "A") == ("htr", "A")
+    assert inventory.canonical_sample_pair("acm", "Z") is None
+
+
 def _inventory_from_nodes(dev_id: str, payload: Mapping[str, Any]) -> Inventory:
     """Return an Inventory built from ``payload``."""
 


### PR DESCRIPTION
## Summary
- refactor energy history import to iterate inventory targets lazily and validate via canonical helpers
- extend the inventory with canonical node metadata helpers and iterator accessors
- add regression coverage for canonical filtering and inventory helpers

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
https://chatgpt.com/codex/tasks/task_e_68f0986bc4dc8329a77a9ac701d1f070