### PR TITLE
Fix accumulator boost context attribute collision

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -552,6 +552,8 @@ custom_components/termoweb/button.py :: StateRefreshButton.async_press
     Request an immediate coordinator refresh when pressed.
 custom_components/termoweb/button.py :: AccumulatorBoostButtonBase.__init__
     Initialise an accumulator boost helper button.
+custom_components/termoweb/button.py :: AccumulatorBoostButtonBase.boost_context
+    Return the inventory-derived context for this entity.
 custom_components/termoweb/button.py :: AccumulatorBoostButtonBase._service_minutes
     Return the minutes payload passed to the helper service.
 custom_components/termoweb/button.py :: AccumulatorBoostButtonBase.async_press


### PR DESCRIPTION
## Summary
- stop storing accumulator metadata in Entity._context to avoid clobbering Home Assistant event contexts
- expose the boost context via a dedicated accessor and document it in the function map

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_690494ef3d40832993ee1334ba9e1087