### PR TITLE
Expose accumulator charge metadata for accumulators

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -1268,7 +1268,7 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return accumulator attributes including boost metadata."""
+        """Return accumulator attributes including boost and charge metadata."""
 
         base_attrs = super().extra_state_attributes
         attrs: dict[str, Any] = dict(base_attrs) if base_attrs is not None else {}
@@ -1280,6 +1280,17 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
         attrs["boost_end"] = boost_state.end_iso
         attrs["boost_end_label"] = boost_state.end_label
         attrs["preferred_boost_minutes"] = self._preferred_boost_minutes()
+
+        charging = settings.get("charging")
+        if isinstance(charging, bool):
+            attrs["charging"] = charging
+        elif charging is not None:
+            attrs["charging"] = bool(charging)
+
+        for key in ("current_charge_per", "target_charge_per"):
+            value = settings.get(key)
+            if isinstance(value, (int, float)):
+                attrs[key] = int(value)
 
         return attrs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,7 +183,7 @@ Representative payload emitted after a successful write:
 
 - **Controls:** Boost duration and setpoint sliders constrained to **1–10 hours (60–600 minutes)** and **5–30 °C** respectively.
 - **Helpers:** Single **Start boost** button pulls the stored duration and temperature presets before invoking the boost service.
-- **Attributes:** expose `boost`, `boost_end_day`, `boost_end_min`, `stemp`, and `units` so dashboards mirror cloud state.
+- **Attributes:** expose `boost`, `boost_end_day`, `boost_end_min`, `stemp`, and `units`, plus accumulator charge fields `charging`, `current_charge_per`, and `target_charge_per` so dashboards mirror cloud state.
 - **Defaults:** cache `/setup` values (`extra_options.boost_time`, `boost_temp`) to pre-populate selectors without toggling Boost directly.
 
 ### Services

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -166,6 +166,8 @@ custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._merge_boos
     Copy boost metadata from ``source`` into ``target`` safely.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._merge_boost_metadata._assign
     Assign a metadata value while respecting preference rules.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._merge_accumulator_charge_metadata
+    Copy accumulator charge metadata from ``source`` into ``target``.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_settings
     Flatten the vendor payload into HA-friendly heater settings.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._normalise_thm_settings
@@ -665,7 +667,7 @@ custom_components/termoweb/climate.py :: AccumulatorClimateEntity.preset_mode
 custom_components/termoweb/climate.py :: AccumulatorClimateEntity.async_set_preset_mode
     Set the accumulator preset mode.
 custom_components/termoweb/climate.py :: AccumulatorClimateEntity.extra_state_attributes
-    Return accumulator attributes including boost metadata.
+    Return accumulator attributes including boost and charge metadata.
 custom_components/termoweb/climate.py :: AccumulatorClimateEntity._validate_boost_minutes
     Return a validated boost duration or ``None`` when absent.
 custom_components/termoweb/climate.py :: AccumulatorClimateEntity.async_set_acm_preset

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1178,6 +1178,9 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
         "boost_end_min": 60,
         "boost_end": None,
         "boost_remaining": None,
+        "charging": False,
+        "current_charge_per": 67,
+        "target_charge_per": 90,
     }
 
     coordinator = _make_coordinator(
@@ -1234,6 +1237,9 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     assert attrs["boost_minutes_remaining"] == 60
     assert attrs["boost_end"] == "2024-01-01T01:00:00+00:00"
     assert attrs["boost_end_label"] is None
+    assert attrs["charging"] is False
+    assert attrs["current_charge_per"] == 67
+    assert attrs["target_charge_per"] == 90
 
     class RaisingResolver:
         def __call__(self, day: Any, minute: Any) -> tuple[dt.datetime | None, int | None]:

--- a/tests/test_ducaheat_nodes.py
+++ b/tests/test_ducaheat_nodes.py
@@ -136,6 +136,32 @@ def test_ducaheat_rest_normalise_ws_settings_boost_fields() -> None:
     assert result["boost_end_min"] == 15
 
 
+def test_ducaheat_rest_normalise_settings_charge_fields() -> None:
+    """Accumulator settings should expose normalised charge metadata."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+
+    payload = {
+        "status": {
+            "mode": "auto",
+            "charging": "1",
+            "current_charge_per": "45.5",
+            "target_charge_per": 120,
+        },
+        "setup": {
+            "extra_options": {
+                "current_charge_per": 10,
+            }
+        },
+    }
+
+    result = client._normalise_settings(payload, node_type="acm")
+
+    assert result["charging"] is True
+    assert result["current_charge_per"] == 45
+    assert result["target_charge_per"] == 100
+
+
 @pytest.mark.asyncio
 async def test_ducaheat_get_node_settings_normalises_thm() -> None:
     client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")


### PR DESCRIPTION
## Summary
- normalise accumulator charge metadata returned by the Ducaheat REST and websocket payloads
- surface charging, current charge percentage, and target charge percentage as accumulator climate attributes
- document the new attributes and add targeted regression tests

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ab4b95788329a5e92876e3de90d9)