### PR TITLE
Expose accumulator charge metrics as sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ We do not yet have integration with heaters using the Tevolve-app, but it looks 
 - See cumulative energy use and import energy use history from TermoWeb.
 - Add energy sensors to the HA energy dashboard so you can see current and historical use/cost.
 - Monitor thermostat battery level so you know when wireless controllers need attention.
+- Track accumulator charging status and charge targets to understand storage heater behaviour.
 - Use HA **automations**, **scenes**, and **voice assistants** (including HA’s Google/Alexa integrations).
 
 ---

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -77,6 +77,15 @@
       },
       "boost_end": {
         "name": "Boost end"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/bg.json
+++ b/custom_components/termoweb/translations/bg.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Край на усилването"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/cs.json
+++ b/custom_components/termoweb/translations/cs.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Konec zvýšení"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/da.json
+++ b/custom_components/termoweb/translations/da.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost-ende"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/de.json
+++ b/custom_components/termoweb/translations/de.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost Ende"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/el.json
+++ b/custom_components/termoweb/translations/el.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Τέλος ενίσχυσης"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost end"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/es.json
+++ b/custom_components/termoweb/translations/es.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Fin del impulso"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/et.json
+++ b/custom_components/termoweb/translations/et.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost otsa"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/fi.json
+++ b/custom_components/termoweb/translations/fi.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost-pääte"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/fr.json
+++ b/custom_components/termoweb/translations/fr.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Fin de course"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/hr.json
+++ b/custom_components/termoweb/translations/hr.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Kraj pojačanja"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/hu.json
+++ b/custom_components/termoweb/translations/hu.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost vége"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/it.json
+++ b/custom_components/termoweb/translations/it.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Fine della spinta"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/lt.json
+++ b/custom_components/termoweb/translations/lt.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Didinimo pabaiga"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/lv.json
+++ b/custom_components/termoweb/translations/lv.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Paaugstināšanas beigas"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/nb.json
+++ b/custom_components/termoweb/translations/nb.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost-slutt"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/nl.json
+++ b/custom_components/termoweb/translations/nl.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Einde boost"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/pl.json
+++ b/custom_components/termoweb/translations/pl.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Koniec doładowania"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/pt-PT.json
+++ b/custom_components/termoweb/translations/pt-PT.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Fim do reforço"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/ro.json
+++ b/custom_components/termoweb/translations/ro.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Sfârșit boost"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/ru.json
+++ b/custom_components/termoweb/translations/ru.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Конец буста"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/sk.json
+++ b/custom_components/termoweb/translations/sk.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Zvýšenie koncovej hodnoty"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/sl.json
+++ b/custom_components/termoweb/translations/sl.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Konec povečanja"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/sv.json
+++ b/custom_components/termoweb/translations/sv.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Boost slut"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/tr.json
+++ b/custom_components/termoweb/translations/tr.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Yükseltme sonu"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/custom_components/termoweb/translations/uk.json
+++ b/custom_components/termoweb/translations/uk.json
@@ -81,6 +81,15 @@
       },
       "boost_end": {
         "name": "Буст-енд"
+      },
+      "accumulator_charging": {
+        "name": "Charging"
+      },
+      "accumulator_current_charge": {
+        "name": "Current charge"
+      },
+      "accumulator_target_charge": {
+        "name": "Target charge"
       }
     }
   },

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1172,6 +1172,18 @@ custom_components/termoweb/sensor.py :: ThermostatBatterySensor.native_value
     Return the thermostat battery percentage as 0–100.
 custom_components/termoweb/sensor.py :: ThermostatBatterySensor.extra_state_attributes
     Return additional thermostat battery metadata.
+custom_components/termoweb/sensor.py :: AccumulatorChargeSensorBase._raw_value
+    Return the raw setting backing this accumulator charge sensor.
+custom_components/termoweb/sensor.py :: AccumulatorChargeSensorBase._coerce_value
+    Convert a raw accumulator charge setting into a Home Assistant state.
+custom_components/termoweb/sensor.py :: AccumulatorChargeSensorBase.native_value
+    Return the processed accumulator charge metric.
+custom_components/termoweb/sensor.py :: AccumulatorChargeSensorBase.extra_state_attributes
+    Return identifiers that locate the accumulator charge metric.
+custom_components/termoweb/sensor.py :: AccumulatorChargingSensor._coerce_value
+    Return a canonical boolean charging state when available.
+custom_components/termoweb/sensor.py :: AccumulatorChargePercentageSensor._coerce_value
+    Return the accumulator charge percentage as an integer.
 custom_components/termoweb/sensor.py :: HeaterEnergyBase.__init__
     Initialise a heater energy-derived sensor entity.
 custom_components/termoweb/sensor.py :: HeaterEnergyBase._device_available

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,7 +8,12 @@ from conftest import FakeCoordinator, _install_stubs, build_coordinator_device_s
 _install_stubs()
 
 from custom_components.termoweb.inventory import Inventory, build_node_inventory
-from custom_components.termoweb.sensor import ThermostatBatterySensor
+from custom_components.termoweb.sensor import (
+    AccumulatorChargingSensor,
+    AccumulatorCurrentChargeSensor,
+    AccumulatorTargetChargeSensor,
+    ThermostatBatterySensor,
+)
 from homeassistant.core import HomeAssistant
 
 
@@ -24,6 +29,18 @@ def thermostat_inventory(
     return inventory_builder(dev_id, raw_nodes, node_list)
 
 
+@pytest.fixture
+def accumulator_inventory(
+    inventory_builder,
+) -> Inventory:
+    """Return helper inventory for accumulator sensor tests."""
+
+    dev_id = "dev-acm"
+    raw_nodes = {"nodes": [{"type": "acm", "addr": "A1"}]}
+    node_list = build_node_inventory(raw_nodes)
+    return inventory_builder(dev_id, raw_nodes, node_list)
+
+
 def _make_coordinator(
     inventory: Inventory,
     *,
@@ -35,6 +52,28 @@ def _make_coordinator(
     dev_id = "dev-thm"
     nodes = {"nodes": [{"type": "thm", "addr": "T1"}]}
     settings = payload or {"thm": {"T1": {}}}
+    record = build_coordinator_device_state(nodes=nodes, settings=settings)
+    return FakeCoordinator(
+        hass,
+        dev_id=dev_id,
+        dev=record,
+        nodes=nodes,
+        inventory=inventory,
+        data={dev_id: record},
+    )
+
+
+def _make_accumulator_coordinator(
+    inventory: Inventory,
+    *,
+    payload: Mapping[str, Mapping[str, Any]] | None = None,
+) -> FakeCoordinator:
+    """Construct a fake coordinator with accumulator settings."""
+
+    hass = HomeAssistant()
+    dev_id = "dev-acm"
+    nodes = {"nodes": [{"type": "acm", "addr": "A1"}]}
+    settings = payload or {"acm": {"A1": {}}}
     record = build_coordinator_device_state(nodes=nodes, settings=settings)
     return FakeCoordinator(
         hass,
@@ -90,3 +129,115 @@ def test_thermostat_battery_sensor_handles_invalid_level(
 
     assert sensor.native_value is None
     assert sensor.extra_state_attributes["batt_level_steps"] is None
+
+
+def test_accumulator_charging_sensor_reports_boolean(
+    accumulator_inventory: Inventory,
+) -> None:
+    coordinator = _make_accumulator_coordinator(
+        accumulator_inventory,
+        payload={"acm": {"A1": {"charging": True}}},
+    )
+
+    sensor = AccumulatorChargingSensor(
+        coordinator,
+        "entry-acm",
+        "dev-acm",
+        "A1",
+        None,
+        "uid-acm-charging",
+        device_name="Accumulator A1",
+        node_type="acm",
+        inventory=accumulator_inventory,
+    )
+
+    assert sensor.native_value is True
+    assert sensor.extra_state_attributes == {"dev_id": "dev-acm", "addr": "A1"}
+
+
+def test_accumulator_charging_sensor_handles_invalid_state(
+    accumulator_inventory: Inventory,
+) -> None:
+    coordinator = _make_accumulator_coordinator(
+        accumulator_inventory,
+        payload={"acm": {"A1": {"charging": "unexpected"}}},
+    )
+
+    sensor = AccumulatorChargingSensor(
+        coordinator,
+        "entry-acm",
+        "dev-acm",
+        "A1",
+        None,
+        "uid-acm-charging-invalid",
+        device_name="Accumulator A1",
+        node_type="acm",
+        inventory=accumulator_inventory,
+    )
+
+    assert sensor.native_value is None
+
+
+def test_accumulator_charge_percentage_sensors_clamp_values(
+    accumulator_inventory: Inventory,
+) -> None:
+    coordinator = _make_accumulator_coordinator(
+        accumulator_inventory,
+        payload={
+            "acm": {
+                "A1": {
+                    "current_charge_per": 150.5,
+                    "target_charge_per": -12,
+                }
+            }
+        },
+    )
+
+    current_sensor = AccumulatorCurrentChargeSensor(
+        coordinator,
+        "entry-acm",
+        "dev-acm",
+        "A1",
+        None,
+        "uid-acm-current",
+        device_name="Accumulator A1",
+        node_type="acm",
+        inventory=accumulator_inventory,
+    )
+    target_sensor = AccumulatorTargetChargeSensor(
+        coordinator,
+        "entry-acm",
+        "dev-acm",
+        "A1",
+        None,
+        "uid-acm-target",
+        device_name="Accumulator A1",
+        node_type="acm",
+        inventory=accumulator_inventory,
+    )
+
+    assert current_sensor.native_value == 100
+    assert target_sensor.native_value == 0
+
+
+def test_accumulator_charge_percentage_handles_missing_values(
+    accumulator_inventory: Inventory,
+) -> None:
+    coordinator = _make_accumulator_coordinator(
+        accumulator_inventory,
+        payload={"acm": {"A1": {"current_charge_per": None}}},
+    )
+
+    current_sensor = AccumulatorCurrentChargeSensor(
+        coordinator,
+        "entry-acm",
+        "dev-acm",
+        "A1",
+        None,
+        "uid-acm-current-missing",
+        device_name="Accumulator A1",
+        node_type="acm",
+        inventory=accumulator_inventory,
+    )
+
+    assert current_sensor.native_value is None


### PR DESCRIPTION
## Summary
- add dedicated accumulator charging and charge percentage sensors for accumulators and register them during setup
- expose the new entities to the UI via updated strings/translations and highlight them in the README
- extend the sensor test suite and function map to cover the new entities

## Testing
- ruff check custom_components/termoweb/sensor.py tests/test_sensor.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691621907a7c8329b40915e8214338cc)