### PR TITLE
Normalize websocket node payloads

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -25,6 +25,7 @@ from custom_components.termoweb.backend.ws_client import (
     DUCAHEAT_NAMESPACE,
     HandshakeError,
     WSStats,
+    _nodes_payload_from_inventory,
     _prepare_nodes_dispatch,
     _WSCommon,
     _WsLeaseMixin,
@@ -1011,8 +1012,10 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             _LOGGER.error("WS (ducaheat): missing inventory for node dispatch on %s", self.dev_id)
             return
 
+        nodes_payload = _nodes_payload_from_inventory(raw_nodes, inventory)
+
         self._apply_heater_addresses(
-            raw_nodes,
+            nodes_payload,
             inventory=inventory,
             log_prefix="WS (ducaheat)",
             logger=_LOGGER,
@@ -1022,6 +1025,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
             "dev_id": self.dev_id,
             "node_type": None,
             "inventory": inventory,
+            "nodes": nodes_payload,
         }
 
         cadence_payload = cadence_source or context.payload

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -55,6 +55,7 @@ from custom_components.termoweb.inventory import (
 from .ws_client import (
     HandshakeError,
     WSStats,
+    _nodes_payload_from_inventory,
     _prepare_nodes_dispatch,
     _WSCommon,
     forward_ws_sample_updates,
@@ -846,8 +847,10 @@ class WebSocketClient(_WSCommon):
             _LOGGER.error("WS: missing inventory for node dispatch on %s", self.dev_id)
             return None
 
+        nodes_payload = _nodes_payload_from_inventory(raw_nodes, inventory)
+
         self._apply_heater_addresses(
-            raw_nodes,
+            nodes_payload,
             inventory=inventory,
             log_prefix="WS",
             logger=_LOGGER,
@@ -857,6 +860,7 @@ class WebSocketClient(_WSCommon):
             "dev_id": self.dev_id,
             "node_type": None,
             "inventory": inventory,
+            "nodes": nodes_payload,
         }
 
         self._mark_ws_payload(

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -564,6 +564,15 @@ def _prepare_nodes_dispatch(
     )
 
 
+def _nodes_payload_from_inventory(raw_nodes: Any, inventory: Inventory | None) -> Any:
+    """Return the inventory node payload when updates omit mapping data."""
+
+    if isinstance(inventory, Inventory) and not isinstance(raw_nodes, Mapping):
+        return inventory.payload
+
+    return raw_nodes
+
+
 class _WSCommon(_WSStatusMixin):
     """Shared helpers for websocket clients."""
 
@@ -702,8 +711,10 @@ class _WSCommon(_WSStatusMixin):
         if inventory is not None and not isinstance(self._inventory, Inventory):
             self._inventory = inventory
 
+        nodes_payload = _nodes_payload_from_inventory(raw_nodes, inventory)
+
         self._apply_heater_addresses(
-            raw_nodes,
+            nodes_payload,
             inventory=inventory,
             log_prefix="WS",
             logger=_LOGGER,
@@ -717,6 +728,7 @@ class _WSCommon(_WSStatusMixin):
             "dev_id": self.dev_id,
             "node_type": None,
             "inventory": inventory,
+            "nodes": nodes_payload,
         }
         async_dispatcher_send(self.hass, signal_ws_data(self.entry_id), payload_copy)
 

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -881,7 +881,52 @@ class HeaterNodeBase(CoordinatorEntity):
         """Process websocket payloads addressed to this heater."""
         if not self._payload_matches_heater(payload):
             return
+        self._merge_ws_settings(payload)
         self._handle_ws_event(payload)
+
+    def _merge_ws_settings(self, payload: Mapping[str, Any]) -> None:
+        """Merge websocket settings updates into the coordinator cache."""
+
+        nodes = payload.get("nodes")
+        if not isinstance(nodes, Mapping):
+            return
+
+        data = getattr(self.coordinator, "data", None)
+        if not isinstance(data, dict):
+            return
+
+        dev_data = data.get(self._dev_id)
+        if not isinstance(dev_data, dict):
+            return
+
+        settings_bucket = dev_data.setdefault("settings", {})
+        if not isinstance(settings_bucket, dict):
+            return
+
+        for raw_type, sections in nodes.items():
+            node_type = normalize_node_type(raw_type, use_default_when_falsey=True)
+            if not node_type or node_type != self._node_type:
+                continue
+            if not isinstance(sections, Mapping):
+                continue
+            settings_section = sections.get("settings")
+            if not isinstance(settings_section, Mapping):
+                continue
+            node_settings = settings_bucket.setdefault(node_type, {})
+            if not isinstance(node_settings, dict):
+                continue
+            for raw_addr, update in settings_section.items():
+                addr = normalize_node_addr(raw_addr, use_default_when_falsey=True)
+                if not addr or addr != self._addr or not isinstance(update, Mapping):
+                    continue
+                existing = node_settings.get(addr)
+                merged = dict(existing) if isinstance(existing, Mapping) else {}
+                merged.update(update)
+                node_settings[addr] = merged
+
+        setter = getattr(self.coordinator, "async_set_updated_data", None)
+        if callable(setter):
+            setter(data)
 
     def _payload_matches_heater(self, payload: dict) -> bool:
         """Return True when the websocket payload targets this heater."""

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -482,6 +482,8 @@ custom_components/termoweb/backend/ws_client.py :: _WSStatusMixin._update_status
     Publish websocket status updates to Home Assistant listeners.
 custom_components/termoweb/backend/ws_client.py :: _prepare_nodes_dispatch
     Normalise node payload data for downstream websocket dispatch.
+custom_components/termoweb/backend/ws_client.py :: _nodes_payload_from_inventory
+    Return the inventory node payload when updates omit mapping data.
 custom_components/termoweb/backend/ws_client.py :: _WSCommon._process_power_updates
     Extract instantaneous power readings from websocket payloads.
 custom_components/termoweb/backend/ws_client.py :: _WSCommon.__init__
@@ -930,6 +932,8 @@ custom_components/termoweb/heater.py :: HeaterNodeBase.async_will_remove_from_ha
     Tidy up websocket listeners before the entity is removed.
 custom_components/termoweb/heater.py :: HeaterNodeBase._handle_ws_message
     Process websocket payloads addressed to this heater.
+custom_components/termoweb/heater.py :: HeaterNodeBase._merge_ws_settings
+    Merge websocket settings updates into the coordinator cache.
 custom_components/termoweb/heater.py :: HeaterNodeBase._payload_matches_heater
     Return True when the websocket payload targets this heater.
 custom_components/termoweb/heater.py :: HeaterNodeBase._handle_ws_event

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -311,7 +311,7 @@ def test_dispatch_nodes_includes_inventory_metadata(
 
     assert client._dispatcher.call_count == 1
     dispatched = client._dispatcher.call_args[0][2]
-    assert "nodes" not in dispatched
+    assert dispatched["nodes"] == payload
     assert "nodes_by_type" not in dispatched
     assert "addresses_by_type" not in dispatched
     assert "addr_map" not in dispatched
@@ -340,7 +340,7 @@ def test_incremental_updates_preserve_address_payload(
     client._dispatch_nodes(base)
 
     first_payload = client._dispatcher.call_args_list[-1][0][2]
-    assert "nodes" not in first_payload
+    assert first_payload["nodes"] == base
     assert "nodes_by_type" not in first_payload
     assert "addresses_by_type" not in first_payload
     assert "addr_map" not in first_payload
@@ -350,7 +350,7 @@ def test_incremental_updates_preserve_address_payload(
     client._dispatch_nodes(update)
 
     dispatched = client._dispatcher.call_args_list[-1][0][2]
-    assert "nodes" not in dispatched
+    assert dispatched["nodes"] == update
     assert "nodes_by_type" not in dispatched
     assert "addresses_by_type" not in dispatched
     assert "addr_map" not in dispatched

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -155,6 +155,45 @@ def test_heater_handle_ws_event_requires_loop_or_mock() -> None:
     assert called is False
 
 
+def test_heater_merges_ws_settings_into_cache() -> None:
+    hass = HomeAssistant()
+    payload = {
+        "dev_id": "dev",
+        "node_type": "acm",
+        "addr": "01",
+        "nodes": {
+            "acm": {
+                "settings": {
+                    "01": {
+                        "charging": True,
+                        "current_charge_per": 80,
+                    }
+                }
+            }
+        },
+    }
+    data = {"dev": {"settings": {"acm": {"01": {"charging": False}}}}}
+    setter = MagicMock()
+    coordinator = SimpleNamespace(data=data, async_set_updated_data=setter, hass=hass)
+    heater = HeaterNodeBase(
+        coordinator,
+        "entry",
+        "dev",
+        "01",
+        "Heater 1",
+        node_type="acm",
+    )
+    heater.hass = hass
+    heater.schedule_update_ha_state = MagicMock()  # type: ignore[assignment]
+
+    heater._handle_ws_message(payload)
+
+    settings = data["dev"]["settings"]["acm"]["01"]
+    assert settings["charging"] is True
+    assert settings["current_charge_per"] == 80
+    setter.assert_called_once_with(data)
+
+
 def test_heater_section_requires_inventory_for_name() -> None:
     """Heater metadata should not fabricate inventory-backed details."""
 

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -903,7 +903,7 @@ def test_dispatch_nodes_with_inventory(monkeypatch: pytest.MonkeyPatch, caplog: 
     client._coordinator.update_nodes.assert_not_called()
     dispatcher.assert_called_once()
     _, _, payload = dispatcher.call_args[0]
-    assert "nodes" not in payload
+    assert payload["nodes"] == {"htr": {"settings": {"1": {}}}}
     assert payload["inventory"] is client._inventory
     assert "inventory_addresses" not in payload
     assert client._inventory.addresses_by_type["htr"] == ["1"]
@@ -926,7 +926,7 @@ def test_dispatch_nodes_handles_unknown_types(monkeypatch: pytest.MonkeyPatch) -
     client._coordinator.update_nodes.assert_not_called()
     dispatcher.assert_called_once()
     _, _, payload = dispatcher.call_args[0]
-    assert "nodes" not in payload
+    assert payload["nodes"] == {}
     assert "inventory_addresses" not in payload
     assert "unknown_types" not in payload
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -634,7 +634,41 @@ def test_dispatch_nodes_reuses_record_inventory(
     dispatched_payload = dispatcher.call_args.args[2]
     assert dispatched_payload["inventory"] is inventory
     assert "addresses_by_type" not in dispatched_payload
-    assert "nodes" not in dispatched_payload
+    assert dispatched_payload["nodes"] == payload["nodes"]
+
+
+def test_dispatch_nodes_prefers_inventory_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    ws_common_stub: Callable[..., base_ws._WSCommon],
+) -> None:
+    """Non-mapping payloads should be replaced by the inventory snapshot."""
+
+    inventory_payload = {"nodes": [{"addr": "1", "type": "htr"}]}
+    node_inventory = build_node_inventory(inventory_payload)
+    inventory = Inventory("device", inventory_payload, node_inventory)
+
+    hass_record: dict[str, Any] = {"dev_id": "device", "inventory": inventory}
+    hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": hass_record}})
+    coordinator = SimpleNamespace(update_nodes=MagicMock(), dev_id="dev")
+    dispatcher = MagicMock()
+    monkeypatch.setattr(base_ws, "async_dispatcher_send", dispatcher)
+
+    dummy = ws_common_stub(
+        hass=hass,
+        entry_id="entry",
+        dev_id="device",
+        coordinator=coordinator,
+    )
+    dummy._inventory = inventory
+
+    payload = {"nodes": ["unexpected"]}
+    dummy._dispatch_nodes(payload)
+
+    coordinator.update_nodes.assert_not_called()
+    dispatcher.assert_called_once()
+    dispatched_payload = dispatcher.call_args.args[2]
+    assert dispatched_payload["inventory"] is inventory
+    assert dispatched_payload["nodes"] == inventory_payload
 
 
 def test_prepare_nodes_dispatch_uses_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1444,6 +1478,7 @@ def test_ws_common_dispatch_nodes(
         "dev_id": "dev",
         "node_type": None,
         "inventory": inventory_obj,
+        "nodes": raw_nodes,
     }
 
 


### PR DESCRIPTION
## Summary
- ensure websocket node dispatch reuses immutable inventory snapshots when incoming payloads lack mapping updates
- share the inventory-aware node payload helper across TermoWeb and Ducaheat websocket clients
- add coverage for inventory-backed websocket payloads and update the function map documentation

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check .`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244a1d5b208329a2f6a5aa552f3272)