### PR TITLE
Mirror Ducaheat websocket settings into coordinator cache

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -252,6 +252,8 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._reset_pay
     Reset the payload stale window to the default.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._dispatch_nodes
     Publish node updates with inventory-aware cache refresh.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._mirror_nodes_in_dev_map
+    Merge websocket node settings into the coordinator cache.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._merge_nodes
     Deep merge ``source`` updates into ``target`` in place.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._collect_sample_updates

--- a/tests/test_ducaheat_ws_apply_nodes_raw_cache.py
+++ b/tests/test_ducaheat_ws_apply_nodes_raw_cache.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock
 import aiohttp
 import pytest
 
+from custom_components.termoweb.backend.ducaheat import DucaheatRESTClient
+
 from tests.test_ducaheat_ws_protocol import (
     QueueWebSocket,
     _make_client,
@@ -48,6 +50,41 @@ async def test_dev_data_snapshot_does_not_populate_cache(
     assert payload["inventory"] is client._inventory
     assert "addr_map" not in payload
     assert "addresses_by_type" not in payload
+
+
+@pytest.mark.asyncio
+async def test_update_settings_mirrors_dev_map(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accumulator charge fields should be mirrored into coordinator state."""
+
+    client = _make_client(monkeypatch)
+    normaliser = DucaheatRESTClient.__new__(DucaheatRESTClient)
+    client._client.normalise_ws_nodes = normaliser.normalise_ws_nodes  # type: ignore[method-assign]
+    dispatched: list[Mapping[str, Any]] = []
+    client._dispatcher = lambda *_args: dispatched.append(_args[2])
+
+    class UpdateWS(QueueWebSocket):
+        def __init__(self) -> None:
+            super().__init__(
+                [
+                    SimpleNamespace(
+                        type=aiohttp.WSMsgType.TEXT,
+                        data='442["update",{"body":{"charging":"yes","current_charge_per":"12","target_charge_per":110},"path":"/api/v2/devs/device/acm/11/settings"}]',
+                    )
+                ]
+            )
+
+    client._ws = UpdateWS()  # type: ignore[assignment]
+
+    await _run_read_loop(client)
+
+    settings = client._coordinator.data.get("device", {}).get("settings", {})
+    acm_settings = settings.get("acm") or {}
+    assert acm_settings["11"]["charging"] is True
+    assert acm_settings["11"]["current_charge_per"] == 12
+    assert acm_settings["11"]["target_charge_per"] == 100
+    assert dispatched
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- mirror websocket node settings into the coordinator device map using normalised payloads
- keep accumulator charge metadata consistent with REST normalisation when applying websocket updates
- add regression coverage to confirm websocket accumulator settings populate the coordinator cache

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300ff4b40c8329955c45c4361dd4c8)