### PR TITLE
Ensure websocket cleanup reuses shared inventory

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,10 @@ subscriptions and UI naming hints while assuming that the set of devices and
 addresses remains stable across the lifetime of the entry. When hardware changes
 are required, users are expected to reload the integration so a fresh inventory is
 captured from the backend.【F:custom_components/termoweb/inventory.py†L138-L236】【F:custom_components/termoweb/__init__.py†L320-L411】
+Websocket clients reuse this immutable inventory directly when dispatching
+snapshots or reconnecting after a disconnect, and they clear their per-device
+`ws_state`/`ws_trackers` buckets whenever a session stops so repeated retries do
+not allocate extra dictionaries beyond the shared inventory entry.【F:custom_components/termoweb/backend/ws_client.py†L266-L349】【F:custom_components/termoweb/backend/termoweb_ws.py†L20-L117】【F:custom_components/termoweb/backend/ducaheat_ws.py†L139-L221】
 
 Power monitors (`pmo`) ride alongside heaters in the captured `dev_data`
 snapshot. The snapshot also exposes a `pmo_system` block with global power

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -118,6 +118,12 @@ custom_components/termoweb/backend/base.py :: HttpClientProto.get_nodes
     Return the node description for the given device.
 custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_settings
     Return settings for the specified node.
+custom_components/termoweb/backend/ws_client.py :: _WSCommon._bind_inventory_from_context
+    Attach the shared inventory stored on the Home Assistant entry.
+custom_components/termoweb/backend/ws_client.py :: _WSStatusMixin._ws_bucket_sizes
+    Return the current websocket state and tracker bucket sizes.
+custom_components/termoweb/backend/ws_client.py :: _WSStatusMixin._cleanup_ws_state
+    Remove cached websocket state and tracker entries for this device.
 custom_components/termoweb/backend/base.py :: HttpClientProto.set_node_settings
     Update node settings for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_samples


### PR DESCRIPTION
## Summary
- remove stale websocket state and health trackers when sessions disconnect or stop
- bind websocket clients to the shared inventory objects and add bucket size instrumentation for reconnects
- document cleanup expectations and add coverage for repeated start/stop cycles

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f97960d48329b2513982c33e5e0f)