### PR TITLE
Add websocket connection rate limiting safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ See instructions in custom_components/termoweb/assets, to install the card and c
 
 ## Troubleshooting
 
-- **Login fails:** First confirm credentials at the TermoWeb website (control.termoweb.net / control2.termoweb.net).  
-- **No devices found:** Check the **gateway** is powered and online (LEDs), and that the manufacturer app shows heaters online.  
-- **Collect diagnostics:** In **Settings → Devices & Services → TermoWeb → ⋮**, choose **Download diagnostics** to save an anonymised report (integration/Home Assistant versions, backend brand, node inventory). Attach that JSON file when opening an issue so we can reproduce problems faster.  
+- **Login fails:** First confirm credentials at the TermoWeb website (control.termoweb.net / control2.termoweb.net).
+- **No devices found:** Check the **gateway** is powered and online (LEDs), and that the manufacturer app shows heaters online.
+- **Slow reconnect after errors:** Websocket retries are rate limited to protect the backend. A brief pause between attempts is
+  expected after any outage.
+- **Collect diagnostics:** In **Settings → Devices & Services → TermoWeb → ⋮**, choose **Download diagnostics** to save an anonymised report (integration/Home Assistant versions, backend brand, node inventory). Attach that JSON file when opening an issue so we can reproduce problems faster.
 - **Need help?** Open a GitHub issue with brand/model and a brief description. **Never share passwords or private info.**
 
 ---

--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -258,6 +258,7 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
         try:
             while True:
                 try:
+                    await self._throttle_connection_attempt()
                     await self._connect_once()
                     await self._read_loop_ws()
                 except asyncio.CancelledError:

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -364,6 +364,7 @@ class WebSocketClient(_WSCommon):
             while not self._closing:
                 error: Exception | None = None
                 try:
+                    await self._throttle_connection_attempt()
                     await self._connect_once()
                     await self._wait_for_events()
                 except asyncio.CancelledError:
@@ -850,7 +851,7 @@ class WebSocketClient(_WSCommon):
 
         if not isinstance(inventory, Inventory):
             _LOGGER.error("WS: missing inventory for node dispatch on %s", self.dev_id)
-            return None
+            return
 
         self._apply_heater_addresses(
             raw_nodes,
@@ -882,7 +883,7 @@ class WebSocketClient(_WSCommon):
         else:  # pragma: no cover - legacy hass loop stub
             _send()
 
-        return None
+        return
 
     def _heater_sample_subscription_targets(self) -> Iterable[tuple[str, str]]:
         """Return ordered ``(node_type, addr)`` heater sample subscriptions."""
@@ -1222,6 +1223,7 @@ class TermoWebWSClient(WebSocketClient):  # pragma: no cover - legacy network cl
         while not self._closing:
             should_retry = True
             try:
+                await self._throttle_connection_attempt()
                 _LOGGER.debug("WS: initiating Socket.IO 0.9 handshake")
                 sid, hb_timeout = await self._handshake()
                 _LOGGER.debug(

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -490,8 +490,14 @@ custom_components/termoweb/backend/ws_client.py :: _prepare_nodes_dispatch
     Normalise node payload data for downstream websocket dispatch.
 custom_components/termoweb/backend/ws_client.py :: _WSCommon._process_power_updates
     Extract instantaneous power readings from websocket payloads.
+custom_components/termoweb/backend/ws_client.py :: ConnectionRateLimiter.__init__
+    Initialise the limiter with optional clock and sleep hooks.
+custom_components/termoweb/backend/ws_client.py :: ConnectionRateLimiter.wait_for_slot
+    Sleep if necessary before allowing the next connection attempt.
 custom_components/termoweb/backend/ws_client.py :: _WSCommon.__init__
     Initialise shared websocket state.
+custom_components/termoweb/backend/ws_client.py :: _WSCommon._throttle_connection_attempt
+    Apply a defensive rate limit before dialing the backend.
 custom_components/termoweb/backend/ws_client.py :: __getattr__
     Lazily expose backend websocket client implementations.
 custom_components/termoweb/backend/ws_health.py :: WsHealthTracker.update_status


### PR DESCRIPTION
## Summary
- add a shared websocket ConnectionRateLimiter to guard connection attempts
- apply throttling to both TermoWeb and Ducaheat websocket loops, including the legacy Socket.IO client, and document the expected pause after errors
- add regression coverage to ensure connection retries honor the limiter even when errors occur

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693823bed9b483299dd9cb41ffc3c733)