### PR TITLE
Handle websocket handshake cache lifecycle

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -124,6 +124,8 @@ custom_components/termoweb/backend/ws_client.py :: _WSStatusMixin._ws_bucket_siz
     Return the current websocket state and tracker bucket sizes.
 custom_components/termoweb/backend/ws_client.py :: _WSStatusMixin._cleanup_ws_state
     Remove cached websocket state and tracker entries for this device.
+custom_components/termoweb/backend/termoweb_ws.py :: WebSocketClient._reset_handshake_cache
+    Clear cached handshake metadata to avoid retaining payloads.
 custom_components/termoweb/backend/base.py :: HttpClientProto.set_node_settings
     Update node settings for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_samples


### PR DESCRIPTION
## Summary
- replace legacy websocket handshake payload caching with lightweight key/timestamp metadata and clear it on disconnect/reconnect
- drop handshake cache after initial dev_data snapshot while keeping state bucket entries minimal
- add regression coverage for reconnect cycles to ensure handshake cache cleanup and update existing handshake logging expectations

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/backend/termoweb_ws.py tests/test_termoweb_ws_protocol.py (fails on pre-existing repo warnings)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69539b37617c8329bfd6ff707c06c16a)