### PR TITLE
Refine heater name map caching

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1050,6 +1050,8 @@ custom_components/termoweb/inventory.py :: Inventory._validate_sample_targets
     Return deduplicated and sanitised sample target pairs.
 custom_components/termoweb/inventory.py :: Inventory.heater_name_map
     Return cached heater name mapping for ``default_factory``.
+custom_components/termoweb/inventory.py :: Inventory._heater_factory_signature
+    Return a stable cache key for ``factory`` when possible.
 custom_components/termoweb/inventory.py :: _normalize_node_iterable
     Return filtered node tuples and raw length for ``nodes``.
 custom_components/termoweb/inventory.py :: resolve_record_inventory


### PR DESCRIPTION
## Summary
- refactor `Inventory.heater_name_map` to normalize cache keys, skip anonymous factories, and evict stale entries when the cache exceeds a small limit
- ensure equivalent factories reuse cached heater name maps and add bounds-checking unit tests
- record the new factory signature helper in the function map documentation

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `uv run ruff check custom_components/termoweb/inventory.py tests/test_inventory.py` *(fails: existing lint findings unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a11f78a8832989feea1a2f8dbfa3)