### PR TITLE
Gate raw settings payloads and filter coordinator cache

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -152,6 +152,8 @@ custom_components/termoweb/backend/base.py :: fetch_normalised_hourly_samples
     Return per-node normalised samples for ``nodes`` between ``start`` and ``end``.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRequestError.__init__
     Initialise error metadata for logging and diagnostics.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._include_raw_settings
+    Return True when raw payloads should be retained for debugging.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._post_segmented
     Log segmented POST requests before delegating to ``_request``.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._log_segmented_post
@@ -736,6 +738,10 @@ custom_components/termoweb/coordinator.py :: StateCoordinator.__init__
     Initialize the TermoWeb device coordinator.
 custom_components/termoweb/coordinator.py :: StateCoordinator._collect_previous_settings
     Return normalised settings carried over from previous poll.
+custom_components/termoweb/coordinator.py :: StateCoordinator._include_raw_settings
+    Return True when raw settings payloads should be retained.
+custom_components/termoweb/coordinator.py :: StateCoordinator._filtered_settings_payload
+    Return a defensive copy of ``payload`` without raw blobs.
 custom_components/termoweb/coordinator.py :: StateCoordinator._instant_power_key
     Return a normalized key for instant power tracking.
 custom_components/termoweb/coordinator.py :: StateCoordinator._instant_power_snapshot

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1677,7 +1677,7 @@ async def test_set_acm_boost_state_rejects_invalid_stemp() -> None:
 
 
 def test_ducaheat_get_node_settings_normalises_payload(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     async def _run() -> None:
         session = FakeSession()
@@ -1730,7 +1730,10 @@ def test_ducaheat_get_node_settings_normalises_payload(
 
         monkeypatch.setattr(client, "authed_headers", fake_headers)
 
-        data = await client.get_node_settings("dev", ("htr", "A1"))
+        with caplog.at_level(
+            logging.DEBUG, logger="custom_components.termoweb.backend.ducaheat"
+        ):
+            data = await client.get_node_settings("dev", ("htr", "A1"))
 
         assert data["mode"] == "manual"
         assert data["state"] == "heating"

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -142,9 +142,12 @@ async def test_ducaheat_rest_client_normalises_acm(
 
     monkeypatch.setattr(ducaheat_rest_client, "_request", fake_request)
 
-    def fake_normalise(self, payload, *, node_type: str = "htr"):
+    def fake_normalise(
+        self, payload, *, node_type: str = "htr", include_raw: bool = False
+    ):
         seen["node_type"] = node_type
         seen["payload"] = payload
+        seen["include_raw"] = include_raw
         return {"normalized": True}
 
     monkeypatch.setattr(DucaheatRESTClient, "_normalise_settings", fake_normalise)

--- a/tests/test_ducaheat.py
+++ b/tests/test_ducaheat.py
@@ -1,0 +1,49 @@
+"""Tests for Ducaheat REST client settings payload handling."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.termoweb.backend.ducaheat import DucaheatRESTClient
+
+
+def test_normalise_settings_omits_raw_by_default() -> None:
+    """Normalised heater settings should exclude raw payload copies."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+    payload = {
+        "status": {"mode": "Auto", "temp": 21},
+        "setup": {"raw_only": True},
+    }
+
+    result = client._normalise_settings(payload)
+
+    assert "raw" not in result
+    assert result["mode"] == "auto"
+    assert result["mtemp"] == "21.0"
+
+
+@pytest.mark.asyncio
+async def test_get_node_settings_includes_raw_when_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Raw payloads should be retained when debug logging is enabled."""
+
+    client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
+    payload = {"status": {"mode": "Manual"}}
+
+    with (
+        patch.object(client, "authed_headers", AsyncMock(return_value={})),
+        patch.object(client, "_request", AsyncMock(return_value=payload)),
+        caplog.at_level(
+            logging.DEBUG, logger="custom_components.termoweb.backend.ducaheat"
+        ),
+    ):
+        result = await client.get_node_settings("dev", ("htr", "01"))
+
+    assert result["mode"] == "manual"
+    assert result["raw"] == payload


### PR DESCRIPTION
## Summary
- drop deep-copied raw payloads from ducaheat settings normalization by default and gate optional retention on debug logging
- filter coordinator settings caches to strip raw blobs between polls while keeping an opt-in debug path
- add tests covering memory-friendly settings payloads and update function map documentation

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(fails: timeout before completion)*
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing tests/test_backend_ducaheat.py tests/test_ducaheat.py tests/test_coordinator_collect_previous_settings.py tests/test_energy_coordinator.py tests/test_api.py
- pytest tests/test_ducaheat.py -q
- pytest tests/test_backend_ducaheat.py -q
- pytest tests/test_energy_coordinator.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a7032b0c8329a8a28226d524a29a)