### PR TITLE
Add TermoWeb settings/sample codecs (v2.0.0-pre3)

### DIFF
--- a/custom_components/termoweb/codecs/termoweb_codec.py
+++ b/custom_components/termoweb/codecs/termoweb_codec.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
-from .termoweb_models import DevListResponse, DevSummary, NodesResponse
+from .termoweb_models import (
+    DevListResponse,
+    DevSummary,
+    HeaterSettingsPayload,
+    NodesResponse,
+    PowerMonitorPayload,
+    SamplesResponse,
+    ThermostatSettingsPayload,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def decode_payload(payload: Any) -> Any:
@@ -65,3 +76,116 @@ def decode_nodes_payload(raw: Any) -> Any:
         return raw
 
     return model.model_dump(by_alias=True, exclude_none=True)
+
+
+def decode_node_settings(node_type: str, raw: Any) -> dict[str, Any]:
+    """Validate and normalise node settings while preserving legacy keys."""
+
+    if not isinstance(raw, dict):
+        return raw if raw is not None else {}
+
+    model_cls = HeaterSettingsPayload
+    if node_type == "thm":
+        model_cls = ThermostatSettingsPayload
+    elif node_type == "pmo":
+        model_cls = PowerMonitorPayload
+
+    try:
+        model = model_cls.model_validate(raw)
+        validated = model.model_dump(exclude_none=True)
+    except ValidationError:
+        return dict(raw)
+
+    if node_type in {"htr", "acm"}:
+        for key in ("mode", "stemp", "mtemp", "temp", "ptemp", "prog"):
+            if key in raw:
+                validated.setdefault(key, raw.get(key))
+
+    status_raw = raw.get("status")
+    if node_type in {"htr", "acm", "thm"} and isinstance(status_raw, dict):
+        status_validated = validated.setdefault("status", {})
+        if isinstance(status_validated, dict):
+            for key in ("stemp", "mtemp", "temp", "mode", "ptemp", "prog"):
+                if key in status_raw:
+                    status_validated.setdefault(key, status_raw.get(key))
+    return validated
+
+
+def decode_samples(
+    raw: Any,
+    *,
+    timestamp_divisor: float = 1.0,
+    logger: logging.Logger | None = None,
+) -> list[dict[str, str | int]]:
+    """Normalise heater samples payloads into {"t", "counter"} lists."""
+
+    log = logger or _LOGGER
+    items: list[Any] | None = None
+    if isinstance(raw, dict) and isinstance(raw.get("samples"), list):
+        try:
+            model = SamplesResponse.model_validate(raw)
+            items = [
+                sample.model_dump(exclude_none=True)
+                if isinstance(sample, BaseModel)
+                else sample
+                for sample in model.samples or []
+            ]
+        except ValidationError:
+            items = raw["samples"]
+    elif isinstance(raw, list):
+        items = [
+            sample.model_dump(exclude_none=True)
+            if isinstance(sample, BaseModel)
+            else sample
+            for sample in raw
+        ]
+
+    if items is None:
+        log.debug(
+            "Unexpected htr samples payload (%s); returning empty list",
+            type(raw).__name__,
+        )
+        return []
+
+    samples: list[dict[str, str | int]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            log.debug("Unexpected htr sample item: %r", item)
+            continue
+        timestamp: Any = item.get("t")
+        if timestamp is None:
+            timestamp = item.get("timestamp")
+        if not isinstance(timestamp, (int, float)):
+            log.debug("Unexpected htr sample shape: %s", item)
+            log.debug("Unexpected htr sample timestamp: %r", timestamp)
+            continue
+
+        counter_value: Any = item.get("counter")
+        counter_min: Any = item.get("counter_min")
+        counter_max: Any = item.get("counter_max")
+        if isinstance(counter_value, dict):
+            counter_min = counter_value.get("min", counter_min)
+            counter_max = counter_value.get("max", counter_max)
+            if "value" in counter_value:
+                counter_value = counter_value.get("value")
+            elif "counter" in counter_value:
+                counter_value = counter_value.get("counter")
+        if counter_value is None:
+            counter_value = item.get("value")
+        if counter_value is None:
+            counter_value = item.get("energy")
+        if counter_value is None:
+            log.debug("Unexpected htr sample shape: %s", item)
+            log.debug("Unexpected htr sample counter: %r", item)
+            continue
+
+        sample: dict[str, str | int] = {
+            "t": int(float(timestamp) / timestamp_divisor),
+            "counter": str(counter_value),
+        }
+        if counter_min is not None:
+            sample["counter_min"] = str(counter_min)
+        if counter_max is not None:
+            sample["counter_max"] = str(counter_max)
+        samples.append(sample)
+    return samples

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre2"
+  "version": "2.0.0-pre3"
 }

--- a/docs/v2_refactor_status.md
+++ b/docs/v2_refactor_status.md
@@ -9,5 +9,6 @@
 - The refactor progresses via a strangler pattern: new domain/codecs coexist with legacy code until fully migrated.
 
 ## Progress log
+- **v2.0.0-pre3**: Added Pydantic v2 models and codecs for TermoWeb node settings and samples; wired REST client read paths through codecs without changing outward behaviors. Testing: targeted codec + REST client sample/settings tests.
 - **v2.0.0-pre2**: Added TermoWeb REST codec and Pydantic v2 models for device and node inventory responses; wired REST client through codecs without changing return shapes. Testing: unit tests for codec payload normalization and API paths.
 - **v2.0.0-pre1**: Added domain and codec scaffolding; no runtime behavior changes. Testing: targeted unit tests for domain ids/inventory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre2"
+version = "2.0.0-pre3"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_termoweb_codec_settings_samples.py
+++ b/tests/test_termoweb_codec_settings_samples.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from custom_components.termoweb.codecs.termoweb_codec import (
+    decode_node_settings,
+    decode_samples,
+)
+
+
+def test_decode_node_settings_formats_temperatures() -> None:
+    raw = {
+        "mode": "Auto",
+        "stemp": 21,
+        "mtemp": " 19.25 ",
+        "ptemp": [18, "20", None],
+    }
+
+    decoded = decode_node_settings("htr", raw)
+
+    assert decoded["mode"] == "Auto"
+    assert decoded["stemp"] == "21.0"
+    assert decoded["mtemp"] == "19.2"
+    assert decoded["ptemp"] == ["18.0", "20.0", None]
+
+
+def test_decode_node_settings_handles_status_block() -> None:
+    raw = {
+        "status": {
+            "mode": "off",
+            "stemp": 19,
+            "prog": [0, 1, 2],
+            "ptemp": ["7", "17.5", "21.0"],
+        }
+    }
+
+    decoded = decode_node_settings("acm", raw)
+
+    assert decoded["status"]["mode"] == "off"
+    assert decoded["status"]["stemp"] == "19.0"
+    assert decoded["status"]["prog"] == [0, 1, 2]
+    assert decoded["status"]["ptemp"] == ["7.0", "17.5", "21.0"]
+
+
+def test_decode_node_settings_preserves_short_prog() -> None:
+    raw = {"prog": [0, 1, 2]}
+
+    decoded = decode_node_settings("htr", raw)
+
+    assert decoded["prog"] == [0, 1, 2]
+
+
+def test_decode_samples_filters_invalid_items(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG)
+    raw = {
+        "samples": [
+            {"t": 1000, "counter": 1.5},
+            {"timestamp": 2000, "value": 5},
+            {"t": "bad", "counter": 3},
+            {"t": 3000},
+        ]
+    }
+
+    decoded = decode_samples(raw)
+
+    assert decoded == [
+        {"t": 1000, "counter": "1.5"},
+        {"t": 2000, "counter": "5"},
+    ]
+    assert any("Unexpected htr sample shape" in rec.message for rec in caplog.records)
+
+
+def test_decode_samples_applies_timestamp_divisor() -> None:
+    raw = {"samples": [{"t": 1000.0, "counter": 5}]}
+
+    decoded = decode_samples(raw, timestamp_divisor=10.0)
+
+    assert decoded == [{"t": 100, "counter": "5"}]


### PR DESCRIPTION
## Summary
- add Pydantic v2 models for TermoWeb settings and sample payloads and normalize values for existing shapes
- route REST client settings and sample reads through the new codecs and bump the integration to v2.0.0-pre3
- document the v2 refactor status and add codec coverage for settings/sample normalization

## Testing
- ruff check custom_components/termoweb/codecs/termoweb_codec.py custom_components/termoweb/codecs/termoweb_models.py tests/test_termoweb_codec_settings_samples.py
- pytest -q tests/test_termoweb_codec_settings_samples.py tests/test_api.py::test_get_node_samples_success tests/test_api.py::test_get_node_samples_empty_payload tests/test_api.py::test_get_node_samples_decreasing_counters tests/test_api.py::test_get_node_samples_malformed_items tests/test_api.py::test_get_node_samples_unexpected_payload tests/test_api.py::test_get_node_settings_acm_logs tests/test_api.py::test_get_node_settings_pmo_uses_device_endpoint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d844099483299a637616e03172ae)