### PR TITLE
Domain state store: explicit fields only (no raw/extra payload retention)

### DIFF
--- a/custom_components/termoweb/binary_sensor.py
+++ b/custom_components/termoweb/binary_sensor.py
@@ -146,10 +146,10 @@ class GatewayOnlineBinarySensor(
             "dev_id": self._dev_id,
             "name": data.get("name"),
             "connected": data.get("connected"),
+            "model": data.get("model"),
             "ws_status": ws.get("status"),
             "ws_last_event_at": ws.get("last_event_at"),
             "ws_healthy_minutes": ws.get("healthy_minutes"),
-            "raw": data.get("raw") or {},
         }
 
     @callback

--- a/custom_components/termoweb/codecs/ducaheat_codec.py
+++ b/custom_components/termoweb/codecs/ducaheat_codec.py
@@ -54,22 +54,18 @@ def decode_prog(payload: Any) -> Any:
     raise NotImplementedError
 
 
-def decode_settings(
-    payload: Any, *, node_type: NodeType, include_raw: bool = False
-) -> dict[str, Any]:
+def decode_settings(payload: Any, *, node_type: NodeType) -> dict[str, Any]:
     """Decode segmented settings payloads into the legacy mapping."""
 
     if node_type is NodeType.THERMOSTAT:
-        return _decode_thm_settings(payload, include_raw=include_raw)
+        return _decode_thm_settings(payload)
     if node_type in {NodeType.HEATER, NodeType.ACCUMULATOR}:
-        return _decode_status_payload(
-            payload, node_type=node_type, include_raw=include_raw
-        )
+        return _decode_status_payload(payload, node_type=node_type)
     return payload if isinstance(payload, dict) else {}
 
 
 def _decode_status_payload(  # noqa: C901
-    payload: Any, *, node_type: NodeType, include_raw: bool
+    payload: Any, *, node_type: NodeType
 ) -> dict[str, Any]:
     """Normalise heater/accumulator settings payloads."""
 
@@ -181,9 +177,6 @@ def _decode_status_payload(  # noqa: C901
         if key in payload:
             flattened[key] = payload[key]
 
-    if include_raw:
-        flattened["raw"] = payload
-
     if node_type is NodeType.ACCUMULATOR:
         capabilities = _normalise_acm_capabilities(payload)
         if capabilities:
@@ -192,7 +185,7 @@ def _decode_status_payload(  # noqa: C901
     return flattened
 
 
-def _decode_thm_settings(payload: Any, *, include_raw: bool) -> dict[str, Any]:
+def _decode_thm_settings(payload: Any) -> dict[str, Any]:
     """Return a normalised thermostat settings mapping."""
 
     if not isinstance(payload, dict):
@@ -264,9 +257,6 @@ def _decode_thm_settings(payload: Any, *, include_raw: bool) -> dict[str, Any]:
     sync_status = payload.get("sync_status")
     if isinstance(sync_status, str):
         normalised["sync_status"] = sync_status
-
-    if include_raw:
-        normalised["raw"] = payload
 
     return normalised
 

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -136,25 +136,11 @@ class StateCoordinator(
 
         return self._domain_view
 
-    def _include_raw_settings(self) -> bool:
-        """Return True when raw settings payloads should be retained."""
-
-        try:
-            checker = getattr(_LOGGER, "isEnabledFor", None)
-            if callable(checker):
-                return bool(checker(logging.DEBUG))
-        except (AttributeError, TypeError):  # pragma: no cover - defensive
-            return False
-        return False
-
     def _filtered_settings_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
         """Return a defensive copy of ``payload`` without raw blobs."""
 
         if not isinstance(payload, Mapping):
             return {}
-
-        if self._include_raw_settings():
-            return dict(payload)
 
         return {key: value for key, value in payload.items() if key != "raw"}
 
@@ -762,7 +748,7 @@ class StateCoordinator(
             store,
             inventory,
             device_name=dev_name,
-            device_raw=self._device,
+            device_details=self._device,
         )
         new_data = dict(self.data or {})
         new_data.update(device_record)
@@ -804,7 +790,7 @@ class StateCoordinator(
             store,
             inventory,
             device_name=dev_name,
-            device_raw=self._device,
+            device_details=self._device,
         )
         new_data = dict(self.data or {})
         new_data.update(device_record)
@@ -909,7 +895,7 @@ class StateCoordinator(
                 store,
                 inventory,
                 device_name=dev_name,
-                device_raw=self._device,
+                device_details=self._device,
             )
             new_data = dict(self.data or {})
             new_data.update(device_record)
@@ -974,7 +960,7 @@ class StateCoordinator(
                 store,
                 inventory,
                 device_name=dev_name,
-                device_raw=self._device,
+                device_details=self._device,
                 include_nodes_by_type=False,
             )
 

--- a/custom_components/termoweb/domain/legacy_view.py
+++ b/custom_components/termoweb/domain/legacy_view.py
@@ -16,16 +16,22 @@ def store_to_legacy_coordinator_data(
     inventory: Inventory,
     *,
     device_name: str,
-    device_raw: Mapping[str, Any] | None,
+    device_details: Mapping[str, Any] | None = None,
     include_nodes_by_type: bool = True,
 ) -> dict[str, dict[str, Any]]:
     """Return a coordinator data mapping using the legacy dict schema."""
+
+    model: str | None = None
+    if isinstance(device_details, Mapping):
+        model_value = device_details.get("model")
+        if model_value not in (None, ""):
+            model = str(model_value)
 
     settings = store.legacy_view()
     device_record: dict[str, Any] = {
         "dev_id": dev_id,
         "name": device_name,
-        "raw": device_raw or {},
+        "model": model,
         "connected": True,
         "inventory": inventory,
         "settings": settings,

--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -14,7 +14,7 @@ RawNodePayload = Any
 PrebuiltNode = Any
 
 _NODE_SECTION_IGNORE_KEYS = frozenset(
-    {"dev_id", "name", "raw", "connected", "nodes", "nodes_by_type"}
+    {"dev_id", "name", "connected", "nodes", "nodes_by_type"}
 )
 
 _SNAPSHOT_NAME_CANDIDATE_KEYS = (

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre13"
+  "version": "2.0.0-pre14"
 }

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -111,11 +111,9 @@ def build_gateway_device_info(
     if data:
         gateway_data = data.get(str(dev_id))
         if isinstance(gateway_data, Mapping):
-            raw = gateway_data.get("raw")
-            if isinstance(raw, Mapping):
-                model = raw.get("model")
-                if model not in (None, ""):
-                    info["model"] = str(model)
+            model = gateway_data.get("model")
+            if model not in (None, ""):
+                info["model"] = str(model)
 
     return info
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,10 @@ coordinators already consume.【F:custom_components/termoweb/inventory.py†L181
   REST snapshots and websocket deltas are written into the shared
   `DomainStateStore` for both vendors, and the exposed coordinator data is a
   derived, legacy-shaped view of that store rather than an independently merged
-  dictionary. `EnergyStateCoordinator` tracks address subscriptions, derives
+  dictionary. The store retains only explicit, bounded fields (modes,
+  temperatures, charge metadata, battery levels, capabilities) and discards
+  unknown vendor keys or raw payload blobs to keep memory usage predictable.
+  `EnergyStateCoordinator` tracks address subscriptions, derives
   power deltas from hourly counters and suppresses REST polling when fresh
   websocket samples arrive.【F:custom_components/termoweb/coordinator.py†L93-L745】
 - **Entity platforms** – `HeaterNodeBase` wires coordinator caches and

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -132,8 +132,6 @@ custom_components/termoweb/backend/base.py :: normalise_energy_samples
     Return energy samples expressed in epoch seconds and kWh.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRequestError.__init__
     Initialise error metadata for logging and diagnostics.
-custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._include_raw_settings
-    Return True when raw payloads should be retained for debugging.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._post_segmented
     Log segmented POST requests before delegating to ``_request``.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._log_segmented_post
@@ -916,8 +914,6 @@ custom_components/termoweb/coordinator.py :: StateCoordinator.__init__
     Initialize the TermoWeb device coordinator.
 custom_components/termoweb/coordinator.py :: StateCoordinator.domain_view
     Return the read-only domain state view.
-custom_components/termoweb/coordinator.py :: StateCoordinator._include_raw_settings
-    Return True when raw settings payloads should be retained.
 custom_components/termoweb/coordinator.py :: StateCoordinator._filtered_settings_payload
     Return a defensive copy of ``payload`` without raw blobs.
 custom_components/termoweb/coordinator.py :: StateCoordinator._instant_power_key
@@ -1042,6 +1038,8 @@ custom_components/termoweb/domain/state.py :: NodeStatusDelta.payload
     Return the status mapping payload.
 custom_components/termoweb/domain/state.py :: NodeSamplesDelta.payload
     Return the samples mapping payload.
+custom_components/termoweb/domain/state.py :: _coerce_number
+    Return ``value`` as a number when possible.
 custom_components/termoweb/domain/state.py :: _populate_heater_state
     Populate base heater fields on ``state`` from ``payload``.
 custom_components/termoweb/domain/state.py :: _build_heater_state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre13"
+version = "2.0.0-pre14"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1874,7 +1874,7 @@ class FakeCoordinator:
             self._state_store,
             self.inventory,
             device_name=device_name or self.dev_id,
-            device_raw=self.dev,
+            device_details=self.dev,
         )
         self.data.update(device_record)
         return True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1745,7 +1745,7 @@ def test_ducaheat_get_node_settings_normalises_payload(
         assert "boost_temp" not in data
         assert len(data["prog"]) == 168
         assert data["ptemp"] == ["7.0", "18.0", "21.0"]
-        assert data["raw"]["status"]["mode"] == "Manual"
+        assert "raw" not in data
 
     asyncio.run(_run())
 

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -55,7 +55,7 @@ def test_binary_sensor_setup_and_dispatch(
                 dev_id: {
                     "name": "Living Room",  # attributes
                     "connected": True,
-                    "raw": {"model": "TW-GW"},
+                    "model": "TW-GW",
                 }
             },
         )
@@ -124,10 +124,10 @@ def test_binary_sensor_setup_and_dispatch(
             "dev_id": dev_id,
             "name": "Living Room",
             "connected": True,
+            "model": "TW-GW",
             "ws_status": "healthy",
             "ws_last_event_at": "2024-05-01T12:00:00Z",
             "ws_healthy_minutes": 42,
-            "raw": {"model": "TW-GW"},
         }
 
         entity.schedule_update_ha_state = MagicMock()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -701,7 +701,7 @@ async def test_refresh_skips_pending_settings_merge(
         "dev": {
             "dev_id": "dev",
             "name": "Device",
-            "raw": {"name": "Device"},
+            "model": None,
             "connected": True,
             "inventory": inventory,
             "settings": {"htr": {"1": {"mode": "manual", "stemp": "21.0"}}},
@@ -755,7 +755,7 @@ async def test_poll_skips_pending_settings_merge(
         "dev": {
             "dev_id": "dev",
             "name": "Device",
-            "raw": {"name": "Device"},
+            "model": None,
             "connected": True,
             "inventory": inventory,
             "settings": {"htr": {"1": {"mode": "manual", "stemp": "21.0"}}},

--- a/tests/test_coordinator_assemble_device_record.py
+++ b/tests/test_coordinator_assemble_device_record.py
@@ -29,7 +29,7 @@ def test_assemble_device_record_uses_inventory_maps(
     )
 
     settings = {
-        "htr": {"01": {"target": 21}},
+        "htr": {"01": {"stemp": 21}},
         "acm": {"07": {"mode": "auto"}},
     }
 
@@ -47,7 +47,7 @@ def test_assemble_device_record_uses_inventory_maps(
         store,
         inventory,
         device_name="Device dev",
-        device_raw={"name": "Device dev"},
+        device_details={"name": "Device dev"},
     )
 
     device = record["dev"]

--- a/tests/test_coordinator_clone_inventory.py
+++ b/tests/test_coordinator_clone_inventory.py
@@ -25,7 +25,7 @@ def test_device_record_reuses_inventory_instance() -> None:
         store,
         inventory,
         device_name="Device",
-        device_raw={},
+        device_details={},
     )
 
     device = record["dev-123"]

--- a/tests/test_domain_state_store.py
+++ b/tests/test_domain_state_store.py
@@ -4,6 +4,8 @@ import datetime as dt
 from typing import Any, Callable, Mapping
 
 from custom_components.termoweb.domain import (
+    ThermostatState,
+    build_state_from_payload,
     DomainStateStore,
     NodeId,
     NodeSettingsDelta,
@@ -23,7 +25,15 @@ def test_domain_state_store_applies_snapshots_and_patches() -> None:
     store.apply_full_snapshot(
         "htr",
         "1",
-        {"mode": "manual", "stemp": "21.0", "prog": [0, 1, 2]},
+        {
+            "mode": "manual",
+            "stemp": "21.0",
+            "prog": [0, 1, 2],
+            "state": "heating",
+            "max_power": 1000,
+            "batt_level": "4",
+            "unexpected": "ignored",
+        },
     )
     store.apply_full_snapshot(
         "acm",
@@ -31,15 +41,33 @@ def test_domain_state_store_applies_snapshots_and_patches() -> None:
         {
             "mode": "auto",
             "charge_level": 75,
+            "boost": True,
             "boost_active": False,
             "boost_end_datetime": dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+            "charging": True,
+            "current_charge_per": "45.5",
+            "target_charge_per": 95,
+            "boost_end": {"day": 7, "minute": 15},
+            "boost_remaining": 10,
+            "extra": {"raw": "data"},
         },
     )
     settings = store.legacy_view()
     assert settings["htr"]["1"]["mode"] == "manual"
     assert settings["htr"]["1"]["stemp"] == "21.0"
+    assert settings["htr"]["1"]["state"] == "heating"
+    assert settings["htr"]["1"]["max_power"] == 1000
+    assert settings["htr"]["1"]["batt_level"] == 4
+    assert "unexpected" not in settings["htr"]["1"]
     assert settings["acm"]["2"]["charge_level"] == 75
     assert settings["acm"]["2"]["boost_active"] is False
+    assert settings["acm"]["2"]["charging"] is True
+    assert settings["acm"]["2"]["current_charge_per"] == 45.5
+    assert settings["acm"]["2"]["target_charge_per"] == 95
+    assert settings["acm"]["2"]["boost"] is True
+    assert settings["acm"]["2"]["boost_end"] == {"day": 7, "minute": 15}
+    assert settings["acm"]["2"]["boost_remaining"] == 10
+    assert "extra" not in settings["acm"]["2"]
 
     store.apply_patch("htr", "1", {"stemp": "19.5"})
     patched = store.legacy_view()
@@ -69,6 +97,28 @@ def test_domain_state_store_applies_deltas() -> None:
     assert legacy["htr"]["1"]["status"]["online"] is True
 
 
+def test_build_state_from_payload_ignores_unknown_fields() -> None:
+    """Domain state instances should only retain explicit fields."""
+
+    state = build_state_from_payload(
+        "thm",
+        {
+            "mode": "auto",
+            "state": "idle",
+            "batt_level": "5",
+            "capabilities": {"supports": ["battery"]},
+            "mystery": {"raw": "payload"},
+        },
+    )
+    assert isinstance(state, ThermostatState)
+    legacy = state.to_legacy()
+    assert legacy["mode"] == "auto"
+    assert legacy["state"] == "idle"
+    assert legacy["batt_level"] == 5
+    assert legacy["capabilities"] == {"supports": ["battery"]}
+    assert "mystery" not in legacy
+
+
 def test_store_to_legacy_coordinator_data_matches_schema(
     inventory_builder: Callable[
         [str, Mapping[str, Any] | None, Iterable[Any] | None], Any
@@ -90,11 +140,12 @@ def test_store_to_legacy_coordinator_data_matches_schema(
         store,
         inventory,
         device_name="Device dev",
-        device_raw={"dev_id": "dev"},
+        device_details={"dev_id": "dev", "model": "Controller"},
     )
     record = legacy["dev"]
     assert record["dev_id"] == "dev"
     assert record["name"] == "Device dev"
+    assert record["model"] == "Controller"
     assert record["inventory"] is inventory
     assert record["settings"]["acm"]["2"]["boost_minutes_delta"] == 15
     assert record["settings"]["htr"]["1"]["mode"] == "manual"

--- a/tests/test_ducaheat.py
+++ b/tests/test_ducaheat.py
@@ -28,10 +28,10 @@ def test_normalise_settings_omits_raw_by_default() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_node_settings_includes_raw_when_debug(
+async def test_get_node_settings_excludes_raw_payloads(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Raw payloads should be retained when debug logging is enabled."""
+    """Raw payloads should never be retained in normalised settings."""
 
     client = DucaheatRESTClient(SimpleNamespace(), "user", "pass")
     payload = {"status": {"mode": "Manual"}}
@@ -46,4 +46,4 @@ async def test_get_node_settings_includes_raw_when_debug(
         result = await client.get_node_settings("dev", ("htr", "01"))
 
     assert result["mode"] == "manual"
-    assert result["raw"] == payload
+    assert "raw" not in result

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -506,7 +506,7 @@ def test_refresh_heater_updates_existing_and_new_data() -> None:
         dev = first["dev"]
         assert dev["dev_id"] == "dev"
         assert dev["name"] == "Device"
-        assert dev["raw"] == {"name": " Device "}
+        assert dev["model"] is None
         assert "nodes" not in dev
         assert dev["connected"] is True
         assert dev["settings"]["htr"]["A"] == {"mode": "auto"}
@@ -676,7 +676,7 @@ def test_refresh_heater_populates_missing_metadata() -> None:
         result = updates[-1]["dev"]
         client.get_node_settings.assert_called_once_with("dev", ("htr", "A"))
         assert result["name"] == "Device"
-        assert result["raw"] == {"name": " Device "}
+        assert result["model"] is None
         assert "nodes" not in result
         assert result["connected"] is True
         assert result["settings"]["htr"]["A"] == {"mode": "heat"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,7 +158,7 @@ def test_build_gateway_device_info_respects_include_version_flag() -> None:
                     "brand": "Ducaheat",
                     "version": "9.1",
                     "coordinator": types.SimpleNamespace(
-                        data={"dev": {"raw": {"model": "Controller"}}}
+                        data={"dev": {"model": "Controller"}}
                     ),
                 }
             }
@@ -178,7 +178,7 @@ def test_build_gateway_device_info_uses_gateway_model_from_coordinator() -> None
             DOMAIN: {
                 "entry": {
                     "coordinator": types.SimpleNamespace(
-                        data={"dev": {"raw": {"model": "Controller"}}}
+                        data={"dev": {"model": "Controller"}}
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- remove raw payload retention across the domain store, device records, and diagnostics helpers while promoting explicit heater/accumulator/thermostat fields (state, max_power, charge metadata, battery level)
- drop legacy include_raw plumbing from the Ducaheat codec/backend and stop attaching raw metadata to coordinator data and gateway entities
- document the bounded domain store shape, update the function map, and bump the integration to v2.0.0-pre14 with refreshed tests

## Testing
- `uv run ruff check .` *(fails: pre-existing lint in untouched modules such as api.py/base.py)*
- `uv run ruff check custom_components/termoweb/domain/state.py custom_components/termoweb/domain/legacy_view.py custom_components/termoweb/utils.py custom_components/termoweb/backend/ducaheat.py custom_components/termoweb/codecs/ducaheat_codec.py custom_components/termoweb/coordinator.py`
- `uv run timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954d82dc5488329ba2763b90c434ba1)