### PR TITLE
Align TermoWeb coordinator with domain state store snapshot

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre14"
+  "version": "2.0.0-pre15"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -634,10 +634,6 @@ custom_components/termoweb/climate.py :: HeaterClimateEntity._slot_label
     Translate a program slot integer into a label.
 custom_components/termoweb/climate.py :: HeaterClimateEntity._current_prog_slot
     Return the active program slot index for the heater.
-custom_components/termoweb/climate.py :: HeaterClimateEntity._settings_maps
-    Return all cached settings maps referencing this node.
-custom_components/termoweb/climate.py :: HeaterClimateEntity._settings_maps._iter_node_types
-    Yield node types that may hold settings for this address.
 custom_components/termoweb/climate.py :: HeaterClimateEntity._shared_inventory
     Return the shared immutable inventory for this coordinator.
 custom_components/termoweb/climate.py :: HeaterClimateEntity._optimistic_update
@@ -932,6 +928,10 @@ custom_components/termoweb/coordinator.py :: StateCoordinator.instant_power_over
     Return a diagnostics-friendly snapshot of instant power values.
 custom_components/termoweb/coordinator.py :: StateCoordinator._should_skip_rest_power
     Return ``True`` when websocket data is fresh enough to skip REST power.
+custom_components/termoweb/coordinator.py :: StateCoordinator._device_record
+    Return a minimal coordinator payload for this device.
+custom_components/termoweb/coordinator.py :: StateCoordinator._publish_device_record
+    Push the latest device snapshot to coordinator listeners.
 custom_components/termoweb/coordinator.py :: StateCoordinator._async_fetch_settings_to_store
     Fetch settings for every address and store them in the domain cache.
 custom_components/termoweb/coordinator.py :: StateCoordinator._normalize_mode_value
@@ -966,8 +966,6 @@ custom_components/termoweb/coordinator.py :: StateCoordinator._node_ids_from_inv
     Return domain node identifiers derived from ``inventory``.
 custom_components/termoweb/coordinator.py :: StateCoordinator._ensure_state_store
     Ensure a domain state store exists when applicable.
-custom_components/termoweb/coordinator.py :: StateCoordinator._seed_state_store_from_data
-    Populate the domain store from any existing coordinator data.
 custom_components/termoweb/coordinator.py :: StateCoordinator.handle_ws_deltas
     Merge websocket-delivered deltas into the domain state store.
 custom_components/termoweb/coordinator.py :: StateCoordinator.apply_entity_patch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre14"
+version = "2.0.0-pre15"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -323,21 +323,17 @@ def test_accumulator_boost_cancel_button_tracks_availability() -> None:
         dev_id = "device-cancel"
         addr = "5"
 
+        context = _make_boost_context(entry_id, dev_id, addr=addr, name="Hallway")
         coordinator = FakeCoordinator(
             hass,
             dev_id=dev_id,
             data={
                 dev_id: {
-                    "settings": {
-                        "acm": {
-                            addr: {"boost_active": True},
-                        }
-                    }
+                    "settings": {"acm": {addr: {"boost_active": True}}},
                 }
             },
+            inventory=context.inventory,
         )
-
-        context = _make_boost_context(entry_id, dev_id, addr=addr, name="Hallway")
         button = AccumulatorBoostCancelButton(
             coordinator,
             context,
@@ -350,7 +346,9 @@ def test_accumulator_boost_cancel_button_tracks_availability() -> None:
 
         assert button.available is True
 
-        coordinator.data[dev_id]["settings"]["acm"][addr]["boost_active"] = False
+        assert coordinator.apply_entity_patch(
+            "acm", addr, lambda cur: cur.__setitem__("boost_active", False)
+        )
         for listener in list(getattr(coordinator, "listeners", [])):
             listener()
 


### PR DESCRIPTION
## Summary
- Update TermoWeb coordinator to publish device snapshots backed by the domain state store and views
- Ensure optimistic patches clear derived boost metadata and keep state in sync
- Adapt test infrastructure and platform tests to domain store helpers and inventory-backed setups

## Testing
- ruff check custom_components/termoweb/coordinator.py custom_components/termoweb/heater.py custom_components/termoweb/climate.py custom_components/termoweb/button.py tests/test_coordinator.py
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e1701aac8329aa3038eff89056bf)