### PR TITLE
WS + codec cleanup: remove legacy hooks and deep-copy caches (bounded deltas only)

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre15"
+  "version": "2.0.0-pre16"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -236,8 +236,6 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._reset_pay
     Reset the payload stale window to the default.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._dispatch_nodes
     Publish inventory-derived node addresses for downstream consumers.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._merge_nodes
-    Deep merge ``source`` updates into ``target`` in place.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._collect_sample_updates
     Extract heater sample updates from a websocket payload.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._nodes_to_deltas
@@ -442,6 +440,10 @@ custom_components/termoweb/backend/ws_client.py :: ConnectionRateLimiter.__init_
     Initialise the limiter with optional clock and sleep hooks.
 custom_components/termoweb/backend/ws_client.py :: ConnectionRateLimiter.wait_for_slot
     Sleep if necessary before allowing the next connection attempt.
+custom_components/termoweb/backend/ws_client.py :: clone_payload_value
+    Return a shallow copy of mapping or sequence payload values.
+custom_components/termoweb/backend/ws_client.py :: build_settings_delta
+    Extract canonical settings keys from a websocket section payload.
 custom_components/termoweb/backend/ws_client.py :: resolve_ws_update_section
     Map a websocket path segment onto the node section bucket.
 custom_components/termoweb/backend/ws_client.py :: forward_ws_sample_updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre15"
+version = "2.0.0-pre16"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -368,8 +368,9 @@ def test_nodes_to_deltas_translates_payloads(
 
     nodes = {
         "htr": {
-            "settings": {"1": {"mode": "auto"}},
-            "status": {"1": {"online": True}},
+            "settings": {"1": {"mode": "auto", "ignored": "value"}},
+            "status": {"1": {"online": True, "extra": "keep"}},
+            "samples": {"1": {"temp": 25}},
         }
     }
 
@@ -381,6 +382,8 @@ def test_nodes_to_deltas_translates_payloads(
     assert delta.node_id.addr == "1"
     assert delta.payload["mode"] == "auto"
     assert delta.payload["status"]["online"] is True
+    assert "ignored" not in delta.payload
+    assert "samples" not in delta.payload
 
 
 def test_nodes_to_deltas_validates_inventory(
@@ -1402,17 +1405,6 @@ async def test_disconnect_resets_payload_window(
     state = client._ws_state_bucket()
     assert state["payload_window_hint"] is None
     assert state["payload_window_source"] == "disconnect"
-
-
-def test_merge_nodes_overwrites_non_mapping() -> None:
-    """The merge helper should replace non-mapping targets."""
-
-    target = {"htr": "invalid"}
-    source = {"htr": {"status": {"1": {}}}}
-
-    ducaheat_ws.DucaheatWSClient._merge_nodes(target, source)
-
-    assert target["htr"]["status"]["1"] == {}
 
 
 def test_log_nodes_summary_branches(

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -799,9 +799,11 @@ def test_termoweb_nodes_to_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
 
     nodes_payload = {
         "htr": {
-            "settings": {"1": {"mode": "manual"}},
+            "settings": {"1": {"mode": "manual", "unknown": "drop"}},
             "status": {"1": {"online": True}},
             "prog": {"1": {"0": 1}},
+            "samples": {"1": {"temp": 12}},
+            "advanced": {"1": {"misc": "skip"}},
         }
     }
 
@@ -813,6 +815,8 @@ def test_termoweb_nodes_to_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
     assert delta.payload["mode"] == "manual"
     assert delta.payload["status"]["online"] is True
     assert delta.payload["prog"] == {"0": 1}
+    assert "unknown" not in delta.payload
+    assert "samples" not in delta.payload
 
 
 def test_termoweb_nodes_to_deltas_validates_inventory(


### PR DESCRIPTION
## Summary
- add canonical websocket settings extraction helpers and shallow payload cloning to keep deltas bounded
- route both TermoWeb and Ducaheat websocket delta builders through the canonical filter and remove the unused merge helper coverage
- bump integration metadata to v2.0.0-pre16

## Testing
- ruff check . *(fails: repository has pre-existing lint issues such as missing docstrings and inline imports in websocket modules)*
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing -q *(timed out around mid-run; partial progress logged)*
- pytest -q tests/test_ws_client.py tests/test_ducaheat_ws_protocol.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69550260b8f8832996da9e03543df5be)