### PR TITLE
v2.0.0-pre17: Drop raw inventory payload retention; inventory holds only typed nodes; sync socketio pin

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -515,7 +515,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
     node_inventory = build_node_inventory(nodes)
     # Inventory-centric design: build and freeze the gateway/node topology once
     # during setup so every runtime component can trust the shared metadata.
-    inventory = Inventory(dev_id, nodes, node_inventory)
+    inventory = Inventory(dev_id, node_inventory)
     await _async_probe_unknown_node_types(backend, dev_id, inventory)
     if inventory.nodes:
         type_counts = Counter(node.type for node in inventory.nodes)

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -654,21 +654,7 @@ class StateCoordinator(
         """Return domain node identifiers derived from ``inventory``."""
 
         node_ids: list[DomainNodeId] = []
-        raw_nodes: Iterable[Any] | None = inventory.nodes
-        nodes_iterable: Iterable[Any] = raw_nodes or ()
-        if not nodes_iterable:
-            payload = (
-                inventory.payload if isinstance(inventory.payload, Mapping) else {}
-            )
-            nodes_section = payload.get("nodes") if isinstance(payload, Mapping) else []
-            if isinstance(nodes_section, Iterable) and not isinstance(
-                nodes_section, (str, bytes)
-            ):
-                nodes_iterable = nodes_section
-            else:
-                nodes_iterable = ()
-
-        for node in nodes_iterable:
+        for node in inventory.nodes:
             node_type_value: Any
             addr_value: Any
             if isinstance(node, Mapping):

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -835,11 +835,7 @@ def heater_platform_details_for_entry(
                 dev_id = entry_data.get("dev_id") if isinstance(entry_data, Mapping) else None
                 if isinstance(nodes_payload, Mapping) and isinstance(dev_id, str):
                     try:
-                        inventory = Inventory(
-                            dev_id,
-                            nodes_payload,
-                            build_node_inventory(nodes_payload),
-                        )
+                        inventory = Inventory(dev_id, build_node_inventory(nodes_payload))
                         if isinstance(entry_data, MutableMapping):
                             entry_data["inventory"] = inventory
                     except (TypeError, ValueError):  # pragma: no cover - defensive reconstruction

--- a/custom_components/termoweb/inventory.py
+++ b/custom_components/termoweb/inventory.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from .const import DOMAIN
 
-RawNodePayload = Any
 PrebuiltNode = Any
 
 _NODE_SECTION_IGNORE_KEYS = frozenset(
@@ -61,7 +60,6 @@ __all__ = [
     "build_node_inventory",
     "heater_platform_details_from_inventory",
     "heater_sample_subscription_targets",
-    "energy_sample_types",
     "normalize_heater_addresses",
     "normalize_node_addr",
     "normalize_node_type",
@@ -112,7 +110,6 @@ class Inventory:
     _DEFAULT_FACTORY_CACHE_KEY: ClassVar[str] = "default_factory"
 
     _dev_id: str
-    _payload: RawNodePayload
     _nodes: tuple[PrebuiltNode, ...]
     _addresses_by_type_cache: dict[str, tuple[str, ...]] | None
     _nodes_by_type_cache: dict[str, tuple[PrebuiltNode, ...]] | None
@@ -139,13 +136,11 @@ class Inventory:
     def __init__(
         self,
         dev_id: str,
-        payload: RawNodePayload,
         nodes: Iterable[PrebuiltNode],
     ) -> None:
         """Initialize the inventory container."""
 
         object.__setattr__(self, "_dev_id", dev_id)
-        object.__setattr__(self, "_payload", payload)
         object.__setattr__(self, "_nodes", tuple(nodes))
         object.__setattr__(self, "_addresses_by_type_cache", None)
         object.__setattr__(self, "_nodes_by_type_cache", None)
@@ -166,12 +161,6 @@ class Inventory:
         """Get the device identifier."""
 
         return self._dev_id
-
-    @property
-    def payload(self) -> RawNodePayload:
-        """Get the raw node payload."""
-
-        return self._payload
 
     @property
     def nodes(self) -> tuple[PrebuiltNode, ...]:
@@ -974,12 +963,12 @@ class Inventory:
         """Return the cached inventory stored within ``record``."""
 
         if not isinstance(record, Mapping):
-            raise LookupError(
+            raise LookupError(  # noqa: TRY004
                 f"{context or 'inventory'} record is unavailable; integration state missing"
             )
         candidate = record.get(attr)
         if not isinstance(candidate, Inventory):
-            raise LookupError(
+            raise LookupError(  # noqa: TRY004
                 f"{context or 'inventory'} record is unavailable; cached inventory missing"
             )
         return candidate
@@ -1168,7 +1157,7 @@ def boostable_accumulator_details_for_entry(
 ) -> tuple[HeaterPlatformDetails, list[tuple[str, str, str]]]:
     """Return boostable accumulator metadata for a config entry."""
 
-    from .heater import (
+    from .heater import (  # noqa: PLC0415
         heater_platform_details_for_entry,
         iter_boostable_heater_nodes,
         log_skipped_nodes,

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre16"
+  "version": "2.0.0-pre17"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre16"
+version = "2.0.0-pre17"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]
@@ -8,7 +8,7 @@ requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2025.1.0",
     "aiohttp>=3.12.0",
-    "python-socketio==5.16.0",
+    "python-socketio==5.13.0",
     "voluptuous>=0.13",
     "pydantic>=2.8.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,21 +51,17 @@ def inventory_builder() -> Callable[
     """Return helper to construct Inventory containers for tests."""
 
     from custom_components.termoweb.inventory import Inventory
+    from custom_components.termoweb.inventory import build_node_inventory
 
     def _factory(
         dev_id: str,
         payload: Mapping[str, Any] | None = None,
         nodes: Iterable[Any] | None = None,
     ) -> "Inventory":
-        payload_value: Any
-        if payload is None:
-            payload_value = {}
-        elif isinstance(payload, Mapping):
-            payload_value = dict(payload)
-        else:
-            payload_value = payload
         node_list = list(nodes or [])
-        return Inventory(dev_id, payload_value, node_list)
+        if not node_list and payload is not None:
+            node_list = list(build_node_inventory(payload))
+        return Inventory(dev_id, node_list)
 
     return _factory
 

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -45,7 +45,7 @@ def test_binary_sensor_setup_and_dispatch(
         entry = types.SimpleNamespace(entry_id="entry-1")
         dev_id = "device-123"
 
-        inventory = Inventory(dev_id, {"nodes": []}, [])
+        inventory = Inventory(dev_id, [])
 
         coordinator = FakeCoordinator(
             hass,
@@ -169,7 +169,7 @@ def test_binary_sensor_setup_requires_inventory(heater_hass_data) -> None:
 def test_iter_boostable_inventory_nodes_uses_inventory_helper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    inventory = Inventory("dev", {"nodes": []}, [])
+    inventory = Inventory("dev", [])
 
     metadata = [
         InventoryNodeMetadata(
@@ -218,7 +218,7 @@ def test_refresh_button_device_info_and_press(heater_hass_data) -> None:
             async_request_refresh=AsyncMock(),
         )
 
-        inventory = Inventory(dev_id, {"nodes": []}, [])
+        inventory = Inventory(dev_id, [])
 
         heater_hass_data(
             hass,
@@ -501,9 +501,7 @@ def test_iter_accumulator_contexts_uses_inventory_metadata(
     entry_id = "entry-meta"
     dev_id = "device-meta"
     canonical = AccumulatorNode(name="Accumulator A", addr="1")
-    inventory = Inventory(
-        dev_id, {"nodes": []}, [canonical, HeaterNode(name="Heater", addr="2")]
-    )
+    inventory = Inventory(dev_id, [canonical, HeaterNode(name="Heater", addr="2")])
 
     metadata = [
         InventoryNodeMetadata(
@@ -553,9 +551,7 @@ def _make_boost_context(
     addr: str = "2",
     name: str = "Living Room",
 ) -> AccumulatorBoostContext:
-    inventory = Inventory(
-        dev_id, {"nodes": []}, [AccumulatorNode(name=name, addr=addr)]
-    )
+    inventory = Inventory(dev_id, [AccumulatorNode(name=name, addr=addr)])
     nodes = inventory.nodes_by_type.get("acm", ())
     assert nodes, "inventory must expose at least one accumulator"
     node = nodes[0]

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -173,14 +173,14 @@ def _make_coordinator(
     effective_inventory = inventory
     if not isinstance(effective_inventory, Inventory) and nodes_payload is not None:
         node_list = list(build_node_inventory(nodes_payload))
-        effective_inventory = Inventory(dev_id, nodes_payload, node_list)
+        effective_inventory = Inventory(dev_id, node_list)
 
     return FakeCoordinator(
         hass,
         client=client,
         dev_id=dev_id,
         dev=normalised,
-        nodes=normalised.get("inventory_payload", {}),
+        nodes=None,
         inventory=effective_inventory,
         data={dev_id: normalised},
     )
@@ -949,7 +949,7 @@ def test_accumulator_hvac_mode_reporting() -> None:
     addr = "7"
     inventory_payload = {"nodes": [{"type": "acm", "addr": addr}]}
     inventory_list = list(inventory_module.build_node_inventory(inventory_payload))
-    inventory = Inventory(dev_id, inventory_payload, inventory_list)
+    inventory = Inventory(dev_id, inventory_list)
     settings: dict[str, Any] = {"mode": "off", "units": "C"}
     coordinator = _make_coordinator(
         hass,
@@ -1193,7 +1193,7 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     addr = "8"
     inventory_payload = {"nodes": [{"type": "acm", "addr": addr}]}
     inventory_list = list(inventory_module.build_node_inventory(inventory_payload))
-    inventory = Inventory(dev_id, inventory_payload, inventory_list)
+    inventory = Inventory(dev_id, inventory_list)
     settings = {
         "mode": "auto",
         "units": "C",
@@ -1891,7 +1891,7 @@ def test_heater_additional_cancelled_edges(
         base_prog: list[int] = [0, 1, 2] * 56
         inventory_payload = {"nodes": [{"type": "htr", "addr": addr}]}
         inventory_list = list(inventory_module.build_node_inventory(inventory_payload))
-        inventory = Inventory(dev_id, inventory_payload, inventory_list)
+        inventory = Inventory(dev_id, inventory_list)
         settings = {
             "mode": "manual",
             "state": "heating",
@@ -2052,7 +2052,7 @@ def test_heater_write_paths_and_errors(
         base_prog: list[int] = [0, 1, 2] * 56
         inventory_payload = {"nodes": [{"type": "htr", "addr": addr}]}
         inventory_list = list(inventory_module.build_node_inventory(inventory_payload))
-        inventory = Inventory(dev_id, inventory_payload, inventory_list)
+        inventory = Inventory(dev_id, inventory_list)
         settings = {
             "mode": "manual",
             "state": "heating",
@@ -2523,7 +2523,7 @@ def test_heater_cancellation_and_error_paths(monkeypatch: pytest.MonkeyPatch) ->
         base_prog: list[int] = [0, 1, 2] * 56
         inventory_payload = {"nodes": [{"type": "htr", "addr": addr}]}
         inventory_list = list(inventory_module.build_node_inventory(inventory_payload))
-        inventory = Inventory(dev_id, inventory_payload, inventory_list)
+        inventory = Inventory(dev_id, inventory_list)
         settings = {
             "mode": "manual",
             "state": "heating",
@@ -2712,7 +2712,7 @@ def test_heater_cancelled_paths_propagate(
         base_prog: list[int] = [0, 1, 2] * 56
         inventory_payload = {"nodes": [{"type": "htr", "addr": addr}]}
         inventory_list = list(inventory_module.build_node_inventory(inventory_payload))
-        inventory = Inventory(dev_id, inventory_payload, inventory_list)
+        inventory = Inventory(dev_id, inventory_list)
         settings = {
             "mode": "manual",
             "state": "heating",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -103,7 +103,7 @@ def test_resolve_boost_end_from_fields_variants(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -156,7 +156,7 @@ async def test_async_fetch_rtc_datetime_updates_reference(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -188,7 +188,7 @@ async def test_async_fetch_rtc_datetime_handles_error(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -212,7 +212,7 @@ def test_boost_helpers_guard_against_invalid_sections(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -244,7 +244,7 @@ def test_apply_accumulator_boost_metadata_updates_payload(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -326,7 +326,7 @@ async def test_async_update_data_skips_without_inventory(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -355,7 +355,7 @@ async def test_async_update_data_requires_inventory(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -424,7 +424,7 @@ async def test_async_fetch_settings_by_address_pending_and_boost(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -497,7 +497,7 @@ async def test_async_refresh_heater_errors_without_inventory(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -534,7 +534,7 @@ async def test_async_refresh_heater_fetches_rtc(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -580,7 +580,7 @@ def test_mode_and_pending_key_helpers(
         base_interval=30,
         dev_id="dev",
         device={"name": "Device"},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -604,7 +604,7 @@ def test_prune_and_register_pending_settings(
         base_interval=30,
         dev_id="dev",
         device={"name": "Device"},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -645,7 +645,7 @@ def test_should_defer_pending_setting_branches(
         base_interval=30,
         dev_id="dev",
         device={"name": "Device"},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -706,7 +706,7 @@ async def test_refresh_skips_pending_settings_merge(
         base_interval=30,
         dev_id="dev",
         device={"name": "Device"},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -753,7 +753,7 @@ async def test_poll_skips_pending_settings_merge(
         base_interval=30,
         dev_id="dev",
         device={"name": "Device"},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -800,7 +800,7 @@ def test_handle_ws_deltas_updates_store(
         base_interval=30,
         dev_id="dev",
         device={"name": "Device"},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 

--- a/tests/test_coordinator_clone_inventory.py
+++ b/tests/test_coordinator_clone_inventory.py
@@ -13,9 +13,8 @@ from custom_components.termoweb.inventory import Inventory, Node
 def test_device_record_reuses_inventory_instance() -> None:
     """Ensure the coordinator stores the provided inventory without cloning."""
 
-    payload = {"nodes": [{"addr": "1", "type": "htr"}]}
     nodes = [Node(name="Heater", addr="1", node_type="htr")]
-    inventory = Inventory("dev-123", payload, nodes)
+    inventory = Inventory("dev-123", nodes)
 
     store = DomainStateStore([NodeId(NodeType.HEATER, "2")])
     store.apply_full_snapshot("htr", "2", {"mode": "auto"})
@@ -35,3 +34,5 @@ def test_device_record_reuses_inventory_instance() -> None:
     assert "power_monitor_address_map" not in device
 
     assert device["settings"] == {"htr": {"2": {"mode": "auto"}}}
+    assert "nodes" not in device
+    assert "inventory_payload" not in device

--- a/tests/test_coordinator_instant_power.py
+++ b/tests/test_coordinator_instant_power.py
@@ -23,7 +23,7 @@ async def test_handle_instant_power_update_records_ws(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -59,7 +59,7 @@ async def test_handle_instant_power_update_rejects_invalid(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -84,7 +84,7 @@ async def test_rest_updates_respect_ws_priority(
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 
@@ -134,7 +134,7 @@ async def test_should_skip_rest_power(monkeypatch, inventory_builder) -> None:
         base_interval=30,
         dev_id="dev",
         device={},
-        nodes=inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 

--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -76,7 +76,7 @@ def test_apply_heater_addresses_updates_state() -> None:
             {"type": "pmo", "addr": "A1"},
         ]
     }
-    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("device", build_node_inventory(raw_nodes))
 
     normalized_map: Mapping[Any, Iterable[Any]] = {
         "htr": [" 1 ", "01"],
@@ -104,7 +104,6 @@ def test_dispatch_nodes_includes_inventory_metadata() -> None:
     inventory_payload = _build_inventory_payload()
     inventory = Inventory(
         "device",
-        inventory_payload,
         build_node_inventory(inventory_payload),
     )
 

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -188,7 +188,6 @@ def _make_client(monkeypatch: pytest.MonkeyPatch) -> ducaheat_ws.DucaheatWSClien
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
     inventory = Inventory(
         "device",
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     hass.data[ducaheat_ws.DOMAIN]["entry"]["inventory"] = inventory
@@ -273,11 +272,7 @@ def _set_inventory(
 ) -> Inventory:
     """Bind a fresh inventory container to the client and hass record."""
 
-    inventory = Inventory(
-        client.dev_id,
-        payload,
-        build_node_inventory(payload),
-    )
+    inventory = Inventory(client.dev_id, build_node_inventory(payload))
     hass_record = client.hass.data[ducaheat_ws.DOMAIN][client.entry_id]
     hass_record["inventory"] = inventory
     client._inventory = inventory
@@ -576,7 +571,6 @@ def test_extract_dev_data_payload_variants(monkeypatch: pytest.MonkeyPatch) -> N
     client = _make_client(monkeypatch)
     client._inventory = Inventory(
         client.dev_id,
-        {"nodes": [{"type": "htr", "addr": "1"}]},
         build_node_inventory([{"type": "htr", "addr": "1"}]),
     )
     nodes = {"nodes": {"htr": {}}}
@@ -822,7 +816,6 @@ async def test_read_loop_handles_list_snapshot(
     client = _make_client(monkeypatch)
     client._inventory = Inventory(
         client.dev_id,
-        {"nodes": [{"type": "htr", "addr": "1"}]},
         build_node_inventory([{"type": "htr", "addr": "1"}]),
     )
     monkeypatch.setattr(client, "_subscribe_feeds", AsyncMock(return_value=2))
@@ -1781,7 +1774,6 @@ async def test_subscribe_feeds_stores_inventory_only(
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._inventory = inventory
@@ -1813,7 +1805,6 @@ async def test_subscribe_feeds_uses_inventory_cache(
     node_inventory = build_node_inventory([{"type": "htr", "addr": "7"}])
     inventory = Inventory(
         client.dev_id,
-        {"nodes": [{"type": "htr", "addr": "7"}]},
         node_inventory,
     )
     client._inventory = inventory
@@ -1852,7 +1843,6 @@ async def test_subscribe_feeds_uses_record_inventory_cache(
     node_inventory = build_node_inventory([{"type": "htr", "addr": "9"}])
     record["inventory"] = Inventory(
         client.dev_id,
-        {"nodes": [{"type": "htr", "addr": "9"}]},
         node_inventory,
     )
 
@@ -1880,7 +1870,6 @@ async def test_subscribe_feeds_handles_missing_targets(
     payload = {"nodes": []}
     client.hass.data[ducaheat_ws.DOMAIN]["entry"]["inventory"] = Inventory(
         "device",
-        payload,
         build_node_inventory(payload),
     )
     emit_mock = AsyncMock()
@@ -1905,7 +1894,6 @@ async def test_subscribe_feeds_prefers_coordinator_inventory(
     inventory_nodes = build_node_inventory([{"type": "htr", "addr": "3"}])
     coordinator_inventory = Inventory(
         client.dev_id,
-        {"nodes": [{"type": "htr", "addr": "3"}]},
         inventory_nodes,
     )
     client._coordinator._inventory = coordinator_inventory
@@ -1934,7 +1922,6 @@ async def test_subscribe_feeds_handles_mapping_record(
     raw_nodes = {"nodes": [{"addr": "8", "type": "htr"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     mapping_record = MappingProxyType({"inventory": inventory})
@@ -1969,7 +1956,6 @@ async def test_subscribe_feeds_handles_missing_record(
     raw_nodes = {"nodes": [{"addr": "6", "type": "htr"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._inventory = inventory

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -182,7 +182,7 @@ def test_heater_section_includes_inventory_details() -> None:
     """Heater metadata should expose inventory-backed name and availability."""
 
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1", "name": "Living"}]}
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     coordinator = SimpleNamespace(
         data={"dev": {"settings": {"htr": {"1": {"mode": "auto"}}}}},
         inventory=inventory,
@@ -483,7 +483,7 @@ def test_boost_entities_expose_state(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
     raw_nodes = [{"type": "acm", "addr": "1", "name": "Accumulator"}]
-    inventory = Inventory("dev", {"nodes": raw_nodes}, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     settings_map = {"acm": {"1": settings}}
 
     coordinator = SimpleNamespace(
@@ -552,7 +552,7 @@ def test_boost_entities_handle_missing_data() -> None:
     """Boost entities should gracefully handle missing settings."""
 
     raw_nodes = [{"type": "acm", "addr": "1", "name": "Accumulator"}]
-    inventory = Inventory("dev", {"nodes": raw_nodes}, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     settings_map = {"acm": {"1": {}}}
 
     coordinator = SimpleNamespace(data={"dev": {"settings": settings_map}})
@@ -617,7 +617,7 @@ def test_boost_end_sensor_returns_base_state_when_available() -> None:
     )
 
     payload: dict[str, Any] = {"nodes": []}
-    inventory = Inventory("dev", payload, build_node_inventory(payload))
+    inventory = Inventory("dev", build_node_inventory(payload))
 
     sensor = HeaterBoostEndSensor(
         coordinator,
@@ -654,7 +654,7 @@ def test_boost_end_sensor_handles_isoformat_error() -> None:
     )
 
     payload: dict[str, Any] = {"nodes": []}
-    inventory = Inventory("dev", payload, build_node_inventory(payload))
+    inventory = Inventory("dev", build_node_inventory(payload))
 
     sensor = HeaterBoostEndSensor(
         coordinator,
@@ -746,7 +746,7 @@ def test_iter_nodes_metadata_uses_inventory() -> None:
             {"type": "pmo", "addr": "99"},
         ]
     }
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
 
     results = list(
         inventory.iter_nodes_metadata(
@@ -776,7 +776,7 @@ def test_iter_nodes_metadata_uses_inventory_method(
 ) -> None:
     """Generator should source node data from inventory iterator."""
 
-    inventory = Inventory("dev", {}, [])
+    inventory = Inventory("dev", [])
     default_factory = lambda addr: f"Heater {addr}"
 
     metadata = InventoryNodeMetadata(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -82,7 +82,7 @@ def _make_state_coordinator(
         30,
         "dev",
         {"name": "Device"},
-        inventory.payload,
+        nodes=None,
         inventory=inventory,
     )
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -428,7 +428,7 @@ async def test_async_setup_entry_creates_number_entities(
     payload = {"nodes": raw_nodes}
     node_inventory = build_node_inventory(raw_nodes)
     InventoryType = heater_module.Inventory
-    inventory = InventoryType(dev_id, payload, node_inventory)
+    inventory = InventoryType(dev_id, node_inventory)
     coordinator = FakeCoordinator(hass, dev_id=dev_id)
 
     heater_details = heater_module.HeaterPlatformDetails(

--- a/tests/test_sensor_normalise_energy.py
+++ b/tests/test_sensor_normalise_energy.py
@@ -97,7 +97,7 @@ async def test_async_setup_entry_handles_missing_power_monitors(
     entry = SimpleNamespace(entry_id="entry-1")
     raw_nodes = [{"type": "htr", "addr": "1", "name": "Heater"}]
     node_inventory = build_node_inventory({"nodes": raw_nodes})
-    inventory = Inventory("dev-1", {"nodes": raw_nodes}, node_inventory)
+    inventory = Inventory("dev-1", node_inventory)
     iter_calls: list[tuple[Any, Any]] = []
 
     def _iter_nodes_metadata_stub(
@@ -191,7 +191,6 @@ def test_power_monitor_available_uses_inventory_has_node(
     )
     inventory = Inventory(
         "dev-1",
-        {"nodes": []},
         [PowerMonitorNode(name="Monitor", addr="01")],
     )
 
@@ -234,7 +233,7 @@ async def test_heater_energy_sensor_availability() -> None:
     dev_id = "dev-energy"
     raw_nodes = {"nodes": [{"type": "htr", "addr": "01", "name": "Heater"}]}
     node_inventory = list(build_node_inventory(raw_nodes))
-    inventory = Inventory(dev_id, raw_nodes, node_inventory)
+    inventory = Inventory(dev_id, node_inventory)
     device_state = build_coordinator_device_state(
         nodes=raw_nodes,
         settings={"htr": {"01": {}}},

--- a/tests/test_termoweb_ws_handle_event_addr.py
+++ b/tests/test_termoweb_ws_handle_event_addr.py
@@ -49,7 +49,6 @@ def test_handle_event_routes_updates_to_deltas(
     inventory_payload = {"nodes": [{"type": "htr", "addr": "2"}]}
     client._inventory = module.Inventory(
         client.dev_id,
-        inventory_payload,
         build_node_inventory(inventory_payload),
     )
     hass.data[module.DOMAIN]["entry"]["inventory"] = client._inventory

--- a/tests/test_termoweb_ws_protocol.py
+++ b/tests/test_termoweb_ws_protocol.py
@@ -161,7 +161,6 @@ def _make_client(
     inventory_payload = {"nodes": [{"type": "htr", "addr": "1"}]}
     default_inventory = Inventory(
         "device",
-        inventory_payload,
         build_node_inventory(inventory_payload),
     )
     hass.data.setdefault(module.DOMAIN, {})["entry"] = {
@@ -1003,7 +1002,7 @@ def test_dispatch_nodes_with_inventory(
 
     client, _sio, dispatcher = _make_client(monkeypatch)
     record = client.hass.data[module.DOMAIN]["entry"]
-    record["inventory"] = Inventory(client.dev_id, {"nodes": {}}, ())
+    record["inventory"] = Inventory(client.dev_id, ())
     energy = SimpleNamespace(
         update_addresses=MagicMock(), handle_ws_samples=MagicMock()
     )
@@ -1015,7 +1014,6 @@ def test_dispatch_nodes_with_inventory(
     nodes_payload = {"nodes": [{"type": "htr", "addr": "1"}]}
     client._inventory = Inventory(
         client.dev_id,
-        nodes_payload,
         build_node_inventory(nodes_payload),
     )
     caplog.set_level(logging.DEBUG)
@@ -1041,7 +1039,6 @@ def test_dispatch_nodes_handles_unknown_types(monkeypatch: pytest.MonkeyPatch) -
 
     client._inventory = Inventory(
         client.dev_id,
-        {"nodes": [{"type": "foo", "addr": "9"}]},
         build_node_inventory([{"type": "foo", "addr": "9"}]),
     )
     client._dispatch_nodes({"nodes": {}})
@@ -1066,7 +1063,6 @@ def test_dispatch_nodes_uses_inventory_payload(monkeypatch: pytest.MonkeyPatch) 
         def __init__(self) -> None:
             super().__init__(
                 client.dev_id,
-                {"nodes": {"htr": {"settings": {"2": {"temp": 21}}}}},
                 node_inventory,
             )
             object.__setattr__(self, "payload_calls", 0)
@@ -1105,7 +1101,6 @@ def test_apply_heater_addresses_normalises_from_inventory(
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}, {"type": "acm", "addr": "2"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._apply_heater_addresses({"htr": ["1"], "acm": ["2"]}, inventory=inventory)
@@ -1132,7 +1127,6 @@ def test_apply_heater_addresses_includes_power_monitors(
     }
     inventory = Inventory(
         client.dev_id,
-        nodes_payload,
         build_node_inventory(nodes_payload),
     )
 
@@ -1164,7 +1158,6 @@ def test_apply_heater_addresses_updates_inventory(
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._apply_heater_addresses(
@@ -1181,7 +1174,6 @@ def test_heater_sample_subscription_targets(monkeypatch: pytest.MonkeyPatch) -> 
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}, {"type": "acm", "addr": "2"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._inventory = inventory
@@ -1200,7 +1192,6 @@ def test_heater_sample_subscription_targets_use_coordinator_inventory(
     raw_nodes = {"nodes": [{"type": "htr", "addr": "3"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._inventory = None
@@ -1259,7 +1250,6 @@ def test_apply_heater_addresses_filters_non_heaters(
     nodes_payload = {"nodes": [{"type": "htr", "addr": "6"}]}
     inventory_container = Inventory(
         "device",
-        nodes_payload,
         build_node_inventory(nodes_payload),
     )
 
@@ -1283,7 +1273,6 @@ def test_apply_heater_addresses_logs_invalid_inventory(
     raw_nodes = {"nodes": [{"type": "htr", "addr": "4"}]}
     inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     client._inventory = inventory
@@ -1625,7 +1614,6 @@ def test_apply_nodes_payload_translation(monkeypatch: pytest.MonkeyPatch) -> Non
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
     client._inventory = Inventory(
         client.dev_id,
-        raw_nodes,
         build_node_inventory(raw_nodes),
     )
     original_dispatch = client._dispatch_nodes
@@ -1667,7 +1655,6 @@ def test_extract_nodes_variants(monkeypatch: pytest.MonkeyPatch) -> None:
     client, _sio, _ = _make_client(monkeypatch)
     inventory = Inventory(
         "device",
-        {"nodes": [{"type": "htr", "addr": "1"}]},
         build_node_inventory([{"type": "htr", "addr": "1"}]),
     )
     client._inventory = inventory

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -218,7 +218,7 @@ async def test_ws_state_cleanup_and_reuse() -> None:
         loop=loop, data={base_ws.DOMAIN: {"entry": {"dev_id": "device"}}}
     )
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
-    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("device", build_node_inventory(raw_nodes))
     hass.data[base_ws.DOMAIN]["entry"]["inventory"] = inventory
 
     client = module.WebSocketClient(
@@ -259,7 +259,7 @@ async def test_ducaheat_ws_cleanup_and_buckets(monkeypatch: pytest.MonkeyPatch) 
         loop=loop, data={base_ws.DOMAIN: {"entry": {"dev_id": "device"}}}
     )
     raw_nodes = {"nodes": [{"type": "pmo", "addr": "7"}]}
-    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("device", build_node_inventory(raw_nodes))
     hass.data[base_ws.DOMAIN]["entry"]["inventory"] = inventory
 
     rest_client = DummyREST(is_ducaheat=True)
@@ -304,7 +304,7 @@ def _ensure_inventory_record(
                 {"type": "pmo", "addr": "7"},
             ]
         }
-        inventory = Inventory(dev_id, payload, build_node_inventory(payload))
+        inventory = Inventory(dev_id, build_node_inventory(payload))
     hass.data.setdefault(base_ws.DOMAIN, {}).setdefault(entry_id, {})
     hass.data[base_ws.DOMAIN][entry_id].setdefault("inventory", inventory)
     hass.data[base_ws.DOMAIN][entry_id].setdefault("dev_id", dev_id)
@@ -368,7 +368,7 @@ def test_forward_ws_sample_updates_handles_power_monitors(
 
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": {}}})
     raw_nodes = {"nodes": [{"type": "pmo", "addr": "7", "name": "PM"}]}
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     handler = MagicMock()
     hass.data[base_ws.DOMAIN]["entry"] = {
         "energy_coordinator": SimpleNamespace(handle_ws_samples=handler),
@@ -400,7 +400,7 @@ def test_forward_ws_sample_updates_skips_thermostats() -> None:
 
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": {}}})
     raw_nodes = {"nodes": [{"type": "thm", "addr": "1"}]}
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     handler = MagicMock()
     hass.data[base_ws.DOMAIN]["entry"] = {
         "energy_coordinator": SimpleNamespace(handle_ws_samples=handler),
@@ -425,7 +425,7 @@ def test_forward_ws_sample_updates_respect_inventory_types(
 
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": {}}})
     raw_nodes = {"nodes": [{"type": "htr", "addr": "5"}]}
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     object.__setattr__(inventory, "_energy_sample_types_cache", frozenset({"pmo"}))
     handler = MagicMock()
     hass.data[base_ws.DOMAIN]["entry"] = {
@@ -451,7 +451,7 @@ def test_forward_ws_sample_updates_uses_coordinator_inventory(
     """Coordinator inventory aliases and logging should be applied."""
 
     raw_nodes = {"nodes": [{"type": "htr", "addr": "5"}]}
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
 
     monkeypatch.setattr(
         Inventory,
@@ -518,7 +518,7 @@ def test_forward_ws_sample_updates_skips_invalid_sections(
             base_ws.DOMAIN: {
                 "entry": {
                     "energy_coordinator": SimpleNamespace(handle_ws_samples=handler),
-                    "inventory": Inventory("dev", {}, []),
+                    "inventory": Inventory("dev", []),
                 }
             }
         }
@@ -543,7 +543,7 @@ def test_forward_ws_sample_updates_skips_non_mapping_samples() -> None:
             base_ws.DOMAIN: {
                 "entry": {
                     "energy_coordinator": SimpleNamespace(handle_ws_samples=handler),
-                    "inventory": Inventory("dev", {}, []),
+                    "inventory": Inventory("dev", []),
                 }
             }
         }
@@ -576,7 +576,7 @@ def test_forward_ws_sample_updates_inventory_validation(
     """Inventory-derived alias data should tolerate malformed updates."""
 
     raw_nodes = {"nodes": [{"type": "pmo", "addr": "3"}]}
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
 
     monkeypatch.setattr(
         Inventory,
@@ -700,7 +700,7 @@ def test_dispatch_nodes_reuses_record_inventory(
 
     payload = {"nodes": [{"addr": "1", "type": "htr"}]}
     node_inventory = build_node_inventory(payload["nodes"])
-    inventory = Inventory("device", payload["nodes"], node_inventory)
+    inventory = Inventory("device", node_inventory)
 
     hass_record: dict[str, Any] = {"dev_id": "device", "inventory": inventory}
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": hass_record}})
@@ -737,7 +737,8 @@ def test_prepare_nodes_dispatch_uses_inventory(monkeypatch: pytest.MonkeyPatch) 
     coordinator = SimpleNamespace(update_nodes=MagicMock(), dev_id="dev")
     node_inventory = build_node_inventory([{"type": "htr", "addr": "4"}])
     inventory = Inventory(
-        "dev", {"nodes": [{"type": "htr", "addr": "4"}]}, node_inventory
+        "dev",
+        node_inventory,
     )
     context = base_ws._prepare_nodes_dispatch(
         hass,
@@ -757,7 +758,7 @@ def test_prepare_nodes_dispatch_resolves_record_dev_id_and_coordinator_inventory
 ) -> None:
     """Record dev IDs and coordinator inventory should be applied."""
 
-    inventory = Inventory("dev", {}, [])
+    inventory = Inventory("dev", [])
     hass_record: dict[str, Any] = {"dev_id": "raw", "inventory": inventory}
     hass = SimpleNamespace(data={base_ws.DOMAIN: {"entry": hass_record}})
     coordinator = SimpleNamespace(update_nodes=MagicMock())
@@ -794,7 +795,7 @@ def test_termoweb_nodes_to_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
 
     client = _make_termoweb_client(monkeypatch)
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
-    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("device", build_node_inventory(raw_nodes))
     client._inventory = inventory
 
     nodes_payload = {
@@ -826,7 +827,7 @@ def test_termoweb_nodes_to_deltas_validates_inventory(
 
     client = _make_termoweb_client(monkeypatch)
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
-    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("device", build_node_inventory(raw_nodes))
     client._inventory = inventory
 
     with caplog.at_level(logging.WARNING, module._LOGGER.name):
@@ -844,7 +845,7 @@ def test_termoweb_translate_path_deltas(monkeypatch: pytest.MonkeyPatch) -> None
 
     client = _make_termoweb_client(monkeypatch)
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
-    inventory = Inventory("device", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("device", build_node_inventory(raw_nodes))
     client._inventory = inventory
 
     payload = {"path": "/devs/device/htr/1/settings", "body": {"mode": "auto"}}
@@ -936,7 +937,7 @@ def test_ws_common_ensure_type_bucket_uses_inventory_without_clones(
             {"type": "acm", "addr": "2"},
         ]
     }
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     hass_record: dict[str, Any] = {"inventory": inventory}
     dummy.hass.data[base_ws.DOMAIN]["entry"] = hass_record
 
@@ -990,7 +991,7 @@ def test_ws_common_apply_heater_addresses_uses_inventory(
             {"type": "pmo", "addr": "7"},
         ]
     }
-    inventory = Inventory("dev", raw_nodes, build_node_inventory(raw_nodes))
+    inventory = Inventory("dev", build_node_inventory(raw_nodes))
     hass_record: dict[str, Any] = {
         "energy_coordinator": energy_coordinator,
         "inventory": inventory,
@@ -1695,7 +1696,7 @@ def test_ws_common_dispatch_nodes(
 
     raw_nodes = {"nodes": [{"type": "htr", "addr": "1"}]}
     inventory_nodes = build_node_inventory(raw_nodes)
-    inventory_obj = Inventory("dev", raw_nodes, inventory_nodes)
+    inventory_obj = Inventory("dev", inventory_nodes)
 
     hass = SimpleNamespace(
         data={base_ws.DOMAIN: {"entry": {"inventory": inventory_obj}}}

--- a/tests/test_ws_sample_alias_fallback.py
+++ b/tests/test_ws_sample_alias_fallback.py
@@ -52,7 +52,7 @@ def test_forward_ws_sample_updates_uses_alias_fallback_and_max_lease() -> None:
 
     entry_id = "entry"
     hass = SimpleNamespace(data={DOMAIN: {entry_id: {}}})
-    inventory = Inventory("dev", {}, [])
+    inventory = Inventory("dev", [])
 
     object.__setattr__(
         inventory,

--- a/tests/test_ws_sample_alias_merge.py
+++ b/tests/test_ws_sample_alias_merge.py
@@ -35,7 +35,7 @@ def test_forward_ws_sample_updates_merges_inventory_aliases() -> None:
 
     entry_id = "entry"
     hass = SimpleNamespace(data={DOMAIN: {entry_id: {}}})
-    inventory = Inventory("dev", {}, [])
+    inventory = Inventory("dev", [])
 
     object.__setattr__(
         inventory,

--- a/tests/test_ws_sample_invalid_payload.py
+++ b/tests/test_ws_sample_invalid_payload.py
@@ -42,7 +42,6 @@ def test_forward_ws_sample_updates_ignores_non_mapping_sections() -> None:
                     "energy_coordinator": coordinator,
                     "inventory": Inventory(
                         "dev",
-                        {"nodes": [{"type": "htr", "addr": "1"}]},
                         build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
                     ),
                 }

--- a/tests/test_ws_sample_skip_lease_entry.py
+++ b/tests/test_ws_sample_skip_lease_entry.py
@@ -42,7 +42,6 @@ def test_forward_ws_sample_updates_omits_inner_lease_entry() -> None:
                     "energy_coordinator": coordinator,
                     "inventory": Inventory(
                         "dev",
-                        {"nodes": [{"type": "htr", "addr": "1"}]},
                         build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
                     ),
                 }


### PR DESCRIPTION
## Summary
- remove the Inventory payload field and update construction to use typed node objects only across setup and coordinator paths
- adjust platform fallbacks and tests to rebuild inventories from typed nodes, adding guardrails to prevent raw node payload retention
- align python-socketio pins and bump the integration version to 2.0.0-pre17

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695513bb593083299021a4a7a56a6348)