### PR TITLE
Stop persisting raw device payloads; store only device metadata

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -54,7 +54,7 @@ from .const import (
     get_brand_basic_auth,
     signal_ws_status,
 )
-from .coordinator import EnergyStateCoordinator, StateCoordinator
+from .coordinator import EnergyStateCoordinator, StateCoordinator, build_device_metadata
 from .energy import (
     async_import_energy_history as _async_import_energy_history_impl,
     async_register_import_energy_history_service,
@@ -510,7 +510,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         _LOGGER.info("list_devices returned no usable devices")
         raise ConfigEntryNotReady
 
-    dev = dev or {}
+    device_metadata = build_device_metadata(dev_id, dev)
     nodes = await client.get_nodes(dev_id)
     node_inventory = build_node_inventory(nodes)
     # Inventory-centric design: build and freeze the gateway/node topology once
@@ -531,7 +531,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         client,
         base_interval,
         dev_id,
-        dev,
+        device_metadata,
         None,
         inventory,
     )

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre17"
+  "version": "2.0.0-pre18"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -906,12 +906,22 @@ custom_components/termoweb/const.py :: signal_ws_status
     Signal name for WS status/health updates.
 custom_components/termoweb/coordinator.py :: RaiseUpdateFailedCoordinator.async_refresh
     Refresh data and raise ``UpdateFailed`` when polling fails.
+custom_components/termoweb/coordinator.py :: _normalise_device_name
+    Return a trimmed device name or a fallback derived from ``dev_id``.
+custom_components/termoweb/coordinator.py :: _normalise_device_model
+    Return a trimmed model string when present.
+custom_components/termoweb/coordinator.py :: build_device_metadata
+    Return immutable metadata derived from a device payload.
 custom_components/termoweb/coordinator.py :: _device_display_name
     Return the trimmed device name or a fallback for ``dev_id``.
 custom_components/termoweb/coordinator.py :: StateCoordinator.__init__
     Initialize the TermoWeb device coordinator.
 custom_components/termoweb/coordinator.py :: StateCoordinator.domain_view
     Return the read-only domain state view.
+custom_components/termoweb/coordinator.py :: StateCoordinator._device_record
+    Return a minimal coordinator payload for this device.
+custom_components/termoweb/coordinator.py :: StateCoordinator._publish_device_record
+    Push the latest device snapshot to coordinator listeners.
 custom_components/termoweb/coordinator.py :: StateCoordinator._filtered_settings_payload
     Return a defensive copy of ``payload`` without raw blobs.
 custom_components/termoweb/coordinator.py :: StateCoordinator._instant_power_key
@@ -930,10 +940,6 @@ custom_components/termoweb/coordinator.py :: StateCoordinator.instant_power_over
     Return a diagnostics-friendly snapshot of instant power values.
 custom_components/termoweb/coordinator.py :: StateCoordinator._should_skip_rest_power
     Return ``True`` when websocket data is fresh enough to skip REST power.
-custom_components/termoweb/coordinator.py :: StateCoordinator._device_record
-    Return a minimal coordinator payload for this device.
-custom_components/termoweb/coordinator.py :: StateCoordinator._publish_device_record
-    Push the latest device snapshot to coordinator listeners.
 custom_components/termoweb/coordinator.py :: StateCoordinator._async_fetch_settings_to_store
     Fetch settings for every address and store them in the domain cache.
 custom_components/termoweb/coordinator.py :: StateCoordinator._normalize_mode_value
@@ -1020,10 +1026,8 @@ custom_components/termoweb/domain/state.py :: _copy_sequence
     Return a shallow copy of a sequence when applicable.
 custom_components/termoweb/domain/state.py :: _copy_mapping
     Return a shallow copy of a mapping when applicable.
-custom_components/termoweb/domain/state.py :: _deep_copy_value
-    Return a defensive shallow copy for nested payload values.
-custom_components/termoweb/domain/state.py :: _collect_extras
-    Capture non-canonical payload keys as extra metadata.
+custom_components/termoweb/domain/state.py :: _coerce_number
+    Return ``value`` as a number when possible.
 custom_components/termoweb/domain/state.py :: HeaterState.to_legacy
     Convert the state into the legacy coordinator payload shape.
 custom_components/termoweb/domain/state.py :: AccumulatorState.to_legacy
@@ -1038,8 +1042,6 @@ custom_components/termoweb/domain/state.py :: NodeStatusDelta.payload
     Return the status mapping payload.
 custom_components/termoweb/domain/state.py :: NodeSamplesDelta.payload
     Return the samples mapping payload.
-custom_components/termoweb/domain/state.py :: _coerce_number
-    Return ``value`` as a number when possible.
 custom_components/termoweb/domain/state.py :: _populate_heater_state
     Populate base heater fields on ``state`` from ``payload``.
 custom_components/termoweb/domain/state.py :: _build_heater_state
@@ -1216,8 +1218,6 @@ custom_components/termoweb/heater.py :: HeaterNodeBase._domain_state_view
     Return the domain state view exposed by the coordinator.
 custom_components/termoweb/heater.py :: HeaterNodeBase._heater_state_payload
     Return the canonical heater settings payload.
-custom_components/termoweb/heater.py :: HeaterNodeBase._device_record
-    Return the coordinator cache entry for this device.
 custom_components/termoweb/heater.py :: HeaterNodeBase._resolve_inventory
     Return the cached inventory for this entity, if available.
 custom_components/termoweb/heater.py :: HeaterNodeBase._heater_section
@@ -1282,8 +1282,6 @@ custom_components/termoweb/inventory.py :: Inventory.__init__
     Initialize the inventory container.
 custom_components/termoweb/inventory.py :: Inventory.dev_id
     Get the device identifier.
-custom_components/termoweb/inventory.py :: Inventory.payload
-    Get the raw node payload.
 custom_components/termoweb/inventory.py :: Inventory.nodes
     Get the immutable tuple of node objects.
 custom_components/termoweb/inventory.py :: Inventory.has_node

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre17"
+version = "2.0.0-pre18"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_coordinator_instant_power.py
+++ b/tests/test_coordinator_instant_power.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
+from conftest import build_device_metadata_payload
 from custom_components.termoweb import coordinator as coord_module
 
 
@@ -22,7 +23,7 @@ async def test_handle_instant_power_update_records_ws(
         client=AsyncMock(),
         base_interval=30,
         dev_id="dev",
-        device={},
+        device=build_device_metadata_payload("dev"),
         nodes=None,
         inventory=inventory,
     )
@@ -58,7 +59,7 @@ async def test_handle_instant_power_update_rejects_invalid(
         client=AsyncMock(),
         base_interval=30,
         dev_id="dev",
-        device={},
+        device=build_device_metadata_payload("dev"),
         nodes=None,
         inventory=inventory,
     )
@@ -83,7 +84,7 @@ async def test_rest_updates_respect_ws_priority(
         client=AsyncMock(),
         base_interval=30,
         dev_id="dev",
-        device={},
+        device=build_device_metadata_payload("dev"),
         nodes=None,
         inventory=inventory,
     )
@@ -133,7 +134,7 @@ async def test_should_skip_rest_power(monkeypatch, inventory_builder) -> None:
         client=AsyncMock(),
         base_interval=30,
         dev_id="dev",
-        device={},
+        device=build_device_metadata_payload("dev"),
         nodes=None,
         inventory=inventory,
     )

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from conftest import _install_stubs
+from conftest import build_device_metadata_payload
 
 _install_stubs()
 
@@ -57,18 +58,19 @@ def _state_coordinator_from_nodes(
     client: Any,
     base_interval: int,
     dev_id: str,
-    device: Mapping[str, Any],
+    device: coord_module.DeviceMetadata | None,
     nodes: Mapping[str, Any],
 ) -> StateCoordinator:
     """Build a ``StateCoordinator`` with inventory derived from ``nodes``."""
 
     inventory = _inventory_from_nodes(dev_id, nodes)
+    metadata = device or build_device_metadata_payload(dev_id)
     return StateCoordinator(
         hass,
         client,
         base_interval,
         dev_id,
-        device,
+        metadata,
         nodes,
         inventory=inventory,
     )
@@ -92,7 +94,7 @@ def test_update_nodes_accepts_inventory_container(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes=None,
         inventory=container,
     )
@@ -163,7 +165,7 @@ def test_coordinator_success_resets_backoff() -> None:
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes=None,
             inventory=inventory,
         )
@@ -219,7 +221,7 @@ def test_state_coordinator_round_robin_mixed_types() -> None:
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes,
             inventory=inventory,
         )
@@ -273,7 +275,7 @@ def test_state_coordinator_ignores_non_dict_payloads() -> None:
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes,
             inventory=inventory,
         )
@@ -312,7 +314,7 @@ def test_refresh_heater_skips_invalid_inputs() -> None:
             client,
             30,
             "dev",
-            {"name": " Device "},
+            build_device_metadata_payload("dev", name=" Device "),
             nodes,
             inventory=inventory,
         )
@@ -362,7 +364,7 @@ def test_register_pending_setting_normalizes_values(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes,
     )
 
@@ -389,7 +391,7 @@ def test_should_defer_pending_setting_handles_expiry(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes,
     )
 
@@ -412,7 +414,7 @@ def test_should_defer_pending_setting_defers_missing_payload(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes,
     )
 
@@ -435,7 +437,7 @@ def test_should_defer_pending_setting_satisfied_payload(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes,
     )
 
@@ -459,7 +461,7 @@ def test_should_defer_pending_setting_mismatch_defers(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes,
     )
 
@@ -493,7 +495,7 @@ def test_refresh_heater_updates_existing_and_new_data() -> None:
             client,
             15,
             "dev",
-            {"name": " Device "},
+            build_device_metadata_payload("dev", name=" Device "),
             nodes,
         )
 
@@ -556,7 +558,7 @@ def test_refresh_heater_handles_tuple_and_acm() -> None:
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes=None,
             inventory=inventory_container,
         )
@@ -612,7 +614,7 @@ def test_async_refresh_heater_adds_missing_type() -> None:
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes=None,
             inventory=inventory,
         )
@@ -707,7 +709,7 @@ def test_refresh_heater_handles_errors(caplog: pytest.LogCaptureFixture) -> None
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes,
         )
         inventory = coord._ensure_inventory()
@@ -766,7 +768,7 @@ def test_state_coordinator_async_update_data_reuses_previous() -> None:
             client,
             30,
             "dev",
-            {"name": " Device "},
+            build_device_metadata_payload("dev", name=" Device "),
             nodes=None,
             inventory=inventory,
         )
@@ -837,7 +839,7 @@ def test_async_update_data_skips_non_dict_sections() -> None:
             client,
             30,
             "dev",
-            {"name": "Device"},
+            build_device_metadata_payload("dev", name="Device"),
             nodes,
         )
 
@@ -1387,7 +1389,7 @@ def test_state_coordinator_update_nodes_uses_provided_inventory(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes=None,
         inventory=inventory,
     )

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -14,6 +14,7 @@ from conftest import _install_stubs
 
 _install_stubs()
 
+from conftest import build_device_metadata_payload
 import custom_components.termoweb.coordinator as coordinator_module
 import custom_components.termoweb.inventory as inventory_module
 from custom_components.termoweb.inventory import (
@@ -81,7 +82,7 @@ def _make_state_coordinator(
         client,
         30,
         "dev",
-        {"name": "Device"},
+        build_device_metadata_payload("dev", name="Device"),
         nodes=None,
         inventory=inventory,
     )


### PR DESCRIPTION
## Summary
- replace the coordinator’s stored device mapping with a typed `DeviceMetadata` object and drop the legacy raw payload
- convert config entry setup to build device metadata at the edge, keep only typed inventory data, and add a shared helper for tests
- update guardrail tests/docs and bump the integration/version metadata to 2.0.0-pre18

## Testing
- ruff check custom_components/termoweb/coordinator.py custom_components/termoweb/__init__.py tests/conftest.py tests/test_coordinator.py tests/test_energy_coordinator.py tests/test_coordinator_instant_power.py tests/test_nodes.py
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69551aa249688329a0712d2d25ca1f23)