### PR TITLE
v2.0.0-pre19: Domain store holds only canonical typed fields; drop status/capabilities dict retention

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -46,6 +46,7 @@ from custom_components.termoweb.const import (
     signal_ws_data,
 )
 from custom_components.termoweb.domain import (
+    canonicalize_settings_payload,
     NodeId as DomainNodeId,
     NodeSettingsDelta,
     NodeType as DomainNodeType,
@@ -1146,16 +1147,17 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                     if not addr:
                         continue
                     bucket = per_addr.setdefault(addr, {})
+                    settings_delta: Mapping[str, Any] = {}
                     if section == "status" and isinstance(payload, Mapping):
-                        bucket["status"] = dict(payload)
+                        settings_delta = canonicalize_settings_payload(
+                            {"status": payload}
+                        )
+                    elif section == "capabilities":
                         continue
-                    if section == "capabilities" and isinstance(payload, Mapping):
-                        bucket["capabilities"] = dict(payload)
-                        continue
-                    settings_delta = build_settings_delta(section, payload)
-                    if not settings_delta:
-                        continue
-                    bucket.update(settings_delta)
+                    else:
+                        settings_delta = build_settings_delta(section, payload)
+                    if settings_delta:
+                        bucket.update(settings_delta)
 
             for addr, payload in per_addr.items():
                 try:

--- a/custom_components/termoweb/domain/__init__.py
+++ b/custom_components/termoweb/domain/__init__.py
@@ -26,6 +26,7 @@ from .state import (
     PowerMonitorState,
     ThermostatState,
     build_state_from_payload,
+    canonicalize_settings_payload,
 )
 from .view import DomainStateView
 
@@ -55,6 +56,7 @@ __all__ = [
     "StopBoost",
     "ThermostatState",
     "build_state_from_payload",
+    "canonicalize_settings_payload",
     "normalize_node_type",
     "store_to_legacy_coordinator_data",
 ]

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre18"
+  "version": "2.0.0-pre19"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1,6 +1,5 @@
-# TermoWeb Function Map
-
-custom_components/termoweb/__init__.py :: _build_unknown_node_probe_requests
+Wrote 809 functions to /workspace/ha-termoweb/docs/function_map.txt
+build_unknown_node_probe_requests
     Return common REST endpoints to query for an unknown node type.
 custom_components/termoweb/__init__.py :: _async_probe_unknown_node_types
     Log discovery probes for node types not yet supported.
@@ -1034,6 +1033,8 @@ custom_components/termoweb/domain/state.py :: AccumulatorState.to_legacy
     Convert the accumulator state into the legacy payload shape.
 custom_components/termoweb/domain/state.py :: PowerMonitorState.to_legacy
     Convert the power monitor state into the legacy payload shape.
+custom_components/termoweb/domain/state.py :: canonicalize_settings_payload
+    Return canonical setting fields derived from ``payload``.
 custom_components/termoweb/domain/state.py :: NodeDelta.payload
     Return the payload carried by the delta.
 custom_components/termoweb/domain/state.py :: NodeSettingsDelta.payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre18"
+version = "2.0.0-pre19"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -847,7 +847,7 @@ def test_handle_ws_deltas_updates_store(
     deltas = [
         NodeSettingsDelta(
             node_id=NodeId(NodeType.HEATER, "1"),
-            changes={"mode": "auto", "status": {"online": True}},
+            changes={"mode": "auto", "status": {"stemp": "21.0"}},
         )
     ]
     coordinator.handle_ws_deltas("dev", deltas, replace=True)
@@ -857,7 +857,8 @@ def test_handle_ws_deltas_updates_store(
     first_settings = _state_payload(coordinator, "htr", "1")
     assert first_settings is not None
     assert first_settings["mode"] == "auto"
-    assert first_settings["status"]["online"] is True
+    assert first_settings["stemp"] == "21.0"
+    assert "status" not in first_settings
 
     coordinator.handle_ws_deltas(
         "dev",

--- a/tests/test_ducaheat_ws_protocol.py
+++ b/tests/test_ducaheat_ws_protocol.py
@@ -364,7 +364,7 @@ def test_nodes_to_deltas_translates_payloads(
     nodes = {
         "htr": {
             "settings": {"1": {"mode": "auto", "ignored": "value"}},
-            "status": {"1": {"online": True, "extra": "keep"}},
+            "status": {"1": {"stemp": "21.5", "online": True}},
             "samples": {"1": {"temp": 25}},
         }
     }
@@ -376,7 +376,8 @@ def test_nodes_to_deltas_translates_payloads(
     assert delta.node_id.node_type.value == "htr"
     assert delta.node_id.addr == "1"
     assert delta.payload["mode"] == "auto"
-    assert delta.payload["status"]["online"] is True
+    assert delta.payload["stemp"] == "21.5"
+    assert "status" not in delta.payload
     assert "ignored" not in delta.payload
     assert "samples" not in delta.payload
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -801,7 +801,7 @@ def test_termoweb_nodes_to_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
     nodes_payload = {
         "htr": {
             "settings": {"1": {"mode": "manual", "unknown": "drop"}},
-            "status": {"1": {"online": True}},
+            "status": {"1": {"stemp": "18.0", "online": True}},
             "prog": {"1": {"0": 1}},
             "samples": {"1": {"temp": 12}},
             "advanced": {"1": {"misc": "skip"}},
@@ -814,7 +814,7 @@ def test_termoweb_nodes_to_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(delta, NodeSettingsDelta)
     assert delta.node_id.addr == "1"
     assert delta.payload["mode"] == "manual"
-    assert delta.payload["status"]["online"] is True
+    assert delta.payload["stemp"] == "18.0"
     assert delta.payload["prog"] == {"0": 1}
     assert "unknown" not in delta.payload
     assert "samples" not in delta.payload


### PR DESCRIPTION
## Summary
- remove websocket status/capabilities passthrough and canonicalize deltas so the domain store only tracks typed settings values
- add canonical settings guardrails and tests to ensure raw status/capabilities blobs are not retained in domain state
- bump integration metadata to v2.0.0-pre19 and keep socket.io pins aligned across packaging files

## Testing
- pytest --cov=custom_components.termoweb --cov-report=term-missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695538352fc48329b76a53b96c5ec06e)