### PR TITLE
Model energy/power as domain objects; remove dict-shaped coordinator data

### DIFF
--- a/custom_components/termoweb/domain/energy.py
+++ b/custom_components/termoweb/domain/energy.py
@@ -1,0 +1,77 @@
+"""Typed energy domain models for coordinator snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .ids import NodeId, NodeType, normalize_node_type
+
+
+@dataclass(frozen=True, slots=True)
+class EnergySamplePoint:
+    """Represent a single energy counter reading."""
+
+    t: float
+    counter: float
+
+
+@dataclass(frozen=True, slots=True)
+class EnergyNodeMetrics:
+    """Derived energy metrics for a node at a point in time."""
+
+    energy_kwh: float | None
+    power_w: float | None
+    source: str
+    ts: float
+
+
+@dataclass(frozen=True, slots=True)
+class EnergySnapshot:
+    """Immutable energy snapshot published by the coordinator."""
+
+    dev_id: str
+    metrics: Mapping[NodeId, EnergyNodeMetrics]
+    updated_at: float
+    ws_deadline: float | None
+
+    def metrics_for_type(
+        self, node_type: NodeType | str
+    ) -> dict[str, EnergyNodeMetrics]:
+        """Return metrics keyed by address for ``node_type`` when known."""
+
+        try:
+            normalized_type = normalize_node_type(node_type)
+        except ValueError:
+            return {}
+
+        return {
+            node_id.addr: metrics
+            for node_id, metrics in self.metrics.items()
+            if node_id.node_type is normalized_type
+        }
+
+    def iter_metrics(self) -> Iterator[tuple[NodeId, EnergyNodeMetrics]]:
+        """Yield stored metrics keyed by node identifier."""
+
+        yield from self.metrics.items()
+
+
+def build_empty_snapshot(
+    dev_id: str, *, ws_deadline: float | None = None
+) -> EnergySnapshot:
+    """Return an empty snapshot placeholder for ``dev_id``."""
+
+    return EnergySnapshot(
+        dev_id=dev_id,
+        metrics={},
+        updated_at=0.0,
+        ws_deadline=ws_deadline,
+    )
+
+
+def coerce_snapshot(candidate: Any) -> EnergySnapshot | None:
+    """Return ``candidate`` when it behaves like an :class:`EnergySnapshot`."""
+
+    return candidate if isinstance(candidate, EnergySnapshot) else None

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -12,6 +12,6 @@
   "loggers": [
     "custom_components.termoweb"
   ],
-  "requirements": ["python-socketio==5.13.0"],
-  "version": "2.0.0-pre20"
+  "requirements": ["python-socketio==5.16.0"],
+  "version": "2.0.0-pre21"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -986,12 +986,20 @@ custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.__init__
     Initialize the heater energy coordinator.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._resolve_inventory
     Return the active inventory, preferring ``candidate`` when provided.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._node_id_for
+    Return a canonical node identifier for energy tracking.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._iter_energy_targets
     Yield normalised energy node targets from ``inventory``.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._targets_by_type
     Return energy node addresses grouped by canonical type.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._prefill_energy_buckets
     Seed energy and power buckets from cached coordinator state.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._build_snapshot
+    Return an :class:`EnergySnapshot` built from metric buckets.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.metric_for
+    Return metrics for ``node_type``/``addr`` when cached.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.metrics_by_type
+    Return metrics mapping keyed by address for ``node_type``.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._poll_recent_samples
     Fetch recent energy samples for every tracked node.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.update_addresses
@@ -1018,6 +1026,14 @@ custom_components/termoweb/domain/ids.py :: normalize_node_type
     Normalize assorted node type inputs to ``NodeType``.
 custom_components/termoweb/domain/ids.py :: NodeId.__post_init__
     Normalise the node address to a non-empty string.
+custom_components/termoweb/domain/energy.py :: EnergySnapshot.metrics_for_type
+    Return metrics keyed by address for ``node_type`` when known.
+custom_components/termoweb/domain/energy.py :: EnergySnapshot.iter_metrics
+    Yield stored metrics keyed by node identifier.
+custom_components/termoweb/domain/energy.py :: build_empty_snapshot
+    Return an empty snapshot placeholder for ``dev_id``.
+custom_components/termoweb/domain/energy.py :: coerce_snapshot
+    Return ``candidate`` when it behaves like an :class:`EnergySnapshot`.
 custom_components/termoweb/domain/inventory.py :: InstallationInventory.__post_init__
     Ensure nodes mapping is immutable.
 custom_components/termoweb/domain/state.py :: _copy_sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre20"
+version = "2.0.0-pre21"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]
@@ -8,7 +8,7 @@ requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2025.1.0",
     "aiohttp>=3.12.0",
-    "python-socketio==5.13.0",
+    "python-socketio==5.16.0",
     "voluptuous>=0.13",
     "pydantic>=2.8.0",
 ]


### PR DESCRIPTION
## Summary
- model the energy coordinator data as typed EnergySnapshot objects instead of raw nested dicts
- add typed energy domain models and update sensors/tests to consume coordinator metrics via typed accessors
- bump the integration version to 2.0.0-pre21 and align the python-socketio pin with runtime expectations

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955857dbdf88329a82a9adf16815bf9)