### PR TITLE
Typed optimistic updates; remove state_to_dict/apply_payload_to_state roundtrips

### DIFF
--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -24,7 +24,7 @@ import voluptuous as vol
 from .backend.ducaheat import DucaheatRESTClient
 from .boost import coerce_boost_minutes, supports_boost
 from .const import BRAND_DUCAHEAT, DOMAIN
-from .domain import AccumulatorState, DomainState, HeaterState
+from .domain import DomainState, HeaterState
 from .heater import (
     DEFAULT_BOOST_DURATION,
     HeaterNodeBase,
@@ -1012,10 +1012,10 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
                     exc_info=err,
                 )
 
-        def _apply(cur: dict[str, Any]) -> None:
-            if mode_api is not None:
-                cur["mode"] = mode_api
-            if stemp is not None:
+        def _apply(cur: DomainState) -> None:
+            if mode_api is not None and hasattr(cur, "mode"):
+                cur.mode = mode_api
+            if stemp is not None and hasattr(cur, "stemp"):
                 stemp_str: Any = stemp
                 try:
                     stemp_float = float(stemp)
@@ -1025,7 +1025,7 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
                     pass
                 else:
                     stemp_str = f"{stemp_float:.1f}"
-                cur["stemp"] = stemp_str
+                cur.stemp = stemp_str
 
         self._optimistic_update(_apply)
         _LOGGER.debug(

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre22"
+  "version": "2.0.0-pre23"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1076,6 +1076,8 @@ custom_components/termoweb/domain/state.py :: DomainStateStore.reset_nodes
     Reset the allowed node list and prune any stale state.
 custom_components/termoweb/domain/state.py :: DomainStateStore._resolve_node_id
     Return a canonical NodeId when permitted by the inventory.
+custom_components/termoweb/domain/state.py :: DomainStateStore.resolve_node_id
+    Return the canonical NodeId when permitted by the inventory.
 custom_components/termoweb/domain/state.py :: DomainStateStore._apply_payload
     Apply ``payload`` to ``node_id`` using replace semantics when requested.
 custom_components/termoweb/domain/state.py :: DomainStateStore.apply_full_snapshot
@@ -1092,6 +1094,8 @@ custom_components/termoweb/domain/state.py :: DomainStateStore.known_types
     Return the set of node types represented in the store.
 custom_components/termoweb/domain/state.py :: DomainStateStore.iter_states
     Yield stored ``(NodeId, DomainState)`` pairs.
+custom_components/termoweb/domain/state.py :: DomainStateStore.replace_state
+    Replace the stored state for ``(node_type, addr)`` when valid.
 custom_components/termoweb/domain/state.py :: _normalize_node_type
     Return a canonical ``NodeType`` when possible.
 custom_components/termoweb/domain/state.py :: build_state_from_payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre22"
+version = "2.0.0-pre23"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -347,7 +347,7 @@ def test_accumulator_boost_cancel_button_tracks_availability() -> None:
         assert button.available is True
 
         assert coordinator.apply_entity_patch(
-            "acm", addr, lambda cur: cur.__setitem__("boost_active", False)
+            "acm", addr, lambda cur: setattr(cur, "boost_active", False)
         )
         for listener in list(getattr(coordinator, "listeners", [])):
             listener()

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1281,18 +1281,17 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     settings["boost_remaining"] = ""
     coordinator.resolve_boost_end = RaisingResolver()  # type: ignore[assignment]
 
+    def _apply_first(cur: Any) -> None:
+        cur.boost_active = settings["boost_active"]
+        cur.boost_end_day = settings["boost_end_day"]
+        cur.boost_end_min = settings["boost_end_min"]
+        cur.boost_end = settings["boost_end"]
+        cur.boost_remaining = settings["boost_remaining"]
+
     assert coordinator.apply_entity_patch(
         "acm",
         addr,
-        lambda cur: cur.update(
-            {
-                "boost_active": settings["boost_active"],
-                "boost_end_day": settings["boost_end_day"],
-                "boost_end_min": settings["boost_end_min"],
-                "boost_end": settings["boost_end"],
-                "boost_remaining": settings["boost_remaining"],
-            }
-        ),
+        _apply_first,
     )
 
     attrs = entity.extra_state_attributes
@@ -1309,18 +1308,17 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     settings["boost_remaining"] = None
     coordinator.resolve_boost_end = None  # type: ignore[assignment]
 
+    def _apply_second(cur: Any) -> None:
+        cur.boost_active = settings["boost_active"]
+        cur.boost = settings["boost"]
+        cur.mode = settings["mode"]
+        cur.boost_end = settings["boost_end"]
+        cur.boost_remaining = settings["boost_remaining"]
+
     assert coordinator.apply_entity_patch(
         "acm",
         addr,
-        lambda cur: cur.update(
-            {
-                "boost_active": settings["boost_active"],
-                "boost": settings["boost"],
-                "mode": settings["mode"],
-                "boost_end": settings["boost_end"],
-                "boost_remaining": settings["boost_remaining"],
-            }
-        ),
+        _apply_second,
     )
 
     attrs = entity.extra_state_attributes
@@ -1331,16 +1329,15 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     settings["boost_remaining"] = 7.5
     coordinator.resolve_boost_end = None  # type: ignore[assignment]
 
+    def _apply_third(cur: Any) -> None:
+        cur.boost_active = settings["boost_active"]
+        cur.boost_end = settings["boost_end"]
+        cur.boost_remaining = settings["boost_remaining"]
+
     assert coordinator.apply_entity_patch(
         "acm",
         addr,
-        lambda cur: cur.update(
-            {
-                "boost_active": settings["boost_active"],
-                "boost_end": settings["boost_end"],
-                "boost_remaining": settings["boost_remaining"],
-            }
-        ),
+        _apply_third,
     )
 
     attrs = entity.extra_state_attributes


### PR DESCRIPTION
## Summary
- add typed replace_state support to the domain store and enforce exact state types for inventory nodes
- update coordinator and entity optimistic updates to mutate cloned domain state across address aliases without dict round-trips
- refresh tests and function map to cover typed paths and bump integration version to 2.0.0-pre23

## Testing
- `ruff check custom_components/termoweb/coordinator.py custom_components/termoweb/domain/state.py custom_components/termoweb/climate.py tests/test_domain_state_store.py tests/test_coordinator.py tests/test_binary_sensor_button.py tests/conftest.py`
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69561d4c2a3c83298e4522d8ba710cd6)