### PR TITLE
Cleanup coordinator typing and remove codec stubs

### DIFF
--- a/custom_components/termoweb/codecs/ducaheat_codec.py
+++ b/custom_components/termoweb/codecs/ducaheat_codec.py
@@ -31,30 +31,6 @@ from .ducaheat_models import (
 )
 
 
-def decode_payload(payload: Any) -> Any:
-    """Decode a Ducaheat payload (placeholder)."""
-
-    raise NotImplementedError
-
-
-def decode_status(payload: Any) -> Any:
-    """Decode a Ducaheat status payload into domain state."""
-
-    raise NotImplementedError
-
-
-def decode_samples(payload: Any) -> Any:
-    """Decode Ducaheat samples payloads."""
-
-    raise NotImplementedError
-
-
-def decode_prog(payload: Any) -> Any:
-    """Decode Ducaheat program payloads."""
-
-    raise NotImplementedError
-
-
 def decode_settings(payload: Any, *, node_type: NodeType) -> dict[str, Any]:
     """Decode segmented settings payloads into canonical mappings."""
 

--- a/custom_components/termoweb/codecs/termoweb_codec.py
+++ b/custom_components/termoweb/codecs/termoweb_codec.py
@@ -40,18 +40,6 @@ from .termoweb_models import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def decode_payload(payload: Any) -> Any:
-    """Decode a TermoWeb payload."""
-
-    raise NotImplementedError
-
-
-def encode_payload(data: Any) -> Any:
-    """Encode data for TermoWeb payloads."""
-
-    raise NotImplementedError
-
-
 def _validate_prog(prog: list[int]) -> list[int]:
     """Validate a weekly program sequence."""
 

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -140,7 +140,7 @@ def _device_display_name(device: DeviceMetadata | None, dev_id: str) -> str:
 
 
 class StateCoordinator(
-    RaiseUpdateFailedCoordinator[EnergySnapshot]
+    RaiseUpdateFailedCoordinator[dict[str, dict[str, Any]]]
 ):  # dev_id -> per-device data
     """Polls TermoWeb and exposes a per-device dict used by platforms."""
 
@@ -1060,7 +1060,7 @@ class StateCoordinator(
 
 
 class EnergyStateCoordinator(
-    RaiseUpdateFailedCoordinator[dict[str, dict[str, Any]]]
+    RaiseUpdateFailedCoordinator[EnergySnapshot]
 ):  # dev_id -> per-device data
     """Polls heater energy counters and exposes energy and power per heater."""
 

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre24"
+  "version": "2.0.0-pre25"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -724,14 +724,6 @@ custom_components/termoweb/codecs/common.py :: format_temperature
     Format numeric temperatures to a one-decimal string.
 custom_components/termoweb/codecs/common.py :: validate_units
     Validate and normalise temperature units.
-custom_components/termoweb/codecs/ducaheat_codec.py :: decode_payload
-    Decode a Ducaheat payload (placeholder).
-custom_components/termoweb/codecs/ducaheat_codec.py :: decode_status
-    Decode a Ducaheat status payload into domain state.
-custom_components/termoweb/codecs/ducaheat_codec.py :: decode_samples
-    Decode Ducaheat samples payloads.
-custom_components/termoweb/codecs/ducaheat_codec.py :: decode_prog
-    Decode Ducaheat program payloads.
 custom_components/termoweb/codecs/ducaheat_codec.py :: decode_settings
     Decode segmented settings payloads into canonical mappings.
 custom_components/termoweb/codecs/ducaheat_codec.py :: _decode_status_payload
@@ -808,10 +800,6 @@ custom_components/termoweb/codecs/ducaheat_planner.py :: _build_write_call
     Build the primary write call for the supplied command.
 custom_components/termoweb/codecs/ducaheat_planner.py :: _ensure_accumulator
     Validate that accumulator-only commands target an accumulator.
-custom_components/termoweb/codecs/termoweb_codec.py :: decode_payload
-    Decode a TermoWeb payload.
-custom_components/termoweb/codecs/termoweb_codec.py :: encode_payload
-    Encode data for TermoWeb payloads.
 custom_components/termoweb/codecs/termoweb_codec.py :: _validate_prog
     Validate a weekly program sequence.
 custom_components/termoweb/codecs/termoweb_codec.py :: _validate_ptemp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre24"
+version = "2.0.0-pre25"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_codec_placeholders_removed.py
+++ b/tests/test_codec_placeholders_removed.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from custom_components.termoweb.codecs import ducaheat_codec, termoweb_codec
+
+
+def test_termoweb_codec_placeholders_removed() -> None:
+    """Ensure TermoWeb codec placeholder helpers are absent."""
+
+    assert not hasattr(termoweb_codec, "decode_payload")
+    assert not hasattr(termoweb_codec, "encode_payload")
+
+
+def test_ducaheat_codec_placeholders_removed() -> None:
+    """Ensure Ducaheat codec placeholder helpers are absent."""
+
+    assert not hasattr(ducaheat_codec, "decode_payload")
+    assert not hasattr(ducaheat_codec, "decode_status")
+    assert not hasattr(ducaheat_codec, "decode_samples")
+    assert not hasattr(ducaheat_codec, "decode_prog")


### PR DESCRIPTION
## Summary
- fix coordinator generic types so StateCoordinator and EnergyStateCoordinator match their returned data
- remove unused NotImplemented codec placeholder helpers and update the function map accordingly
- add a regression test guarding against reintroducing the placeholder helpers and bump the integration to v2.0.0-pre25

## Testing
- uv run ruff check custom_components/termoweb/coordinator.py custom_components/termoweb/codecs/termoweb_codec.py custom_components/termoweb/codecs/ducaheat_codec.py tests/test_codec_placeholders_removed.py
- uv run timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69562be645d483299f22fbd9d0619276)