### PR TITLE
Remove boost_end dict from domain state; keep only typed boost end fields

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -557,6 +557,7 @@ class DucaheatRESTClient(RESTClient):
 
         self._merge_boost_metadata(settings, settings)
         self._merge_accumulator_charge_metadata(settings, settings)
+        settings.pop("boost_end", None)
 
         return settings
 
@@ -598,7 +599,6 @@ class DucaheatRESTClient(RESTClient):
 
         if "boost_end" in source:
             boost_end = source["boost_end"]
-            _assign("boost_end", boost_end, allow_none=True)
             if isinstance(boost_end, Mapping):
                 _assign("boost_end_day", boost_end.get("day"), prefer=True)
                 _assign("boost_end_min", boost_end.get("minute"), prefer=True)
@@ -696,7 +696,6 @@ class DucaheatRESTClient(RESTClient):
         for extra_key in (
             "boost_active",
             "boost_remaining",
-            "boost_end",
             "lock",
             "lock_active",
             "max_power",
@@ -1133,7 +1132,6 @@ class DucaheatRESTClient(RESTClient):
                 metadata["boost_minutes_delta"] = minutes
             else:
                 metadata.setdefault("boost_minutes_delta", 0)
-            metadata.setdefault("boost_end", None)
             metadata.setdefault("boost_end_day", None)
             metadata.setdefault("boost_end_min", None)
             metadata.setdefault("boost_end_timestamp", None)
@@ -1152,7 +1150,6 @@ class DucaheatRESTClient(RESTClient):
                 metadata["boost_minutes_delta"] = minutes
             else:
                 metadata.setdefault("boost_minutes_delta", 0)
-            metadata.setdefault("boost_end", None)
             metadata.setdefault("boost_end_day", None)
             metadata.setdefault("boost_end_min", None)
             metadata.setdefault("boost_end_timestamp", None)
@@ -1162,10 +1159,8 @@ class DucaheatRESTClient(RESTClient):
             end_dt = rtc_dt + timedelta(minutes=minutes)
             day_of_year = end_dt.timetuple().tm_yday
             minute_of_day = end_dt.hour * 60 + end_dt.minute
-            end_payload = {"day": day_of_year, "minute": minute_of_day}
             metadata.update(
                 {
-                    "boost_end": end_payload,
                     "boost_end_day": day_of_year,
                     "boost_end_min": minute_of_day,
                     "boost_minutes_delta": minutes,
@@ -1175,7 +1170,6 @@ class DucaheatRESTClient(RESTClient):
         else:
             metadata.update(
                 {
-                    "boost_end": None,
                     "boost_end_day": None,
                     "boost_end_min": None,
                     "boost_minutes_delta": 0 if minutes is None else max(0, minutes),

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -50,7 +50,6 @@ CANONICAL_SETTING_KEYS: tuple[str, ...] = (
     "current_charge_per",
     "target_charge_per",
     "boost_active",
-    "boost_end",
     "boost_remaining",
     "boost_time",
     "boost_temp",

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -1445,8 +1445,6 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
                 cur.boost_end_day = None
             if hasattr(cur, "boost_end_min"):
                 cur.boost_end_min = None
-            if hasattr(cur, "boost_end"):
-                cur.boost_end = None
             if getattr(cur, "mode", None) == "boost":
                 cur.mode = "auto"
 

--- a/custom_components/termoweb/codecs/ducaheat_codec.py
+++ b/custom_components/termoweb/codecs/ducaheat_codec.py
@@ -101,7 +101,6 @@ def _decode_status_payload(
     for extra_key in (
         "boost_active",
         "boost_remaining",
-        "boost_end",
         "lock",
         "lock_active",
         "max_power",
@@ -262,7 +261,6 @@ def _merge_boost_metadata(
 
     if "boost_end" in source:
         boost_end = source["boost_end"]
-        _assign("boost_end", boost_end, allow_none=True)
         if isinstance(boost_end, Mapping):
             _assign("boost_end_day", boost_end.get("day"), prefer=True)
             _assign("boost_end_min", boost_end.get("minute"), prefer=True)

--- a/custom_components/termoweb/domain/state.py
+++ b/custom_components/termoweb/domain/state.py
@@ -66,7 +66,6 @@ class AccumulatorState(HeaterState):
     current_charge_per: int | float | None = None
     target_charge_per: int | float | None = None
     boost_active: bool | None = None
-    boost_end: Any | None = None
     boost_remaining: float | int | None = None
     boost_time: int | float | None = None
     boost_temp: Any | None = None
@@ -263,9 +262,6 @@ def _populate_accumulator_fields(
         state.target_charge_per = _coerce_number(payload.get("target_charge_per"))
     if "boost_active" in payload:
         state.boost_active = payload.get("boost_active")
-    if "boost_end" in payload:
-        end_payload = payload.get("boost_end")
-        state.boost_end = _copy_mapping(end_payload) or end_payload
     if "boost_remaining" in payload:
         state.boost_remaining = _coerce_number(payload.get("boost_remaining"))
     if "boost_time" in payload:

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre25"
+  "version": "2.0.0-pre26"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1186,6 +1186,8 @@ custom_components/termoweb/heater.py :: iter_boost_button_metadata
     Yield the metadata describing boost helper buttons.
 custom_components/termoweb/heater.py :: iter_boostable_heater_nodes
     Yield heater nodes that expose boost functionality.
+custom_components/termoweb/heater.py :: _parse_iso_timestamp
+    Parse an ISO timestamp string defensively.
 custom_components/termoweb/heater.py :: derive_boost_state
     Return derived boost metadata for ``settings`` using ``coordinator``.
 custom_components/termoweb/heater.py :: derive_boost_state_from_domain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre25"
+version = "2.0.0-pre26"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2180,9 +2180,9 @@ def test_ducaheat_normalise_settings_acm_boost_metadata() -> None:
 
     result = client._normalise_settings(payload, node_type="acm")
     assert result["boost"] is True
-    assert result["boost_end"] == {"day": 2, "minute": 45}
     assert result["boost_end_day"] == 2
     assert result["boost_end_min"] == 45
+    assert "boost_end" not in result
 
 
 def test_ducaheat_normalise_settings_acm_boost_metadata_fallback() -> None:
@@ -2203,6 +2203,7 @@ def test_ducaheat_normalise_settings_acm_boost_metadata_fallback() -> None:
     result = client._normalise_settings(payload, node_type="acm")
     assert result["boost_end_day"] == 4
     assert result["boost_end_min"] == 180
+    assert "boost_end" not in result
 
 
 def test_ducaheat_merge_boost_metadata_defensive() -> None:
@@ -2213,12 +2214,16 @@ def test_ducaheat_merge_boost_metadata_defensive() -> None:
         api_base="https://api.termoweb.fake",
     )
 
-    target: dict[str, Any] = {"boost": True, "boost_end": None}
+    target: dict[str, Any] = {"boost": True, "boost_end_day": 2}
 
     client._merge_boost_metadata(target, None)
-    client._merge_boost_metadata(target, {"boost_end": None}, prefer_existing=True)
+    client._merge_boost_metadata(
+        target,
+        {"boost_end": None, "boost_end_day": 1, "boost_end_min": 10},
+        prefer_existing=True,
+    )
 
-    assert target == {"boost": True, "boost_end": None}
+    assert target == {"boost": True, "boost_end_day": 2, "boost_end_min": 10}
 
 
 def test_ducaheat_normalise_settings_handles_half_hour_prog() -> None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1119,7 +1119,7 @@ def test_accumulator_extra_state_attributes_handles_resolver_fallbacks() -> None
         "boost": RaiseOnStr(),
         "boost_end_day": 12,
         "boost_end_min": 90,
-        "boost_end": {"day": 14, "minute": 150},
+        "boost_end_datetime": dt.datetime(2024, 1, 1, 3, 0, tzinfo=dt.timezone.utc),
         "boost_remaining": True,
     }
 
@@ -1179,7 +1179,7 @@ def test_accumulator_extra_state_attributes_handles_resolver_fallbacks() -> None
         dt_util.NOW = original_now
 
     assert attrs["boost_active"] is True
-    assert attrs["boost_minutes_remaining"] is None
+    assert attrs["boost_minutes_remaining"] == 180
     assert attrs["boost_end"] == "2024-01-01T03:00:00+00:00"
     assert attrs["boost_end_label"] is None
 
@@ -1202,7 +1202,6 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
         "boost_active": 1,
         "boost_end_day": 2,
         "boost_end_min": 60,
-        "boost_end": None,
         "boost_remaining": None,
         "charging": False,
         "current_charge_per": 67,
@@ -1277,7 +1276,6 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     settings["boost_active"] = " OFF "
     settings["boost_end_day"] = None
     settings["boost_end_min"] = None
-    settings["boost_end"] = {"day": 10, "minute": 15}
     settings["boost_remaining"] = ""
     coordinator.resolve_boost_end = RaisingResolver()  # type: ignore[assignment]
 
@@ -1285,7 +1283,6 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
         cur.boost_active = settings["boost_active"]
         cur.boost_end_day = settings["boost_end_day"]
         cur.boost_end_min = settings["boost_end_min"]
-        cur.boost_end = settings["boost_end"]
         cur.boost_remaining = settings["boost_remaining"]
 
     assert coordinator.apply_entity_patch(
@@ -1304,7 +1301,6 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     settings["boost_active"] = " maybe "
     settings["boost"] = None
     settings["mode"] = "auto"
-    settings["boost_end"] = None
     settings["boost_remaining"] = None
     coordinator.resolve_boost_end = None  # type: ignore[assignment]
 
@@ -1312,7 +1308,6 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
         cur.boost_active = settings["boost_active"]
         cur.boost = settings["boost"]
         cur.mode = settings["mode"]
-        cur.boost_end = settings["boost_end"]
         cur.boost_remaining = settings["boost_remaining"]
 
     assert coordinator.apply_entity_patch(
@@ -1325,13 +1320,11 @@ def test_accumulator_extra_state_attributes_varied_inputs() -> None:
     assert attrs["boost_active"] is False
 
     settings["boost_active"] = 0
-    settings["boost_end"] = None
     settings["boost_remaining"] = 7.5
     coordinator.resolve_boost_end = None  # type: ignore[assignment]
 
     def _apply_third(cur: Any) -> None:
         cur.boost_active = settings["boost_active"]
-        cur.boost_end = settings["boost_end"]
         cur.boost_remaining = settings["boost_remaining"]
 
     assert coordinator.apply_entity_patch(

--- a/tests/test_domain_state_store.py
+++ b/tests/test_domain_state_store.py
@@ -52,6 +52,8 @@ def test_domain_state_store_applies_snapshots_and_patches() -> None:
             "current_charge_per": "45.5",
             "target_charge_per": 95,
             "boost_end": {"day": 7, "minute": 15},
+            "boost_end_day": 7,
+            "boost_end_min": 15,
             "boost_remaining": 10,
             "extra": {"raw": "data"},
         },
@@ -72,9 +74,14 @@ def test_domain_state_store_applies_snapshots_and_patches() -> None:
     assert settings["acm"]["2"]["current_charge_per"] == 45.5
     assert settings["acm"]["2"]["target_charge_per"] == 95
     assert settings["acm"]["2"]["boost"] is True
-    assert settings["acm"]["2"]["boost_end"] == {"day": 7, "minute": 15}
+    assert "boost_end" not in settings["acm"]["2"]
+    assert settings["acm"]["2"]["boost_end_day"] == 7
+    assert settings["acm"]["2"]["boost_end_min"] == 15
     assert settings["acm"]["2"]["boost_remaining"] == 10
     assert "extra" not in settings["acm"]["2"]
+    assert all(
+        not isinstance(value, Mapping) for value in settings["acm"]["2"].values()
+    )
 
     store.apply_patch("htr", "1", {"stemp": "19.5"})
     patched = {

--- a/tests/test_ducaheat_acm_writes.py
+++ b/tests/test_ducaheat_acm_writes.py
@@ -130,7 +130,6 @@ async def test_ducaheat_acm_boost_metadata_fallback_releases_selection(
             "boost_active": True,
             "_fallback": True,
             "boost_minutes_delta": 120,
-            "boost_end": None,
             "boost_end_day": None,
             "boost_end_min": None,
             "boost_end_timestamp": None,
@@ -191,7 +190,6 @@ async def test_ducaheat_acm_boost_metadata_happy_path(
     boost_state = result.get("boost_state")
     assert boost_state == {
         "boost_active": True,
-        "boost_end": {"day": 1, "minute": 510},
         "boost_end_day": 1,
         "boost_end_min": 510,
         "boost_minutes_delta": 180,
@@ -392,7 +390,6 @@ async def test_collect_boost_metadata_rtc_exception_inactive(
         "boost_active": False,
         "_fallback": True,
         "boost_minutes_delta": 0,
-        "boost_end": None,
         "boost_end_day": None,
         "boost_end_min": None,
         "boost_end_timestamp": None,
@@ -447,7 +444,6 @@ async def test_collect_boost_metadata_inactive_valid(
 
     assert metadata == {
         "boost_active": False,
-        "boost_end": None,
         "boost_end_day": None,
         "boost_end_min": None,
         "boost_minutes_delta": 15,

--- a/tests/test_ducaheat_boost_metadata_merge.py
+++ b/tests/test_ducaheat_boost_metadata_merge.py
@@ -30,7 +30,6 @@ def test_merge_boost_metadata_prefers_existing_when_requested() -> None:
         "boost": True,
         "boost_end_day": 1,
         "boost_end_min": 240,
-        "boost_end": {"day": 4, "minute": 240},
     }
 
 
@@ -47,6 +46,5 @@ def test_merge_boost_metadata_nested_mapping_respects_prefer_flags() -> None:
 
     client._merge_boost_metadata(target, {"boost_end": nested})
 
-    assert target["boost_end"] == nested
     assert target["boost_end_day"] == 3
     assert target["boost_end_min"] == 150

--- a/tests/test_heater_entities.py
+++ b/tests/test_heater_entities.py
@@ -357,7 +357,7 @@ def test_derive_boost_state_parses_iso_without_parser(
     monkeypatch.setattr(dt_util, "parse_datetime", lambda value: None)
     settings = {
         "boost_active": True,
-        "boost_end": "2024-01-01T00:30:00+00:00",
+        "boost_end_datetime": "2024-01-01T00:30:00+00:00",
     }
 
     state = heater_module.derive_boost_state(settings, SimpleNamespace())
@@ -375,7 +375,7 @@ def test_derive_boost_state_ignores_placeholder_iso(
     settings = {
         "mode": "auto",
         "boost": False,
-        "boost_end": "1970-01-02T00:00:00UTC",
+        "boost_end_datetime": "1970-01-02T00:00:00UTC",
     }
 
     state = heater_module.derive_boost_state(settings, SimpleNamespace())
@@ -392,11 +392,11 @@ def test_derive_boost_state_parses_string_end(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(dt_util, "now", lambda: base_now)
 
     iso = "2024-01-01T00:30:00+00:00"
-    settings = {"boost_active": True, "boost_end": iso}
+    settings = {"boost_active": True, "boost_end_datetime": iso}
     state = heater_module.derive_boost_state(settings, SimpleNamespace())
 
     assert state.active is True
-    assert state.minutes_remaining is None
+    assert state.minutes_remaining == 30
     assert state.end_iso == iso
     assert state.end_datetime == datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc)
     assert state.end_label is None
@@ -460,7 +460,9 @@ def test_derive_boost_state_uses_parse_datetime(
     monkeypatch.setattr(dt_util, "parse_datetime", _fake_parse, raising=False)
 
     coordinator = SimpleNamespace(resolve_boost_end=None)
-    state = heater_module.derive_boost_state({"boost_end": iso_value}, coordinator)
+    state = heater_module.derive_boost_state(
+        {"boost_end_datetime": iso_value}, coordinator
+    )
 
     assert calls == [iso_value]
     assert state.end_datetime == parsed


### PR DESCRIPTION
## Summary
- Removed the raw `boost_end` mapping from accumulator domain state, leaving only typed boost end fields and canonical payload filtering.
- Updated Ducaheat decoding and websocket normalisation to stop emitting `boost_end` blobs while preserving day/minute and derived datetime handling for boost metadata.
- Refined boost state derivation and entity/test coverage, refreshed function map documentation, and bumped the integration version to `2.0.0-pre26`.

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`
- `ruff check custom_components/termoweb/backend/ducaheat.py custom_components/termoweb/codecs/ducaheat_codec.py custom_components/termoweb/domain/state.py custom_components/termoweb/heater.py custom_components/termoweb/climate.py tests/test_domain_state_store.py tests/test_ducaheat_nodes.py tests/test_api.py tests/test_ducaheat_boost_metadata_merge.py tests/test_ducaheat_acm_writes.py tests/test_heater_entities.py tests/test_climate.py`

## Context recap (must repeat in every PR prompt)
- Each installation has exactly ONE gateway (dev_id) and a fixed set of nodes (addresses + capabilities).
- The installation inventory is immutable during runtime. Inventory is fetched ONCE at startup and is the authoritative source.
- Never re-fetch inventory after startup. Never assume nodes appear/disappear or addresses change.
- We interact ONLY with the vendor cloud API + websocket; no direct node/gateway access.
- Refactor goal: Pydantic v2 validation at the API edge → domain model state store → entity layer. No raw JSON / raw dict payloads should be retained beyond a single call/handler scope.
- Do NOT keep raw node payloads or raw API responses in caches, hass.data, coordinator.data, or entity attributes. Only keep the domain state + minimal HA bookkeeping.
- Do not break REST polling or WS flows; no entity instantiation errors; no reconnect loops due to exceptions.

## Architecture guidelines (must repeat in every PR prompt)
- “Edge” = REST + WS payload parsing/validation. Use Pydantic v2 where available.
- “Domain” = typed state objects + store. Domain state should not contain raw vendor payload dicts (especially nested dict blobs).
- Entities must read ONLY from DomainStateView/DomainStateStore and Inventory, never from raw payload dicts.
- Any mapping/sequence values taken from payloads must not be stored by reference unless explicitly immutable-by-design.
- Prefer small, explicit value objects over “Any” dict blobs in the domain layer.

## Tests / workflow overrides (must repeat in every PR prompt)
- This is a refactor: it is allowed to break tests temporarily while implementing, but the PR MUST end with tests passing.
- Override any AGENT.md “don’t touch legacy code/tests” guidance: update tests as needed to match the refactor.
- Run: pytest -q (and/or targeted subsets while iterating), then full suite before finalizing.
- Keep changes incremental and reviewable. Avoid mixing unrelated cleanups.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69563f671f308329814aad139cbb8a98)