### PR TITLE
v2.0.0-pre27: Eliminate asdict deep-copy churn in domain state cloning (optimistic writes)

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre26"
+  "version": "2.0.0-pre27"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1026,6 +1026,8 @@ custom_components/termoweb/domain/state.py :: _copy_mapping
     Return a shallow copy of a mapping when applicable.
 custom_components/termoweb/domain/state.py :: _coerce_number
     Return ``value`` as a number when possible.
+custom_components/termoweb/domain/state.py :: _copy_state_field_value
+    Return a shallow copy for mappings and sequences.
 custom_components/termoweb/domain/state.py :: canonicalize_settings_payload
     Return canonical setting fields derived from ``payload``.
 custom_components/termoweb/domain/state.py :: NodeDelta.payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre26"
+version = "2.0.0-pre27"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]


### PR DESCRIPTION
## Context recap
- Each installation has exactly ONE gateway (dev_id) and a fixed set of nodes (addresses + capabilities).
- The installation inventory is immutable during runtime. Inventory is fetched ONCE at startup and is the authoritative source.
- Never re-fetch inventory after startup. Never assume nodes appear/disappear or addresses change.
- We interact ONLY with the vendor cloud API + websocket; no direct node/gateway access.
- Refactor goal: Pydantic v2 validation at the API edge → domain model state store → entity layer. No raw JSON / raw dict payloads should be retained beyond a single call/handler scope.
- Do NOT keep raw node payloads or raw API responses in caches, hass.data, coordinator.data, or entity attributes. Only keep the domain state + minimal HA bookkeeping.

## Architecture guidelines
- “Edge” = REST + WS payload parsing/validation. Use Pydantic v2 where available.
- “Domain” = typed state objects + store. Domain state should not contain raw vendor payload dicts (especially nested dict blobs).
- Entities must read ONLY from DomainStateView/DomainStateStore and Inventory, never from raw payload dicts.
- Any mapping/sequence values taken from payloads must not be stored by reference unless explicitly immutable-by-design.
- Prefer small, explicit value objects over “Any” dict blobs in the domain layer.

## Tests / workflow overrides
- This is a refactor: it is allowed to break tests temporarily while implementing, but the PR MUST end with tests passing.
- Override any AGENT.md “don’t touch legacy code/tests” guidance: update tests as needed to match the refactor.
- Run: pytest -q (and/or targeted subsets while iterating), then full suite before finalizing.
- Keep changes incremental and reviewable. Avoid mixing unrelated cleanups.

## Summary
- Replaced dataclasses.asdict cloning with explicit shallow-copy helpers to avoid double-copy churn while keeping optimistic patches isolated from stored state.
- Added regression coverage to ensure state_to_dict and clone_state return independent objects and copy mutable fields only once.
- Bumped integration metadata to version 2.0.0-pre27.

## Testing
- ⚠️ `uv run timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` (timed out at 30s; reran without timeout to confirm pass)
- ✅ `uv run pytest --cov=custom_components.termoweb --cov-report=term-missing`
- ✅ `uv run ruff check custom_components/termoweb/domain/state.py tests/test_domain_state_store.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564702ca4c83298da36fe5f808ca4f)