### PR TITLE
Add subscription retry handling for Ducaheat websocket

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -246,6 +246,10 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._forward_s
     Forward websocket heater sample updates to the energy coordinator.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._subscribe_feeds
     Subscribe to heater status and sample feeds.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._maybe_subscribe
+    Attempt subscription installation when prerequisites are met.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.request_resubscribe
+    Flag the subscription set for reinstatement.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._replay_subscription_paths
     Replay cached subscription paths after a reconnect.
 custom_components/termoweb/backend/factory.py :: create_backend


### PR DESCRIPTION
## Summary
- track pending subscription state with backoff so inventory lookups that are initially missing are retried instead of abandoned
- invoke subscription replay/resubscribe helpers after namespace ack and dev_data handling while avoiding duplicate installs when cached paths exist
- extend websocket protocol tests to cover deferred subscription retries, backoff growth, and resubscribe requests

## Testing
- timeout 30s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing
- uv run ruff check custom_components/termoweb/backend/ducaheat_ws.py tests/test_ducaheat_ws_protocol.py (fails due to existing repository lint/parse errors)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a46ebde88329babd2677ea58dd47)