### PR TITLE
Ducaheat WS idle recovery and resubscribe

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre29"
+  "version": "2.0.0-pre30"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -252,6 +252,22 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.request_re
     Flag the subscription set for reinstatement.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._replay_subscription_paths
     Replay cached subscription paths after a reconnect.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_threshold
+    Return the idle detection threshold in seconds.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_monitor_interval
+    Return the sleep interval between idle checks.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._reset_idle_recovery_state
+    Clear idle recovery flags after activity is observed.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._start_idle_monitor
+    Start the idle monitor when the websocket is ready.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._stop_idle_monitor
+    Stop the idle monitor task if it is running.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._handle_idle_check
+    Perform a single idle check iteration.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._recover_from_idle
+    Attempt resubscription or reconnect when the socket is idle.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_monitor
+    Monitor websocket idleness and trigger recovery steps.
 custom_components/termoweb/backend/factory.py :: create_backend
     Create a backend for the given brand.
 custom_components/termoweb/backend/sanitize.py :: redact_text


### PR DESCRIPTION
## Summary
- add idle monitoring and recovery for the Ducaheat websocket client with resubscribe and reconnect escalation
- expand websocket protocol tests to cover idle recovery flows and subscription replay, updating the function map
- bump the integration version to 2.0.0-pre30

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing (timed out around 55%)
- pytest tests/test_ducaheat_ws_protocol.py --cov=custom_components.termoweb.backend.ducaheat_ws --cov-report=term-missing
- pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a82f021483299a6f6fa3cfb97528)