### PR TITLE
Ducaheat WS telemetry and parsing resilience

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -62,3 +62,14 @@ The integration exposes the `termoweb.import_energy_history` service to backfill
 - Device resets are detected when the cumulative counter drops by more than **0.2 kWh**. The integration starts a new accumulation segment without breaking the monotonic sum expected by Home Assistant.
 - Duplicate timestamps are discarded to avoid redundant statistics writes.
 - A per-node summary and a final run summary are logged at INFO level. The most recent summary is also exposed in diagnostics (`energy_import.last_run`).
+
+---
+
+## Websocket health telemetry (diagnostics)
+
+The **TermoWeb diagnostics JSON** now surfaces extra websocket fields to help support identify “connected but quiet” issues for Ducaheat devices:
+
+- `subscribe_attempts_total`, `subscribe_success_total`, `subscribe_fail_total`, `last_subscribe_success_at` — show whether subscriptions were installed and when they last succeeded.
+- `recovery_attempts_total`, `last_recovery_at` — count idle recovery attempts and the timestamp of the most recent recovery.
+- `last_update_event_at` — the most recent device update (dev_data/update) received from the cloud.
+- `parse_errors_total` — number of malformed websocket frames that were skipped.

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre30"
+  "version": "2.0.0-pre31"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -206,6 +206,16 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._ws_health
     Return the shared websocket health tracker for this client.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._status_should_reset_health
     Return True when a status transition should reset health.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._increment_state_counter
+    Increment a numeric counter in the websocket state bucket.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._record_update_event
+    Record a meaningful update event timestamp.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._record_parse_error
+    Track JSON parse failures and return True when reconnection is advised.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._decode_socketio_event
+    Decode a Socket.IO ``42`` payload safely.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._update_status_from_heartbeat
+    Update status based on heartbeat activity and payload recency.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._build_handshake_url
     Return a handshake URL with the provided query parameters.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._record_frame


### PR DESCRIPTION
## Summary
- add websocket telemetry fields for subscription attempts, recovery actions, parse errors, and the most recent update events to improve diagnostics
- harden Engine.IO/SIO heartbeat handling, idle recovery gating, and subscription retries so silent sockets resubscribe or reconnect rather than remaining connected-without-updates
- protect Socket.IO event parsing from malformed frames, capture parse-error counters, and document the new telemetry while bumping the integration to 2.0.0-pre31

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing
- ruff check custom_components/termoweb/backend/ducaheat_ws.py tests/test_ducaheat_ws_protocol.py
- ruff check . (fails due to pre-existing repository lint issues outside the modified files)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ac401b948329855f547751871749)