### PR TITLE
Diagnostics: surface websocket telemetry

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1096,6 +1096,8 @@ custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.merge_sample
     Merge normalised hourly samples into the cached energy state.
 custom_components/termoweb/coordinator.py :: _wrap_logger
     Return a logger proxy that exposes ``isEnabledFor`` when missing.
+custom_components/termoweb/diagnostics.py :: _extract_websocket_clients
+    Return websocket telemetry entries for diagnostics.
 custom_components/termoweb/diagnostics.py :: async_get_config_entry_diagnostics
     Return a diagnostics payload for ``entry``.
 custom_components/termoweb/domain/energy.py :: EnergySnapshot.metrics_for_type


### PR DESCRIPTION
## Summary
- expose websocket client state in diagnostics including masked device identifiers
- attach health tracker snapshots alongside existing websocket state
- add coverage for websocket diagnostics and document the new helper in the function map

## Testing
- timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing *(times out after ~30s; suite is larger than window)*
- pytest tests/test_diagnostics.py
- ruff check custom_components/termoweb/diagnostics.py tests/test_diagnostics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b01c8ecc832994b6683a34a92132)