### PR TITLE
Ducaheat WS: trigger resubscribe when inventory becomes available

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -65,6 +65,7 @@ from .inventory import (
     build_node_inventory,
     normalize_node_addr,
     normalize_node_type,
+    store_inventory_on_entry,
 )
 from .throttle import default_samples_rate_limit_state, reset_samples_rate_limit_state
 from .utils import async_get_integration_version as _async_get_integration_version
@@ -551,7 +552,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         "coordinator": coordinator,
         "energy_coordinator": energy_coordinator,
         "dev_id": dev_id,
-        "inventory": inventory,
+        "inventory": None,
         "hourly_poller": poller,
         "config_entry": entry,
         "base_poll_interval": max(base_interval, MIN_POLL_INTERVAL),
@@ -568,6 +569,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         "boost_runtime": {},
         "diagnostics_task": diagnostics_task,
     }
+
+    store_inventory_on_entry(
+        inventory,
+        record=data,
+        hass=hass,
+        entry_id=entry.entry_id,
+    )
 
     async def _async_handle_hass_stop(_event: Any) -> None:
         """Stop background activity gracefully when Home Assistant stops."""

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -55,6 +55,7 @@ from custom_components.termoweb.inventory import (
     Inventory,
     normalize_node_addr,
     normalize_node_type,
+    store_inventory_on_entry,
 )
 
 from .ws_client import (
@@ -1023,7 +1024,12 @@ class WebSocketClient(_WSCommon):
 
         record = context.record
         if isinstance(record, MutableMapping) and isinstance(inventory, Inventory):
-            record["inventory"] = inventory
+            store_inventory_on_entry(
+                inventory,
+                record=record,
+                hass=self.hass,
+                entry_id=self.entry_id,
+            )
 
         if not isinstance(inventory, Inventory):
             _LOGGER.error("WS: missing inventory for node dispatch on %s", self.dev_id)

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -23,7 +23,12 @@ from ..const import (
     signal_ws_data,
     signal_ws_status,
 )
-from ..inventory import Inventory, normalize_node_addr, normalize_node_type
+from ..inventory import (
+    Inventory,
+    normalize_node_addr,
+    normalize_node_type,
+    store_inventory_on_entry,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .ducaheat_ws import DucaheatWSClient
@@ -784,7 +789,12 @@ class _WSCommon(_WSStatusMixin):
             self._inventory = inventory
             record = self.hass.data.setdefault(DOMAIN, {}).setdefault(self.entry_id, {})
             if isinstance(record, MutableMapping):
-                record["inventory"] = inventory
+                store_inventory_on_entry(
+                    inventory,
+                    record=record,
+                    hass=self.hass,
+                    entry_id=self.entry_id,
+                )
         return inventory
 
     def _ensure_type_bucket(
@@ -826,7 +836,12 @@ class _WSCommon(_WSStatusMixin):
         except LookupError:
             inventory_container = None
         else:
-            dev_map["inventory"] = inventory_container
+            store_inventory_on_entry(
+                inventory_container,
+                record=dev_map,
+                hass=self.hass,
+                entry_id=self.entry_id,
+            )
 
         settings_section = dev_map.get("settings")
         if isinstance(settings_section, MutableMapping):

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -32,6 +32,7 @@ from .inventory import (
     build_node_inventory,
     normalize_node_addr,
     normalize_node_type,
+    store_inventory_on_entry,
 )
 from .utils import float_or_none
 
@@ -866,7 +867,12 @@ def heater_platform_details_for_entry(
                             dev_id, build_node_inventory(nodes_payload)
                         )
                         if isinstance(entry_data, MutableMapping):
-                            entry_data["inventory"] = inventory
+                            store_inventory_on_entry(
+                                inventory,
+                                record=entry_data,
+                                hass=hass,
+                                entry_id=entry_id,
+                            )
                     except (
                         TypeError,
                         ValueError,

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.0-pre31"
+  "version": "2.0.0-pre32"
 }

--- a/custom_components/termoweb/sensor.py
+++ b/custom_components/termoweb/sensor.py
@@ -54,6 +54,7 @@ from .inventory import (
     PowerMonitorNode,
     normalize_node_addr,
     normalize_node_type,
+    store_inventory_on_entry,
 )
 from .utils import (
     build_gateway_device_info,
@@ -174,7 +175,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     if not isinstance(data.get("inventory"), Inventory):
         coordinator_inventory = getattr(coordinator, "inventory", None)
         if isinstance(coordinator_inventory, Inventory):
-            data["inventory"] = coordinator_inventory
+            store_inventory_on_entry(
+                coordinator_inventory,
+                record=data,
+                hass=hass,
+                entry_id=entry.entry_id,
+            )
 
     heater_details = heater_platform_details_for_entry(
         data,

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1,6 +1,5 @@
-# TermoWeb Function Map
-
-custom_components/termoweb/__init__.py :: _build_unknown_node_probe_requests
+Wrote 871 functions to /workspace/ha-termoweb/docs/function_map.txt
+build_unknown_node_probe_requests
     Return common REST endpoints to query for an unknown node type.
 custom_components/termoweb/__init__.py :: _async_probe_unknown_node_types
     Log discovery probes for node types not yet supported.
@@ -202,6 +201,8 @@ custom_components/termoweb/backend/ducaheat_ws.py :: _decode_polling_packets
     Decode Engine.IO v3 binary polling frames.
 custom_components/termoweb/backend/ducaheat_ws.py :: _brand_headers
     Construct brand-specific headers for polling.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.__init__
+    Initialise the Ducaheat websocket client.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._ws_health
     Return the shared websocket health tracker for this client.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._status_should_reset_health
@@ -216,10 +217,34 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._decode_so
     Decode a Socket.IO ``42`` payload safely.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._update_status_from_heartbeat
     Update status based on heartbeat activity and payload recency.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.start
+    Start the websocket runner task.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.stop
+    Stop the websocket client and background tasks.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.is_running
+    Return True when the websocket runner task is active.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._build_handshake_url
     Return a handshake URL with the provided query parameters.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.ws_url
+    Return the websocket handshake URL.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._record_frame
     Update cached websocket frame statistics and timestamps.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_threshold
+    Return the idle detection threshold in seconds.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_monitor_interval
+    Return the sleep interval between idle checks.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._reset_idle_recovery_state
+    Clear idle recovery flags after activity is observed.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._start_idle_monitor
+    Start the idle monitor when the websocket is ready.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._stop_idle_monitor
+    Stop the idle monitor task if it is running.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._handle_idle_check
+    Perform a single idle check iteration.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._recover_from_idle
+    Attempt resubscription or reconnect when the socket is idle.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_monitor
+    Monitor websocket idleness and trigger recovery steps.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._start_keepalive
     Launch the keepalive loop when the websocket is connected.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._keepalive_loop
@@ -262,22 +287,6 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.request_re
     Flag the subscription set for reinstatement.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._replay_subscription_paths
     Replay cached subscription paths after a reconnect.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_threshold
-    Return the idle detection threshold in seconds.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_monitor_interval
-    Return the sleep interval between idle checks.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._reset_idle_recovery_state
-    Clear idle recovery flags after activity is observed.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._start_idle_monitor
-    Start the idle monitor when the websocket is ready.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._stop_idle_monitor
-    Stop the idle monitor task if it is running.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._handle_idle_check
-    Perform a single idle check iteration.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._recover_from_idle
-    Attempt resubscription or reconnect when the socket is idle.
-custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._idle_monitor
-    Monitor websocket idleness and trigger recovery steps.
 custom_components/termoweb/backend/factory.py :: create_backend
     Create a backend for the given brand.
 custom_components/termoweb/backend/sanitize.py :: redact_text
@@ -1460,6 +1469,10 @@ custom_components/termoweb/inventory.py :: Inventory.require_from_context
     Return the shared inventory associated with a Home Assistant entry.
 custom_components/termoweb/inventory.py :: Inventory.require_from_record
     Return the cached inventory stored within ``record``.
+custom_components/termoweb/inventory.py :: _request_ws_inventory_resubscribe
+    Request websocket resubscribe when inventory becomes available.
+custom_components/termoweb/inventory.py :: store_inventory_on_entry
+    Persist inventory for an entry and notify websocket clients.
 custom_components/termoweb/inventory.py :: _normalize_node_identifier
     Return ``value`` as a normalised node identifier string.
 custom_components/termoweb/inventory.py :: normalize_node_type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.0-pre29"
+version = "2.0.0-pre32"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 from typing import Any, Callable, Iterable, List, Mapping
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -13,6 +14,7 @@ from custom_components.termoweb.inventory import (
     Inventory,
     Node,
     PowerMonitorNode,
+    store_inventory_on_entry,
     normalize_power_monitor_addresses,
 )
 
@@ -35,9 +37,7 @@ def sample_nodes() -> List[DummyNode]:
 
 
 @pytest.fixture
-def inventory(
-    sample_nodes: List[DummyNode]
-) -> Inventory:
+def inventory(sample_nodes: List[DummyNode]) -> Inventory:
     """Build an inventory instance for tests."""
 
     return Inventory("abc123", sample_nodes)
@@ -539,3 +539,64 @@ def test_heater_platform_details_default_name(
     assert addrs_by_type == {"htr": ["1"], "acm": ["2"], "thm": []}
     assert resolver("htr", "1") == "Heater 1"
     assert resolver("acm", "2") == "Accumulator 2"
+
+
+def test_store_inventory_requests_resubscribe_once() -> None:
+    """Storing inventory should request a websocket resubscribe only once."""
+
+    inventory = Inventory("dev", [])
+    entry_id = "entry"
+    hass = SimpleNamespace(data={inventory_module.DOMAIN: {}})
+    ws_client = SimpleNamespace(request_resubscribe=MagicMock())
+    record = {"ws_clients": {"dev": ws_client}}
+    hass.data[inventory_module.DOMAIN][entry_id] = record
+
+    Inventory.require_from_context(
+        inventory=inventory,
+        container=record,
+        hass=hass,
+        entry_id=entry_id,
+    )
+
+    ws_client.request_resubscribe.assert_called_once_with("inventory_ready")
+
+    store_inventory_on_entry(
+        inventory,
+        record=record,
+        hass=hass,
+        entry_id=entry_id,
+    )
+
+    ws_client.request_resubscribe.assert_called_once_with("inventory_ready")
+
+
+def test_store_inventory_notifies_all_ws_clients() -> None:
+    """All websocket clients should be notified when inventory is stored."""
+
+    inventory = Inventory("dev", [])
+    entry_id = "entry"
+    first_client = SimpleNamespace(request_resubscribe=MagicMock())
+    second_client = SimpleNamespace(request_resubscribe=MagicMock())
+    hass = SimpleNamespace(
+        data={
+            inventory_module.DOMAIN: {
+                entry_id: {
+                    "ws_clients": {
+                        "one": first_client,
+                        "two": second_client,
+                    }
+                }
+            }
+        }
+    )
+    record = hass.data[inventory_module.DOMAIN][entry_id]
+
+    store_inventory_on_entry(
+        inventory,
+        record=record,
+        hass=hass,
+        entry_id=entry_id,
+    )
+
+    first_client.request_resubscribe.assert_called_once_with("inventory_ready")
+    second_client.request_resubscribe.assert_called_once_with("inventory_ready")


### PR DESCRIPTION
## Summary
- add a shared helper to persist entry inventory and immediately request websocket resubscription when it first appears
- route inventory writes through the helper across setup, websocket dispatch, and platform fallbacks so Ducaheat clients resubscribe as soon as inventory is ready; add unit coverage for the notification fan-out
- bump integration version to 2.0.0-pre32 and refresh the function map

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` *(times out around 90% collection/run in this environment; partial log captured)*
- `pytest tests/test_inventory.py -k store_inventory`
- `ruff check custom_components/termoweb/inventory.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b8ba90308329860bd50a0366986b)