### PR TITLE
Add Tevolve brand option mapped to Ducaheat backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 # TermoWeb heaters for Home Assistant
 
-Control your **TermoWeb** or **Ducaheat** electric heaters and thermostats in **Home Assistant** — from the HA app, automations, scenes, and voice assistants.
+Control your **TermoWeb**, **Ducaheat**, or **Tevolve** electric heaters and thermostats in **Home Assistant** — from the HA app, automations, scenes, and voice assistants.
 
 [![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ha-termoweb&repository=ha-termoweb&category=integration)
 [![Open your Home Assistant instance and start setting up the integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=termoweb)
@@ -45,9 +45,9 @@ These product lines are documented to work with the **TermoWeb** portal/app:
 
 Ducasa branded heaters (with the Ducaheat app), accumulators and other devices, are now supported with basic functionality tested and working. Heaters support temperature setting, weekly programming, switching modes (auto, manual, off). Preliminary support for "boost" on accumulators is currently in testing. Energy and power readings are also in testing with some basic support. Work is ongoing with full support expected before the end of the year. 
 
-## Tevolve app
+## Tevolve app (Ducaheat backend)
 
-We do not yet have integration with heaters using the Tevolve-app, but it looks like the protocol is very similar if not identical to the TermoWeb and Ducaheat apps. If you have a heater that uses the Tevolve mobile app for control, leave an issue so we can test it. 
+Tevolve-branded heaters use the same backend as the Ducaheat app. If you manage your heaters in the **Tevolve** mobile app or on the **Tevolve** website, select **Tevolve** in the brand picker and this integration will connect using the Ducaheat backend automatically.
 
 ---
 
@@ -177,4 +177,3 @@ See DEBUG.md for information on how to turn on debugging, and download logs and 
 ## Search keywords
 
 *Home Assistant TermoWeb, TermoWeb heaters Home Assistant, ATC radiators, S&P TermoWeb Home Assistant, Soler & Palau TermoWeb, Ecotermi TermoWeb, Linea Plus TermoWeb, Electric Heating Company eco SAVE Home Assistant, eco SAVE Smart Gateway Home Assistant*
-

--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -44,7 +44,8 @@ from .api import BackendAuthError, BackendRateLimitError, RESTClient
 from .backend import Backend, DucaheatRESTClient, WsClientProto, create_backend
 from .backend.sanitize import redact_text
 from .const import (
-    BRAND_DUCAHEAT,
+    BRAND_DUCAHEAT as BRAND_DUCAHEAT,
+    BRAND_TEVOLVE as BRAND_TEVOLVE,
     CONF_BRAND,
     DEFAULT_BRAND,
     DEFAULT_POLL_INTERVAL,
@@ -53,6 +54,7 @@ from .const import (
     get_brand_api_base,
     get_brand_basic_auth,
     signal_ws_status,
+    uses_ducaheat_backend,
 )
 from .coordinator import EnergyStateCoordinator, StateCoordinator, build_device_metadata
 from .energy import (
@@ -118,7 +120,7 @@ def _build_unknown_node_probe_requests(
         seen_paths.add(path)
         requests.append((path, params))
 
-    if brand == BRAND_DUCAHEAT and normalized_addr:
+    if uses_ducaheat_backend(brand) and normalized_addr:
         _append(base_path)
 
     _append(node_path)
@@ -376,7 +378,7 @@ def create_rest_client(
     session = aiohttp_client.async_get_clientsession(hass)
     api_base = get_brand_api_base(brand)
     basic_auth = get_brand_basic_auth(brand)
-    client_cls = DucaheatRESTClient if brand == BRAND_DUCAHEAT else RESTClient
+    client_cls = DucaheatRESTClient if uses_ducaheat_backend(brand) else RESTClient
     return client_cls(
         session,
         username,

--- a/custom_components/termoweb/backend/factory.py
+++ b/custom_components/termoweb/backend/factory.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from ..const import BRAND_DUCAHEAT
+from custom_components.termoweb.const import uses_ducaheat_backend
+
 from .base import Backend, HttpClientProto
 
 
 def create_backend(*, brand: str, client: HttpClientProto) -> Backend:
     """Create a backend for the given brand."""
 
-    if brand == BRAND_DUCAHEAT:
-        from .ducaheat import DucaheatBackend
+    if uses_ducaheat_backend(brand):
+        from . import DucaheatBackend  # noqa: PLC0415
 
         return DucaheatBackend(brand=brand, client=client)
-    from . import TermoWebBackend
+
+    from . import TermoWebBackend  # noqa: PLC0415
 
     return TermoWebBackend(brand=brand, client=client)

--- a/custom_components/termoweb/climate.py
+++ b/custom_components/termoweb/climate.py
@@ -23,7 +23,7 @@ import voluptuous as vol
 
 from .backend.ducaheat import DucaheatRESTClient
 from .boost import coerce_boost_minutes, supports_boost
-from .const import BRAND_DUCAHEAT, DOMAIN
+from .const import DOMAIN, uses_ducaheat_backend
 from .domain import DomainState, HeaterState
 from .heater import (
     DEFAULT_BOOST_DURATION,
@@ -378,9 +378,7 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
         """Translate a program slot integer into a label."""
         return {0: "cold", 1: "night", 2: "day"}.get(v)
 
-    def _current_prog_slot(
-        self, state: HeaterState | DomainState | None
-    ) -> int | None:
+    def _current_prog_slot(self, state: HeaterState | DomainState | None) -> int | None:
         """Return the active program slot index for the heater."""
 
         prog = getattr(state, "prog", None)
@@ -432,9 +430,7 @@ class HeaterClimateEntity(HeaterNode, HeaterNodeBase, ClimateEntity):
                         except Exception:
                             try:
                                 loop = asyncio.get_running_loop()
-                                self._last_refresh_task = loop.create_task(
-                                    refresh_task
-                                )
+                                self._last_refresh_task = loop.create_task(refresh_task)
                             except Exception:
                                 if hasattr(refresh_task, "close"):
                                     refresh_task.close()
@@ -1475,7 +1471,7 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
                 if isinstance(brand_value, str):
                     brand = brand_value
 
-        if brand == BRAND_DUCAHEAT and self._node_type == "acm":
+        if uses_ducaheat_backend(brand) and self._node_type == "acm":
             cancel_boost = False
             boost_state = None
             try:
@@ -1486,7 +1482,7 @@ class AccumulatorClimateEntity(HeaterClimateEntity):
                     self._addr,
                     err,
                     exc_info=err,
-            )
+                )
             if boost_state is not None and boost_state.active is not None:
                 cancel_boost = bool(boost_state.active)
             else:

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     BRAND_DUCAHEAT,
     BRAND_LABELS,
     BRAND_TERMOWEB,
+    BRAND_TEVOLVE,
     CONF_BRAND,
     DEFAULT_BRAND,
     DOMAIN,
@@ -25,7 +26,7 @@ from .const import (
 )
 from .utils import async_get_integration_version
 
-__all__ = ["BRAND_DUCAHEAT"]
+__all__ = ["BRAND_DUCAHEAT", "BRAND_TEVOLVE"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/const.py
+++ b/custom_components/termoweb/const.py
@@ -23,25 +23,30 @@ BASIC_AUTH_B64: Final = "NTIxNzJkYzg0ZjYzZDZjNzU5MDAwMDA1OmJ4djRaM3hVU2U="
 CONF_BRAND: Final = "brand"
 BRAND_TERMOWEB: Final = "termoweb"
 BRAND_DUCAHEAT: Final = "ducaheat"
+BRAND_TEVOLVE: Final = "tevolve"
 DEFAULT_BRAND: Final = BRAND_TERMOWEB
 
 BRAND_LABELS: Final[Mapping[str, str]] = {
     BRAND_TERMOWEB: "TermoWeb",
     BRAND_DUCAHEAT: "Ducaheat",
+    BRAND_TEVOLVE: "Tevolve",
 }
 
 BRAND_API_BASES: Final[Mapping[str, str]] = {
     BRAND_TERMOWEB: API_BASE,
     BRAND_DUCAHEAT: "https://api-tevolve.termoweb.net",
+    BRAND_TEVOLVE: "https://api-tevolve.termoweb.net",
 }
 
 BRAND_BASIC_AUTH: Final[Mapping[str, str]] = {
     BRAND_TERMOWEB: BASIC_AUTH_B64,
     BRAND_DUCAHEAT: "NWM0OWRjZTk3NzUxMDM1MTUwNmM0MmRiOnRldm9sdmU=",
+    BRAND_TEVOLVE: "NWM0OWRjZTk3NzUxMDM1MTUwNmM0MmRiOnRldm9sdmU=",
 }
 
 BRAND_SOCKETIO_PATHS: Final[Mapping[str, str]] = {
     BRAND_DUCAHEAT: "api/v2/socket_io",
+    BRAND_TEVOLVE: "api/v2/socket_io",
 }
 
 # UA / locale (matches app loosely; helps avoid quirky WAF rules)
@@ -55,12 +60,16 @@ ACCEPT_LANGUAGE: Final = "en-US,en;q=0.8"
 BRAND_USER_AGENTS: Final[Mapping[str, str]] = {
     BRAND_TERMOWEB: USER_AGENT,
     BRAND_DUCAHEAT: DUCAHEAT_USER_AGENT,
+    BRAND_TEVOLVE: DUCAHEAT_USER_AGENT,
 }
 
 BRAND_REQUESTED_WITH: Final[Mapping[str, str]] = {
     BRAND_TERMOWEB: TERMOWEB_REQUESTED_WITH,
     BRAND_DUCAHEAT: DUCAHEAT_REQUESTED_WITH,
+    BRAND_TEVOLVE: DUCAHEAT_REQUESTED_WITH,
 }
+
+DUCAHEAT_BRANDS: Final[frozenset[str]] = frozenset({BRAND_DUCAHEAT, BRAND_TEVOLVE})
 
 
 def get_brand_api_base(brand: str) -> str:
@@ -103,6 +112,12 @@ def get_brand_socketio_path(brand: str) -> str:
     if path:
         return path.lstrip("/")
     return "socket.io"
+
+
+def uses_ducaheat_backend(brand: str) -> bool:
+    """Return True when the brand maps to the Ducaheat backend."""
+
+    return brand in DUCAHEAT_BRANDS
 
 
 # Socket.IO namespace used by the websocket client implementation

--- a/custom_components/termoweb/strings.json
+++ b/custom_components/termoweb/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to TermoWeb family heaters",
-        "description": "Choose your TermoWeb or Ducaheat brand and enter your account credentials.",
+        "description": "Choose your TermoWeb, Ducaheat, or Tevolve brand and enter your account credentials. Tevolve uses the Ducaheat backend.",
         "data": {
           "brand": "Brand",
           "username": "Email",

--- a/custom_components/termoweb/translations/en.json
+++ b/custom_components/termoweb/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to TermoWeb family heaters",
-        "description": "Version: {version}\n\nChoose your TermoWeb or Ducaheat brand and enter your account credentials.",
+        "description": "Version: {version}\n\nChoose your TermoWeb, Ducaheat, or Tevolve brand and enter your account credentials. Tevolve uses the Ducaheat backend.",
         "data": {
           "brand": "Brand",
           "username": "Email",

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1,5 +1,6 @@
-Wrote 871 functions to /workspace/ha-termoweb/docs/function_map.txt
-build_unknown_node_probe_requests
+# TermoWeb Function Map
+
+custom_components/termoweb/__init__.py :: _build_unknown_node_probe_requests
     Return common REST endpoints to query for an unknown node type.
 custom_components/termoweb/__init__.py :: _async_probe_unknown_node_types
     Log discovery probes for node types not yet supported.
@@ -985,6 +986,8 @@ custom_components/termoweb/const.py :: get_brand_requested_with
     Return the X-Requested-With header value for the brand.
 custom_components/termoweb/const.py :: get_brand_socketio_path
     Return the Socket.IO path for the selected brand.
+custom_components/termoweb/const.py :: uses_ducaheat_backend
+    Return True when the brand maps to the Ducaheat backend.
 custom_components/termoweb/const.py :: signal_ws_data
     Signal name for WS ‘data’ frames dispatched to platforms.
 custom_components/termoweb/const.py :: signal_ws_status

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -10,7 +10,7 @@ import pytest
 from custom_components.termoweb.backend import create_backend
 from custom_components.termoweb.backend import termoweb as termoweb_backend
 from custom_components.termoweb.backend.ducaheat import DucaheatBackend
-from custom_components.termoweb.const import BRAND_DUCAHEAT
+from custom_components.termoweb.const import BRAND_DUCAHEAT, BRAND_TEVOLVE
 
 
 class DummyHttpClient:
@@ -84,6 +84,14 @@ def test_create_backend_returns_ducaheat_backend() -> None:
     backend = create_backend(brand=BRAND_DUCAHEAT, client=client)
     assert isinstance(backend, DucaheatBackend)
     assert backend.brand == BRAND_DUCAHEAT
+    assert backend.client is client
+
+
+def test_create_backend_returns_tevolve_backend() -> None:
+    client = DummyHttpClient()
+    backend = create_backend(brand=BRAND_TEVOLVE, client=client)
+    assert isinstance(backend, DucaheatBackend)
+    assert backend.brand == BRAND_TEVOLVE
     assert backend.client is client
 
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -15,3 +15,17 @@ def test_get_brand_socketio_path_unknown_brand() -> None:
     """Default to the generic Socket.IO path for unknown brands."""
 
     assert const.get_brand_socketio_path("unknown") == "socket.io"
+
+
+def test_get_brand_socketio_path_tevolve() -> None:
+    """Tevolve reuses the Ducaheat Socket.IO path."""
+
+    assert const.get_brand_socketio_path(const.BRAND_TEVOLVE) == "api/v2/socket_io"
+
+
+def test_uses_ducaheat_backend_aliases() -> None:
+    """Brands mapped to Ducaheat share backend selection."""
+
+    assert const.uses_ducaheat_backend(const.BRAND_DUCAHEAT) is True
+    assert const.uses_ducaheat_backend(const.BRAND_TEVOLVE) is True
+    assert const.uses_ducaheat_backend(const.BRAND_TERMOWEB) is False

--- a/tests/test_init_setup.py
+++ b/tests/test_init_setup.py
@@ -129,16 +129,29 @@ def test_create_rest_client_selects_brand(
         "pw2",
         termoweb_init.BRAND_DUCAHEAT,
     )
+    tevolve_client = termoweb_init.create_rest_client(
+        stub_hass,
+        "user3",
+        "pw3",
+        termoweb_init.BRAND_TEVOLVE,
+    )
 
     assert isinstance(default_client, DefaultClient)
     assert isinstance(duca_client, DucaClient)
+    assert isinstance(tevolve_client, DucaClient)
     assert default_client.api_base == termoweb_init.get_brand_api_base(
         termoweb_init.DEFAULT_BRAND
+    )
+    assert tevolve_client.api_base == termoweb_init.get_brand_api_base(
+        termoweb_init.BRAND_TEVOLVE
     )
     assert duca_client.basic_auth_b64 == termoweb_init.get_brand_basic_auth(
         termoweb_init.BRAND_DUCAHEAT
     )
-    assert stub_hass.client_session_calls == 2
+    assert tevolve_client.basic_auth_b64 == termoweb_init.get_brand_basic_auth(
+        termoweb_init.BRAND_TEVOLVE
+    )
+    assert stub_hass.client_session_calls == 3
 
 
 def test_diagnostics_module_registers_via_home_assistant_helper(


### PR DESCRIPTION
## Summary
- add Tevolve brand constants mapped to the Ducaheat backend and expose them in brand selection logic
- update the config flow strings and README to advertise Tevolve support and note it uses the Ducaheat backend
- adjust backend factories and tests so Tevolve accounts use Ducaheat clients and regenerate the function map

## Testing
- uv run ruff check custom_components/termoweb/const.py custom_components/termoweb/config_flow.py custom_components/termoweb/__init__.py custom_components/termoweb/backend/factory.py custom_components/termoweb/climate.py tests/test_config_flow.py tests/test_init_setup.py tests/test_backend_factory.py tests/test_const.py
- uv run timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957859a12f08329ab09780e8e7e16e0)