### PR TITLE
pre33: kick Ducaheat inventory resubscribe immediately

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -285,7 +285,11 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._subscribe
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._maybe_subscribe
     Attempt subscription installation when prerequisites are met.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.request_resubscribe
-    Flag the subscription set for reinstatement.
+    Flag the subscription set for reinstatement and trigger a prompt attempt.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._schedule_resubscribe_kick
+    Schedule an immediate subscribe attempt when conditions allow.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._run_resubscribe_kick
+    Attempt a single subscription refresh after a resubscribe request.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._replay_subscription_paths
     Replay cached subscription paths after a reconnect.
 custom_components/termoweb/backend/factory.py :: create_backend


### PR DESCRIPTION
## Summary
- reset Ducaheat websocket subscribe backoff and kick an immediate attempt when inventory becomes available
- guard against duplicate kick tasks and clean them up when disconnecting
- add regression coverage and update the function map documentation

## Testing
- timeout 30s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing
- uv run ruff check custom_components/termoweb/backend/ducaheat_ws.py tests/test_ducaheat_ws_protocol.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579773bf7c8329944bed8d470bd8be)