### PR TITLE
pre34: serialize Ducaheat websocket sends

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -206,6 +206,8 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.__init__
     Initialise the Ducaheat websocket client.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._ws_health
     Return the shared websocket health tracker for this client.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._send_str
+    Send a websocket frame with serialized access.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._status_should_reset_health
     Return True when a status transition should reset health.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._increment_state_counter


### PR DESCRIPTION
## Summary
- Serialize all Ducaheat websocket sends through a shared lock and helper used for handshake, keepalive, and pong frames.
- Extend websocket protocol tests with a concurrency-checking stub and coverage for missing websocket scenarios.
- Record the new helper in the function map documentation.

## Testing
- ⚠️ `timeout 30s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing` (timed out around 60% of the suite; the full run exceeds the 30s limit in this environment)
- ✅ `timeout 30s uv run pytest tests/test_ducaheat_ws_protocol.py --cov=custom_components.termoweb.backend.ducaheat_ws --cov-report=term-missing`
- ✅ `uv run ruff check custom_components/termoweb/backend/ducaheat_ws.py tests/test_ducaheat_ws_protocol.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579ffa7a8c8329be778b8d0d542865)