### PR TITLE
pre35: Harden Ducaheat WS probe upgrade handling

### DIFF
--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -226,6 +226,8 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.stop
     Stop the websocket client and background tasks.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.is_running
     Return True when the websocket runner task is active.
+custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._connect_once
+    Perform a single websocket handshake and upgrade attempt.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._build_handshake_url
     Return a handshake URL with the provided query parameters.
 custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient.ws_url


### PR DESCRIPTION
## Summary
- Guard the Ducaheat websocket probe handshake with a timeouted frame loop that handles pings and drains post-upgrade frames before opening the namespace
- Add configurable probe/upgrade drain windows and a docstring for `_connect_once`, updating the function map accordingly
- Extend websocket protocol stubs and tests to cover interleaved probe pings and missing probe acknowledgements

## Testing
- `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957aaf4ee5483298b83ff53aeaee3bf)