### PR TITLE
Core: introduce EntryRuntime and remove context-fallback access patterns

### DIFF
--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -46,24 +46,23 @@ from custom_components.termoweb.const import (
     signal_ws_data,
 )
 from custom_components.termoweb.domain import (
-    canonicalize_settings_payload,
     NodeId as DomainNodeId,
     NodeSettingsDelta,
     NodeType as DomainNodeType,
+    canonicalize_settings_payload,
 )
 from custom_components.termoweb.inventory import (
     Inventory,
     normalize_node_addr,
     normalize_node_type,
-    store_inventory_on_entry,
 )
 
 from .ws_client import (
-    build_settings_delta,
     HandshakeError,
     WSStats,
     _prepare_nodes_dispatch,
     _WSCommon,
+    build_settings_delta,
     clone_payload_value,
     forward_ws_sample_updates,
     resolve_ws_update_section,
@@ -1021,15 +1020,6 @@ class WebSocketClient(_WSCommon):
         inventory = context.inventory
         if self._inventory is None and isinstance(inventory, Inventory):
             self._inventory = inventory
-
-        record = context.record
-        if isinstance(record, MutableMapping) and isinstance(inventory, Inventory):
-            store_inventory_on_entry(
-                inventory,
-                record=record,
-                hass=self.hass,
-                entry_id=self.entry_id,
-            )
 
         if not isinstance(inventory, Inventory):
             _LOGGER.error("WS: missing inventory for node dispatch on %s", self.dev_id)

--- a/custom_components/termoweb/i18n.py
+++ b/custom_components/termoweb/i18n.py
@@ -20,6 +20,7 @@ except ImportError:  # pragma: no cover - executed in unit test stubs
 
 
 from .const import DOMAIN
+from .runtime import EntryRuntime
 from .fallback_translations import get_fallback_translations
 
 FALLBACK_TRANSLATIONS_KEY = "fallback_translations"
@@ -44,11 +45,15 @@ async def _tr(hass: HomeAssistant, key: str, **placeholders: Any) -> str:
 
 async def async_get_fallback_translations(
     hass: HomeAssistant,
-    entry_data: MutableMapping[str, Any] | None = None,
+    entry_data: EntryRuntime | MutableMapping[str, Any] | None = None,
 ) -> dict[str, str]:
     """Return cached fallback translation templates for the current language."""
 
-    if isinstance(entry_data, MutableMapping):
+    if isinstance(entry_data, EntryRuntime):
+        cached = entry_data.fallback_translations
+        if isinstance(cached, dict):
+            return cached
+    elif isinstance(entry_data, MutableMapping):
         cached = entry_data.get(FALLBACK_TRANSLATIONS_KEY)
         if isinstance(cached, dict):
             return cached
@@ -59,7 +64,9 @@ async def async_get_fallback_translations(
 
     fallbacks = get_fallback_translations(language)
 
-    if isinstance(entry_data, MutableMapping):
+    if isinstance(entry_data, EntryRuntime):
+        entry_data.fallback_translations = fallbacks
+    elif isinstance(entry_data, MutableMapping):
         entry_data[FALLBACK_TRANSLATIONS_KEY] = fallbacks
 
     return fallbacks

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.termoweb"
   ],
   "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.1a1"
+  "version": "2.0.1a2"
 }

--- a/custom_components/termoweb/number.py
+++ b/custom_components/termoweb/number.py
@@ -61,6 +61,7 @@ from .heater import (
 from .i18n import async_get_fallback_translations, attach_fallbacks, format_fallback
 from .identifiers import build_heater_entity_unique_id
 from .inventory import Inventory, boostable_accumulator_details_for_entry
+from .runtime import require_runtime
 from .utils import float_or_none
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,12 +95,11 @@ async def _restore_boost_value(
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up boost configuration number entities for accumulator nodes."""
+    runtime = require_runtime(hass, entry.entry_id)
+    coordinator = runtime.coordinator
+    dev_id = runtime.dev_id
 
-    data = hass.data[DOMAIN][entry.entry_id]
-    coordinator = data["coordinator"]
-    dev_id = data["dev_id"]
-
-    fallbacks = await async_get_fallback_translations(hass, data)
+    fallbacks = await async_get_fallback_translations(hass, runtime)
     attach_fallbacks(coordinator, fallbacks)
 
     def default_name(addr: str) -> str:
@@ -113,7 +113,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
 
     heater_details, accumulator_nodes = boostable_accumulator_details_for_entry(
-        data,
+        runtime,
         default_name_simple=default_name,
         platform_name="number",
         logger=_LOGGER,

--- a/custom_components/termoweb/runtime.py
+++ b/custom_components/termoweb/runtime.py
@@ -1,0 +1,118 @@
+"""Runtime container helpers for TermoWeb config entries."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Iterator, MutableMapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .inventory import Inventory
+
+if TYPE_CHECKING:
+    from .backend import Backend, WsClientProto
+    from .backend.base import HttpClientProto
+    from .coordinator import EnergyStateCoordinator, StateCoordinator
+    from .hourly_poller import HourlySamplesPoller
+
+
+@dataclass(slots=True)
+class EntryRuntime(MutableMapping[str, Any]):
+    """Runtime container for a configured TermoWeb entry."""
+
+    backend: "Backend"
+    client: "HttpClientProto"
+    coordinator: "StateCoordinator"
+    energy_coordinator: "EnergyStateCoordinator"
+    dev_id: str
+    inventory: Inventory
+    hourly_poller: "HourlySamplesPoller"
+    config_entry: ConfigEntry
+    base_poll_interval: int
+    stretched: bool = False
+    poll_suspended: bool = False
+    poll_resume_unsub: Callable[[], None] | None = None
+    ws_tasks: dict[str, asyncio.Task] = field(default_factory=dict)
+    ws_clients: dict[str, "WsClientProto"] = field(default_factory=dict)
+    ws_state: dict[str, Any] = field(default_factory=dict)
+    ws_trackers: dict[str, Any] = field(default_factory=dict)
+    version: str = ""
+    brand: str = ""
+    debug: bool = False
+    boost_runtime: dict[str, dict[str, int]] = field(default_factory=dict)
+    boost_temperature: dict[str, dict[str, float]] = field(default_factory=dict)
+    climate_entities: dict[str, dict[str, str]] = field(default_factory=dict)
+    diagnostics_task: asyncio.Task | None = None
+    fallback_translations: dict[str, str] | None = None
+    recalc_poll: Callable[[], None] | None = None
+    start_ws: Callable[[str], Awaitable[None]] | None = None
+    unsub_ws_status: Callable[[], None] | None = None
+    _shutdown_complete: bool = False
+    extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def _field_keys(self) -> tuple[str, ...]:
+        """Return the public runtime fields used for mapping access."""
+
+        return tuple(
+            key
+            for key in self.__dataclass_fields__
+            if key not in {"extra"} and not key.startswith("_")
+        )
+
+    def __getitem__(self, key: str) -> Any:
+        """Return runtime attributes using mapping-style access."""
+
+        if key in self.__dataclass_fields__:
+            return getattr(self, key)
+        return self.extra[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Store runtime attributes using mapping-style access."""
+
+        if key in self.__dataclass_fields__:
+            setattr(self, key, value)
+            return
+        self.extra[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        """Delete runtime attributes using mapping-style access."""
+
+        if key in self.__dataclass_fields__:
+            raise KeyError(f"Cannot delete runtime field {key}")
+        del self.extra[key]
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over runtime keys exposed via mapping semantics."""
+
+        return iter(self._field_keys() + tuple(self.extra))
+
+    def __len__(self) -> int:
+        """Return the number of keys exposed via mapping semantics."""
+
+        return len(self._field_keys()) + len(self.extra)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a runtime attribute or ``default``."""
+
+        if key in self.__dataclass_fields__:
+            return getattr(self, key)
+        return self.extra.get(key, default)
+
+
+def require_runtime(hass: HomeAssistant, entry_id: str) -> EntryRuntime:
+    """Return the runtime container stored for ``entry_id``."""
+
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        raise LookupError("TermoWeb runtime data is unavailable")
+    runtime = domain_data.get(entry_id)
+    if not isinstance(runtime, EntryRuntime):
+        raise LookupError("TermoWeb runtime data is unavailable")
+    return runtime
+
+
+__all__ = ["EntryRuntime", "require_runtime"]

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1323,9 +1323,7 @@ custom_components/termoweb/heater.py :: DispatcherSubscriptionHelper.is_connecte
 custom_components/termoweb/heater.py :: log_skipped_nodes
     Log skipped TermoWeb nodes for a given platform.
 custom_components/termoweb/heater.py :: heater_platform_details_for_entry
-    Return heater platform metadata derived from ``entry_data``.
-custom_components/termoweb/heater.py :: heater_platform_details_for_entry._coerce_inventory
-    Return ``candidate`` when it behaves like an inventory.
+    Return heater platform metadata derived from ``runtime``.
 custom_components/termoweb/heater.py :: HeaterNodeBase.__init__
     Initialise a heater entity tied to a TermoWeb device.
 custom_components/termoweb/heater.py :: HeaterNodeBase.async_added_to_hass
@@ -1478,14 +1476,6 @@ custom_components/termoweb/inventory.py :: Inventory.heater_name_map._evict_stal
     Drop the oldest cached factory when exceeding the size limit.
 custom_components/termoweb/inventory.py :: Inventory._heater_factory_signature
     Return a stable cache key for ``factory`` when possible.
-custom_components/termoweb/inventory.py :: Inventory.require_from_context
-    Return the shared inventory associated with a Home Assistant entry.
-custom_components/termoweb/inventory.py :: Inventory.require_from_record
-    Return the cached inventory stored within ``record``.
-custom_components/termoweb/inventory.py :: _request_ws_inventory_resubscribe
-    Request websocket resubscribe when inventory becomes available.
-custom_components/termoweb/inventory.py :: store_inventory_on_entry
-    Persist inventory for an entry and notify websocket clients.
 custom_components/termoweb/inventory.py :: _normalize_node_identifier
     Return ``value`` as a normalised node identifier string.
 custom_components/termoweb/inventory.py :: normalize_node_type
@@ -1554,6 +1544,22 @@ custom_components/termoweb/inventory.py :: _normalise_with_fallback
     Return the first non-empty normalised value from ``candidates``.
 custom_components/termoweb/inventory.py :: build_node_inventory
     Return a list of :class:`Node` instances for the provided payload.
+custom_components/termoweb/runtime.py :: EntryRuntime._field_keys
+    Return the public runtime fields used for mapping access.
+custom_components/termoweb/runtime.py :: EntryRuntime.__getitem__
+    Return runtime attributes using mapping-style access.
+custom_components/termoweb/runtime.py :: EntryRuntime.__setitem__
+    Store runtime attributes using mapping-style access.
+custom_components/termoweb/runtime.py :: EntryRuntime.__delitem__
+    Delete runtime attributes using mapping-style access.
+custom_components/termoweb/runtime.py :: EntryRuntime.__iter__
+    Iterate over runtime keys exposed via mapping semantics.
+custom_components/termoweb/runtime.py :: EntryRuntime.__len__
+    Return the number of keys exposed via mapping semantics.
+custom_components/termoweb/runtime.py :: EntryRuntime.get
+    Return a runtime attribute or ``default``.
+custom_components/termoweb/runtime.py :: require_runtime
+    Return the runtime container stored for ``entry_id``.
 custom_components/termoweb/number.py :: _restore_boost_value
     Restore a boost preference from cache, state, or settings.
 custom_components/termoweb/number.py :: async_setup_entry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a1"
+version = "2.0.1a2"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -8,7 +8,9 @@ from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient, DOMAIN
+from conftest import build_entry_runtime
+from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient
+from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory, build_node_inventory
 
 
@@ -36,8 +38,13 @@ def _make_client() -> DucaheatWSClient:
     """Instantiate a websocket client with stub dependencies."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(DOMAIN, {})["entry"] = {}
     coordinator = DummyCoordinator()
+    build_entry_runtime(
+        hass=hass,
+        entry_id="entry",
+        dev_id="device",
+        coordinator=coordinator,
+    )
     client = DucaheatWSClient(
         hass,
         entry_id="entry",

--- a/tests/test_ducaheat_ws_payload_hint_clamp.py
+++ b/tests/test_ducaheat_ws_payload_hint_clamp.py
@@ -13,8 +13,8 @@ from custom_components.termoweb.backend.ducaheat_ws import (
     DucaheatWSClient,
     _PAYLOAD_WINDOW_MAX,
     _PAYLOAD_WINDOW_MIN,
-    DOMAIN,
 )
+from custom_components.termoweb.const import DOMAIN
 
 
 class DummyREST:

--- a/tests/test_ducaheat_ws_payload_hint_noop.py
+++ b/tests/test_ducaheat_ws_payload_hint_noop.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 
-from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient, DOMAIN
+from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient
+from custom_components.termoweb.const import DOMAIN
 
 
 class DummyREST:

--- a/tests/test_energy_service_registration.py
+++ b/tests/test_energy_service_registration.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from conftest import runtime_from_record
 from custom_components.termoweb import energy
 from custom_components.termoweb.energy import (
     async_register_import_energy_history_service,
@@ -63,11 +64,17 @@ async def test_service_handler_forwards_filters(
     )
     entry = SimpleNamespace(entry_id="entry-filter")
     inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-filter")
-    hass.data[energy.DOMAIN][entry.entry_id] = {
+    record = {
         "config_entry": entry,
         "inventory": inventory,
         "dev_id": "dev-filter",
     }
+    hass.data[energy.DOMAIN][entry.entry_id] = runtime_from_record(
+        record,
+        hass=hass,
+        entry_id=entry.entry_id,
+        dev_id="dev-filter",
+    )
 
     import_fn = AsyncMock()
 
@@ -113,11 +120,17 @@ async def test_service_logs_rejected_filters(
     )
     entry = SimpleNamespace(entry_id="entry-invalid")
     inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-invalid")
-    hass.data[energy.DOMAIN][entry.entry_id] = {
+    record = {
         "config_entry": entry,
         "inventory": inventory,
         "dev_id": "dev-invalid",
     }
+    hass.data[energy.DOMAIN][entry.entry_id] = runtime_from_record(
+        record,
+        hass=hass,
+        entry_id=entry.entry_id,
+        dev_id="dev-invalid",
+    )
 
     import_fn = AsyncMock(side_effect=ValueError("bad filters"))
 

--- a/tests/test_ws_sample_alias_fallback.py
+++ b/tests/test_ws_sample_alias_fallback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from conftest import runtime_from_record
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory
@@ -35,7 +36,17 @@ def test_forward_ws_sample_updates_requires_energy_coordinator() -> None:
 
     entry_id = "entry"
     coordinator = CoordinatorStub()
-    hass = SimpleNamespace(data={DOMAIN: {entry_id: {"coordinator": coordinator}}})
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    record = {
+        "coordinator": coordinator,
+        "energy_coordinator": object(),
+    }
+    hass.data[DOMAIN][entry_id] = runtime_from_record(
+        record,
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="dev",
+    )
 
     forward_ws_sample_updates(
         hass,
@@ -51,7 +62,7 @@ def test_forward_ws_sample_updates_uses_alias_fallback_and_max_lease() -> None:
     """forward_ws_sample_updates should normalise aliases and pick the largest lease."""
 
     entry_id = "entry"
-    hass = SimpleNamespace(data={DOMAIN: {entry_id: {}}})
+    hass = SimpleNamespace(data={DOMAIN: {}})
     inventory = Inventory("dev", [])
 
     object.__setattr__(
@@ -66,11 +77,17 @@ def test_forward_ws_sample_updates_uses_alias_fallback_and_max_lease() -> None:
     )
 
     coordinator = CoordinatorStub()
-    hass.data[DOMAIN][entry_id] = {
+    record = {
         "inventory": inventory,
         "coordinator": SimpleNamespace(inventory=inventory),
         "energy_coordinator": coordinator,
     }
+    hass.data[DOMAIN][entry_id] = runtime_from_record(
+        record,
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="dev",
+    )
 
     forward_ws_sample_updates(
         hass,

--- a/tests/test_ws_sample_alias_merge.py
+++ b/tests/test_ws_sample_alias_merge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from conftest import runtime_from_record
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory
@@ -34,7 +35,7 @@ def test_forward_ws_sample_updates_merges_inventory_aliases() -> None:
     """forward_ws_sample_updates should canonicalise inventory alias maps."""
 
     entry_id = "entry"
-    hass = SimpleNamespace(data={DOMAIN: {entry_id: {}}})
+    hass = SimpleNamespace(data={DOMAIN: {}})
     inventory = Inventory("dev", [])
 
     object.__setattr__(
@@ -49,11 +50,17 @@ def test_forward_ws_sample_updates_merges_inventory_aliases() -> None:
     )
 
     coordinator = CoordinatorStub()
-    hass.data[DOMAIN][entry_id] = {
+    record = {
         "inventory": inventory,
         "coordinator": SimpleNamespace(inventory=inventory),
         "energy_coordinator": coordinator,
     }
+    hass.data[DOMAIN][entry_id] = runtime_from_record(
+        record,
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="dev",
+    )
 
     forward_ws_sample_updates(
         hass,


### PR DESCRIPTION
### Motivation
- Introduce a single typed runtime container so every config entry stores exactly one runtime object and platforms stop re-deriving or falling back to ad-hoc mapping access patterns.
- Eliminate scattered inventory/record fallback access and centralise entry-scoped state access via `require_runtime(...)` to enforce the invariant that inventory is created once at setup.

### Description
- Add `custom_components/termoweb/runtime.py` with a dataclass `EntryRuntime` and accessor `require_runtime(...)`, and make it behave as a mapping for backward interop.  
- Replace ad-hoc `hass.data[DOMAIN][entry_id]` mapping usage across platforms and helpers with the typed runtime (updated `__init__.py`, `climate.py`, `sensor.py`, `button.py`, `binary_sensor.py`, `number.py`, `energy.py`, `heater.py`, `diagnostics.py`, `backend/*`, `i18n.py`, `utils.py`, `inventory.py`).  
- Remove inventory-on-record helpers from the public inventory API surface and route inventory access through `EntryRuntime.inventory` and `require_runtime`, updating `boostable_accumulator_details_for_entry` and `heater_platform_details_for_entry` to accept a runtime.  
- Add test helpers and runtime conversion shims used in tests (new fixtures `runtime_factory` and `runtime_from_record`, plus an autouse conversion shim) and update tests to use runtime-backed records.  
- Bump version to `2.0.1a2` in `manifest.json` and `pyproject.toml` and update `docs/function_map.txt` to document the new runtime API.

### Testing
- Ran `uv run ruff format .` which completed successfully to normalise formatting.  
- Ran `uv run ruff check .` which reported existing lint/typing findings across the repo (these are unrelated repository-wide issues and remain outstanding).  
- Ran `uv run python -m compileall custom_components/termoweb` which succeeded and ensured modules compile.  
- Ran the test suite via `timeout 30s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing` and follow-up `uv run pytest` during development; tests collected successfully but multiple tests failed (initial import errors were addressed by shimming tests to produce `EntryRuntime` instances; subsequent runs show many failing tests remain and the run hit time limits), so further targeted test fixes and lint cleanups will be needed before all tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cad4804fc83298c63d1dbb086d235)