### PR TITLE
Core: harden vendor boundary (entities vendor-agnostic)

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -1,17 +1,13 @@
 {
-  "domain": "termoweb",
-  "name": "TermoWeb",
-  "after_dependencies": ["recorder"],
-  "codeowners": [
-    "@ha-termoweb"
-  ],
-  "config_flow": true,
-  "documentation": "https://github.com/ha-termoweb/ha-termoweb#readme",
-  "iot_class": "cloud_push",
-  "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
-  "loggers": [
-    "custom_components.termoweb"
-  ],
-  "requirements": ["python-socketio==5.16.0"],
-  "version": "2.0.1a4"
+    "domain": "termoweb",
+    "name": "TermoWeb",
+    "after_dependencies": ["recorder"],
+    "codeowners": ["@ha-termoweb"],
+    "config_flow": true,
+    "documentation": "https://github.com/ha-termoweb/ha-termoweb#readme",
+    "iot_class": "cloud_push",
+    "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
+    "loggers": ["custom_components.termoweb"],
+    "requirements": ["python-socketio==5.16.0"],
+    "version": "2.0.1a5",
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -112,6 +112,8 @@ custom_components/termoweb/backend/base.py :: Backend.brand
     Return the configured brand.
 custom_components/termoweb/backend/base.py :: Backend.client
     Return the HTTP client associated with this backend.
+custom_components/termoweb/backend/base.py :: Backend.set_node_settings
+    Update node settings using the backend client.
 custom_components/termoweb/backend/base.py :: Backend.create_ws_client
     Create a websocket client for the given device.
 custom_components/termoweb/backend/base.py :: Backend.fetch_hourly_samples
@@ -192,6 +194,10 @@ custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._serialise_
     Serialise preset temperatures into the API schema.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._safe_temperature
     Defensively format inbound temperature values.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatBackend._should_cancel_boost
+    Return True when accumulator updates should cancel boost.
+custom_components/termoweb/backend/ducaheat.py :: DucaheatBackend.set_node_settings
+    Update node settings while applying Ducaheat boost heuristics.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatBackend.create_ws_client
     Instantiate the unified websocket client for Ducaheat.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatBackend.fetch_hourly_samples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a4"
+version = "2.0.1a5"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,10 @@ def build_entry_runtime(
 
     if backend is None:
         backend = SimpleNamespace(
-            client=client, brand=brand, create_ws_client=MagicMock()
+            client=client,
+            brand=brand,
+            create_ws_client=MagicMock(),
+            set_node_settings=AsyncMock(),
         )
 
     if hourly_poller is None:
@@ -140,6 +143,12 @@ def _auto_runtime_conversion(monkeypatch: pytest.MonkeyPatch) -> None:
 
     from custom_components.termoweb import runtime as runtime_module
     from custom_components.termoweb.const import DOMAIN
+    from custom_components.termoweb import binary_sensor as binary_sensor_module
+    from custom_components.termoweb import button as button_module
+    from custom_components.termoweb import climate as climate_module
+    from custom_components.termoweb import number as number_module
+    from custom_components.termoweb import heater as heater_module
+    from custom_components.termoweb import sensor as sensor_module
 
     original = runtime_module.require_runtime
 
@@ -166,6 +175,15 @@ def _auto_runtime_conversion(monkeypatch: pytest.MonkeyPatch) -> None:
             raise
 
     monkeypatch.setattr(runtime_module, "require_runtime", _patched_require_runtime)
+    for module in (
+        binary_sensor_module,
+        button_module,
+        climate_module,
+        heater_module,
+        number_module,
+        sensor_module,
+    ):
+        monkeypatch.setattr(module, "require_runtime", _patched_require_runtime)
 
 
 def _coerce_inventory(inventory: Any) -> tuple["Inventory" | None, list[Any]]:


### PR DESCRIPTION
### Motivation
- Keep entity/platform modules vendor-agnostic by moving vendor-specific write heuristics into backend layer.
- Provide a single backend entrypoint for node-settings writes so entities do not cast or special-case vendor clients.
- Use the runtime container (`EntryRuntime`) as authoritative runtime state for WS health checks and to locate the backend.

### Description
- Add `BoostContext` dataclass and a `Backend.set_node_settings(...)` helper in `backend/base.py` to provide a canonical write API and carry boost hints. 
- Implement Ducaheat-specific boost cancellation heuristics in `DucaheatBackend._should_cancel_boost(...)` and override `set_node_settings(...)` in `backend/ducaheat.py` to translate `BoostContext` into the `cancel_boost` flag for segmented writes.
- Route accumulator (`acm`) settings writes from climate entities through the runtime backend by building a `BoostContext` in `climate.py` and calling `backend.set_node_settings(...)` instead of calling vendor clients directly.
- Tie the climate refresh-fallback WS health check to the `EntryRuntime.ws_state` via `require_runtime(...)` so the entity consults a single runtime source instead of ad-hoc hass.data dict access.
- Update tests and test scaffolding to use the runtime-backed backend helper (tests and `conftest.py` were updated to provide a `backend.set_node_settings` stub), and update docs/function map entries accordingly.
- Bump version to `2.0.1a5` in `custom_components/termoweb/manifest.json` and `pyproject.toml`.

### Testing
- Ran lint/format checks with `uv run ruff check` and `uv run ruff format` on modified files; checks passed for the updated files.
- Ran targeted unit tests: `uv run pytest tests/test_backend_base.py tests/test_backend_ducaheat.py tests/test_climate.py` and the suite for those tests passed (`71 passed`).
- Ran an initial full coverage run `uv run timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` which timed out (investigation needed for unrelated long-running tests); targeted fixes limited this PR to the backend/climate surface only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf5c0ab4483298467d9b807bac203)