### PR TITLE
Fix manifest.json JSON validity and tighten version bump discipline

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a8",
+    "version": "2.0.1a9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a8"
+version = "2.0.1a9"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]


### PR DESCRIPTION
### Motivation
- Ensure `custom_components/termoweb/manifest.json` is valid JSON and keep package/version discipline by aligning the integration version across the repository to the next PR target `2.0.1a9`.

### Description
- Removed the trailing comma and updated the `version` field to `"2.0.1a9"` in `custom_components/termoweb/manifest.json` and bumped `version = "2.0.1a9"` in `pyproject.toml` so both files match.

### Testing
- Ran `uv run python -m compileall custom_components/termoweb` which succeeded and confirmed the package compiles. 
- Ran `uv run ruff check .` which reported pre-existing lint issues (not introduced by this change). 
- Ran `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` which timed out (tests collection/execution exceeded the 30s timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc27da15883299f004a1cbe3a9fcc)