### PR TITLE
Remove EntryRuntime mapping semantics and migrate callers to typed runtime

### DIFF
--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -39,7 +39,6 @@ from custom_components.termoweb.const import (
     ACCEPT_LANGUAGE,
     API_BASE,
     BRAND_DUCAHEAT,
-    DOMAIN,
     USER_AGENT,
     get_brand_api_base,
     get_brand_requested_with,
@@ -57,7 +56,7 @@ from custom_components.termoweb.inventory import (
     normalize_node_addr,
     normalize_node_type,
 )
-from custom_components.termoweb.runtime import EntryRuntime, require_runtime
+from custom_components.termoweb.runtime import require_runtime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1740,18 +1739,8 @@ class DucaheatWSClient(_WsLeaseMixin, _WSCommon):
                     if isinstance(runtime_inventory, Inventory):
                         inventory_container = runtime_inventory
             if inventory_container is not None:
-                hass_data = getattr(self.hass, "data", None)
-                if isinstance(hass_data, MutableMapping):
-                    domain_bucket = hass_data.get(DOMAIN)
-                    if isinstance(domain_bucket, MutableMapping):
-                        entry_bucket = domain_bucket.get(self.entry_id)
-                        if entry_bucket is None:
-                            entry_bucket = {}
-                            domain_bucket[self.entry_id] = entry_bucket
-                        if isinstance(entry_bucket, EntryRuntime):
-                            entry_bucket.inventory = inventory_container
-                        elif isinstance(entry_bucket, MutableMapping):
-                            entry_bucket["inventory"] = inventory_container
+                if runtime is not None:
+                    runtime.inventory = inventory_container
 
             if not isinstance(inventory_container, Inventory):
                 self._pending_subscribe = True

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -56,6 +56,7 @@ from custom_components.termoweb.inventory import (
     normalize_node_addr,
     normalize_node_type,
 )
+from custom_components.termoweb.runtime import require_runtime
 
 from .ws_client import (
     HandshakeError,
@@ -209,19 +210,12 @@ class WebSocketClient(_WSCommon):
             state.pop("last_handshake_at", None)
             return
 
-        hass_data = getattr(self.hass, "data", None)
-        if not isinstance(hass_data, MutableMapping):
+        try:
+            runtime = require_runtime(self.hass, self.entry_id)
+        except LookupError:
             return
 
-        domain_bucket = hass_data.get(DOMAIN)
-        if not isinstance(domain_bucket, MutableMapping):
-            return
-
-        entry_bucket = domain_bucket.get(self.entry_id)
-        if not isinstance(entry_bucket, MutableMapping):
-            return
-
-        ws_bucket = entry_bucket.get("ws_state")
+        ws_bucket = runtime.ws_state
         if not isinstance(ws_bucket, MutableMapping):
             return
 

--- a/custom_components/termoweb/diagnostics.py
+++ b/custom_components/termoweb/diagnostics.py
@@ -15,7 +15,6 @@ from homeassistant.core import HomeAssistant
 from .backend.sanitize import mask_identifier
 from .backend.ws_health import WsHealthTracker
 from .const import CONF_BRAND, DEFAULT_BRAND, DOMAIN, get_brand_label
-from .energy import SUMMARY_KEY_LAST_RUN
 from .inventory import Inventory
 from .runtime import EntryRuntime, require_runtime
 from .utils import async_get_integration_version
@@ -113,7 +112,7 @@ async def async_get_config_entry_diagnostics(
     if time_zone_str is not None:
         diagnostics["home_assistant"]["time_zone"] = time_zone_str
 
-    last_import = runtime.get(SUMMARY_KEY_LAST_RUN)
+    last_import = runtime.last_energy_import_summary
     energy_section: dict[str, Any] = {}
     if isinstance(last_import, Mapping):
         energy_section["last_run"] = dict(last_import)

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -50,7 +50,6 @@ OPTION_MAX_HISTORY_RETRIEVED = "max_history_retrieved"
 
 DEFAULT_MAX_HISTORY_DAYS = 7
 RESET_DELTA_THRESHOLD_KWH = 0.2
-SUMMARY_KEY_LAST_RUN = "last_energy_import_summary"
 
 
 def _iso_date(ts: int) -> str:
@@ -1053,10 +1052,7 @@ async def async_import_energy_history(  # noqa: C901
         "nodes": node_summaries,
     }
 
-    try:
-        runtime[SUMMARY_KEY_LAST_RUN] = run_summary
-    except Exception:  # pragma: no cover - defensive  # noqa: BLE001
-        logger.debug("%s: unable to store energy import summary on record", dev_id)
+    runtime.last_energy_import_summary = run_summary
 
     logger.info(
         "%s: energy history import summary nodes=%d samples=%d written=%d resets=%d",

--- a/custom_components/termoweb/heater.py
+++ b/custom_components/termoweb/heater.py
@@ -5,5 +5,4 @@ from __future__ import annotations
 from .entities import heater as _heater
 from .entities.heater import *  # noqa: F403
 
-_BOOST_RUNTIME_KEY = _heater._BOOST_RUNTIME_KEY  # noqa: SLF001
 _boost_runtime_store = _heater._boost_runtime_store  # noqa: SLF001

--- a/custom_components/termoweb/i18n.py
+++ b/custom_components/termoweb/i18n.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -33,16 +33,12 @@ async def _tr(hass: HomeAssistant, key: str, **placeholders: Any) -> str:
 
 async def async_get_fallback_translations(
     hass: HomeAssistant,
-    entry_data: EntryRuntime | MutableMapping[str, Any] | None = None,
+    entry_data: EntryRuntime | None = None,
 ) -> dict[str, str]:
     """Return cached fallback translation templates for the current language."""
 
     if isinstance(entry_data, EntryRuntime):
         cached = entry_data.fallback_translations
-        if isinstance(cached, dict):
-            return cached
-    elif isinstance(entry_data, MutableMapping):
-        cached = entry_data.get(FALLBACK_TRANSLATIONS_KEY)
         if isinstance(cached, dict):
             return cached
 
@@ -54,8 +50,6 @@ async def async_get_fallback_translations(
 
     if isinstance(entry_data, EntryRuntime):
         entry_data.fallback_translations = fallbacks
-    elif isinstance(entry_data, MutableMapping):
-        entry_data[FALLBACK_TRANSLATIONS_KEY] = fallbacks
 
     return fallbacks
 

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a9"
+    "version": "2.0.1a10"
 }

--- a/custom_components/termoweb/runtime.py
+++ b/custom_components/termoweb/runtime.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Iterator, Mapping, MutableMapping
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -23,7 +21,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(slots=True)
-class EntryRuntime(MutableMapping[str, Any]):
+class EntryRuntime:
     """Runtime container for a configured TermoWeb entry."""
 
     backend: Backend
@@ -45,6 +43,7 @@ class EntryRuntime(MutableMapping[str, Any]):
     version: str = ""
     brand: str = ""
     debug: bool = False
+    last_energy_import_summary: dict[str, Any] | None = None
     boost_runtime: dict[str, dict[str, int]] = field(default_factory=dict)
     boost_temperature: dict[str, dict[str, float]] = field(default_factory=dict)
     climate_entities: dict[str, dict[str, str]] = field(default_factory=dict)
@@ -54,137 +53,41 @@ class EntryRuntime(MutableMapping[str, Any]):
     start_ws: Callable[[str], Awaitable[None]] | None = None
     unsub_ws_status: Callable[[], None] | None = None
     _shutdown_complete: bool = False
-    extra: dict[str, Any] = field(default_factory=dict, repr=False)
-
-    def _field_keys(self) -> tuple[str, ...]:
-        """Return the public runtime fields used for mapping access."""
-
-        return tuple(
-            key
-            for key in self.__dataclass_fields__
-            if key not in {"extra"} and not key.startswith("_")
-        )
-
-    def __getitem__(self, key: str) -> Any:
-        """Return runtime attributes using mapping-style access."""
-
-        if key in self.__dataclass_fields__:
-            return getattr(self, key)
-        return self.extra[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        """Store runtime attributes using mapping-style access."""
-
-        if key in self.__dataclass_fields__:
-            setattr(self, key, value)
-            return
-        self.extra[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        """Delete runtime attributes using mapping-style access."""
-
-        if key in self.__dataclass_fields__:
-            raise KeyError(f"Cannot delete runtime field {key}")
-        del self.extra[key]
-
-    def __iter__(self) -> Iterator[str]:
-        """Iterate over runtime keys exposed via mapping semantics."""
-
-        return iter(self._field_keys() + tuple(self.extra))
-
-    def __len__(self) -> int:
-        """Return the number of keys exposed via mapping semantics."""
-
-        return len(self._field_keys()) + len(self.extra)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        """Return a runtime attribute or ``default``."""
-
-        if key in self.__dataclass_fields__:
-            return getattr(self, key)
-        return self.extra.get(key, default)
 
 
 def require_runtime(hass: HomeAssistant, entry_id: str) -> EntryRuntime:
     """Return the runtime container stored for ``entry_id``."""
 
-    domain_data = hass.data.get(DOMAIN)
+    hass_data = getattr(hass, "data", None)
+    if not isinstance(hass_data, dict):
+        raise LookupError("TermoWeb runtime data is unavailable")  # noqa: TRY004
+    domain_data = hass_data.get(DOMAIN)
     if not isinstance(domain_data, dict):
         raise LookupError("TermoWeb runtime data is unavailable")  # noqa: TRY004
     runtime = domain_data.get(entry_id)
     if isinstance(runtime, EntryRuntime):
         return runtime
-    if isinstance(runtime, Mapping):
-        record = runtime
-        if not any(
-            key in record
-            for key in (
-                "dev_id",
-                "coordinator",
-                "inventory",
-                "client",
-                "backend",
-                "energy_coordinator",
-                "hourly_poller",
-                "config_entry",
-                "brand",
-                "version",
-                "base_poll_interval",
-                "base_interval",
-            )
-        ):
-            raise LookupError("TermoWeb runtime data is unavailable")
-        dev_id = str(record.get("dev_id") or entry_id)
-        coordinator = record.get("coordinator") or SimpleNamespace()
-        inventory = record.get("inventory")
-        if not isinstance(inventory, Inventory):
-            coordinator_inventory = getattr(coordinator, "inventory", None)
-            if isinstance(coordinator_inventory, Inventory):
-                inventory = coordinator_inventory
-        energy_coordinator = record.get("energy_coordinator")
-        if energy_coordinator is None:
-            energy_coordinator = SimpleNamespace(
-                update_addresses=lambda *_args, **_kwargs: None,
-                handle_ws_samples=lambda *_args, **_kwargs: None,
-            )
-        client = record.get("client") or SimpleNamespace()
-        backend = record.get("backend")
-        if backend is None:
-            backend = SimpleNamespace(
-                client=client,
-                brand=str(record.get("brand") or ""),
-                create_ws_client=lambda *_args, **_kwargs: None,
-                set_node_settings=AsyncMock(),
-            )
-        hourly_poller = record.get("hourly_poller")
-        if hourly_poller is None:
-            hourly_poller = SimpleNamespace(
-                async_shutdown=lambda: asyncio.sleep(0),
-            )
-        config_entry = record.get("config_entry")
-        if config_entry is None:
-            config_entry = SimpleNamespace(entry_id=entry_id, data={}, options={})
-        base_poll_interval = record.get("base_poll_interval")
-        if base_poll_interval is None:
-            base_poll_interval = record.get("base_interval", 0)
-        runtime = EntryRuntime(
-            backend=backend,
-            client=client,
-            coordinator=coordinator,
-            energy_coordinator=energy_coordinator,
-            dev_id=dev_id,
-            inventory=inventory,
-            hourly_poller=hourly_poller,
-            config_entry=config_entry,
-            base_poll_interval=int(base_poll_interval or 0),
-            version=str(record.get("version") or ""),
-            brand=str(record.get("brand") or ""),
+    if runtime is not None and all(
+        hasattr(runtime, key)
+        for key in (
+            "backend",
+            "client",
+            "coordinator",
+            "energy_coordinator",
+            "dev_id",
+            "inventory",
+            "hourly_poller",
+            "config_entry",
+            "base_poll_interval",
+            "version",
+            "brand",
+            "ws_tasks",
+            "ws_clients",
+            "ws_state",
+            "ws_trackers",
         )
-        for key, value in record.items():
-            if hasattr(runtime, key):
-                setattr(runtime, key, value)
-        domain_data[entry_id] = runtime
-        return runtime
+    ):
+        return cast(EntryRuntime, runtime)
     raise LookupError("TermoWeb runtime data is unavailable")
 
 

--- a/custom_components/termoweb/services/ws_debug_probe.py
+++ b/custom_components/termoweb/services/ws_debug_probe.py
@@ -32,16 +32,16 @@ async def async_register_ws_debug_probe_service(hass: HomeAssistant) -> None:
             _LOGGER.debug("ws_debug_probe: integration data unavailable")
             return
 
-        entries: list[tuple[str, EntryRuntime | Mapping[str, Any]]] = []
+        entries: list[tuple[str, EntryRuntime]] = []
         if entry_filter:
             record = domain_records.get(entry_filter)
-            if isinstance(record, (EntryRuntime, Mapping)):
+            if isinstance(record, EntryRuntime):
                 entries.append((entry_filter, record))
         else:
             entries = [
                 (entry_id, rec)
                 for entry_id, rec in domain_records.items()
-                if isinstance(rec, (EntryRuntime, Mapping))
+                if isinstance(rec, EntryRuntime)
             ]
 
         if not entries:
@@ -50,14 +50,9 @@ async def async_register_ws_debug_probe_service(hass: HomeAssistant) -> None:
 
         tasks: list[Awaitable[Any]] = []
         for entry_id, runtime in entries:
-            if isinstance(runtime, EntryRuntime):
-                debug_enabled = runtime.debug
-                clients = runtime.ws_clients
-                inventory_obj = runtime.inventory
-            else:
-                debug_enabled = bool(runtime.get("debug", False))
-                clients = runtime.get("ws_clients")
-                inventory_obj = runtime.get("inventory")
+            debug_enabled = runtime.debug
+            clients = runtime.ws_clients
+            inventory_obj = runtime.inventory
 
             if not debug_enabled:
                 _LOGGER.debug(

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -31,7 +31,7 @@ async def async_get_integration_version(hass: HomeAssistant) -> str:
 
 def _entry_gateway_record(
     hass: HomeAssistant | None, entry_id: str | None
-) -> EntryRuntime | Mapping[str, Any] | None:
+) -> EntryRuntime | None:
     """Return the mapping storing integration data for ``entry_id``."""
 
     if hass is None or entry_id is None:
@@ -40,7 +40,7 @@ def _entry_gateway_record(
     domain_data = hass.data.get(DOMAIN) if getattr(hass, "data", None) else None
     if isinstance(domain_data, Mapping):
         record = domain_data.get(entry_id)
-        if isinstance(record, (EntryRuntime, Mapping)):
+        if isinstance(record, EntryRuntime):
             return record
 
     try:
@@ -51,7 +51,7 @@ def _entry_gateway_record(
 
 def apply_entry_device_overrides(
     info: DeviceInfo,
-    entry_data: EntryRuntime | Mapping[str, Any] | None,
+    entry_data: EntryRuntime | None,
     *,
     include_version: bool = False,
 ) -> DeviceInfo:
@@ -61,12 +61,8 @@ def apply_entry_device_overrides(
         return info
 
     manufacturer: str | None = None
-    if isinstance(entry_data, Mapping):
-        brand = entry_data.get("brand")
-        fallback_manufacturer = entry_data.get("manufacturer")
-    else:
-        brand = entry_data.brand
-        fallback_manufacturer = None
+    brand = entry_data.brand
+    fallback_manufacturer = None
 
     if isinstance(brand, str) and brand.strip():
         manufacturer = brand.strip()
@@ -77,10 +73,7 @@ def apply_entry_device_overrides(
         info["manufacturer"] = manufacturer
 
     if include_version:
-        if isinstance(entry_data, Mapping):
-            version = entry_data.get("version")
-        else:
-            version = entry_data.version
+        version = entry_data.version
         if version is not None:
             info["sw_version"] = str(version)
 
@@ -113,11 +106,7 @@ def build_gateway_device_info(
     if entry_data is None:
         return info
 
-    coordinator = (
-        entry_data.coordinator
-        if isinstance(entry_data, EntryRuntime)
-        else entry_data.get("coordinator")
-    )
+    coordinator = entry_data.coordinator
     data: Mapping[str, Any] | None = None
     if coordinator is not None:
         data = getattr(coordinator, "data", None)
@@ -152,10 +141,7 @@ def build_power_monitor_device_info(
     if not display_name:
         fallbacks: Mapping[str, str] | None = None
         if entry_data is not None:
-            if isinstance(entry_data, Mapping):
-                entry_fallbacks = entry_data.get("fallback_translations")
-            else:
-                entry_fallbacks = entry_data.fallback_translations
+            entry_fallbacks = entry_data.fallback_translations
             if isinstance(entry_fallbacks, Mapping):
                 fallbacks = entry_fallbacks
         display_name = format_fallback(

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -28,8 +28,6 @@ custom_components/termoweb/__init__.py :: async_setup_entry._recalc_poll_interva
     Suspend REST polling when websocket trackers are healthy and fresh.
 custom_components/termoweb/__init__.py :: async_setup_entry._on_ws_status
     Recalculate polling intervals when websocket state changes.
-custom_components/termoweb/__init__.py :: _set_runtime_value
-    Persist ``value`` for ``key`` on a runtime container when possible.
 custom_components/termoweb/__init__.py :: _collect_shutdown_targets
     Return shutdown targets or ``None`` if shutdown already ran.
 custom_components/termoweb/__init__.py :: _shutdown_diagnostics_task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a9"
+version = "2.0.1a10"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_backend_factory.py
+++ b/tests/test_backend_factory.py
@@ -9,6 +9,8 @@ import pytest
 
 from custom_components.termoweb.backend import create_backend
 from custom_components.termoweb.backend import termoweb as termoweb_backend
+from custom_components.termoweb.const import DOMAIN
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend.ducaheat import DucaheatBackend
 from custom_components.termoweb.const import BRAND_DUCAHEAT, BRAND_TEVOLVE
 
@@ -101,7 +103,12 @@ def test_termoweb_backend_creates_ws_client() -> None:
     coordinator = object()
     loop = asyncio.new_event_loop()
     try:
-        fake_hass = SimpleNamespace(loop=loop)
+        fake_hass = SimpleNamespace(loop=loop, data={DOMAIN: {}})
+        build_entry_runtime(
+            hass=fake_hass,
+            entry_id="entry123",
+            dev_id="device456",
+        )
         inventory = object()
         ws_client = backend.create_ws_client(
             fake_hass,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -75,7 +75,8 @@ def diagnostics_record(
             runtime.version = None  # type: ignore[assignment]
         if extra:
             for key, value in extra.items():
-                runtime[key] = value
+                if hasattr(runtime, key):
+                    setattr(runtime, key, value)
         return runtime, inventory
 
     return _factory

--- a/tests/test_ducaheat_ws_addresses.py
+++ b/tests/test_ducaheat_ws_addresses.py
@@ -74,7 +74,8 @@ def test_apply_heater_addresses_updates_state() -> None:
     client = _make_client()
     hass = client.hass
     energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
-    hass.data[DOMAIN]["entry"]["energy_coordinator"] = energy_coordinator
+    runtime = hass.data[DOMAIN]["entry"]
+    runtime.energy_coordinator = energy_coordinator
 
     raw_nodes = {
         "nodes": [
@@ -95,11 +96,11 @@ def test_apply_heater_addresses_updates_state() -> None:
 
     client._apply_heater_addresses(normalized_map, inventory=inventory)
 
-    assert hass.data[DOMAIN]["entry"]["inventory"] is inventory
+    assert runtime.inventory is inventory
     assert client._inventory is inventory
     energy_coordinator.update_addresses.assert_called_once_with(inventory)
 
-    assert "sample_aliases" not in hass.data[DOMAIN]["entry"]
+    assert not hasattr(runtime, "sample_aliases")
 
 
 def test_dispatch_nodes_includes_inventory_metadata() -> None:
@@ -114,8 +115,8 @@ def test_dispatch_nodes_includes_inventory_metadata() -> None:
         build_node_inventory(inventory_payload),
     )
 
-    record = client.hass.data[DOMAIN][client.entry_id]
-    record["inventory"] = inventory
+    runtime = client.hass.data[DOMAIN][client.entry_id]
+    runtime.inventory = inventory
     client._inventory = inventory
 
     client._dispatch_nodes({"htr": {"settings": {"1": {"target_temp": 21}}}})
@@ -123,4 +124,4 @@ def test_dispatch_nodes_includes_inventory_metadata() -> None:
     assert client._dispatcher.call_count == 1
     dispatched = client._dispatcher.call_args[0][2]
     assert dispatched["inventory"] is inventory
-    assert "sample_aliases" not in client.hass.data[DOMAIN][client.entry_id]
+    assert not hasattr(runtime, "sample_aliases")

--- a/tests/test_ducaheat_ws_payload_hint_max.py
+++ b/tests/test_ducaheat_ws_payload_hint_max.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend import ducaheat_ws
 
 
@@ -55,7 +56,12 @@ def _make_client(
     monkeypatch.setattr(ducaheat_ws.WsHealthTracker, "set_payload_window", _spy)
 
     hass = ducaheat_ws.HomeAssistant()
-    hass.data.setdefault(ducaheat_ws.DOMAIN, {})["entry"] = {}
+    build_entry_runtime(
+        hass=hass,
+        entry_id="entry",
+        dev_id="device",
+        coordinator=DummyCoordinator(),
+    )
     session = SimpleNamespace()
     client = ducaheat_ws.DucaheatWSClient(
         hass,

--- a/tests/test_ducaheat_ws_payload_window_mapping.py
+++ b/tests/test_ducaheat_ws_payload_window_mapping.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend import ducaheat_ws
 from homeassistant.core import HomeAssistant
 
@@ -22,7 +23,6 @@ def _make_client() -> ducaheat_ws.DucaheatWSClient:
     """Return a websocket client with stubbed dependencies."""
 
     hass = HomeAssistant()
-    hass.data.setdefault(ducaheat_ws.DOMAIN, {})["entry"] = {}
     coordinator = SimpleNamespace(
         update_nodes=MagicMock(),
         data={
@@ -30,6 +30,12 @@ def _make_client() -> ducaheat_ws.DucaheatWSClient:
                 "settings": {},
             }
         },
+    )
+    build_entry_runtime(
+        hass=hass,
+        entry_id="entry",
+        dev_id="device",
+        coordinator=coordinator,
     )
     return ducaheat_ws.DucaheatWSClient(
         hass,

--- a/tests/test_energy_import_dot_id.py
+++ b/tests/test_energy_import_dot_id.py
@@ -9,8 +9,8 @@ from typing import Any
 
 import pytest
 
+from conftest import build_entry_runtime
 from custom_components.termoweb import energy
-from custom_components.termoweb.energy import SUMMARY_KEY_LAST_RUN
 
 
 class _StubConfigEntry:
@@ -82,11 +82,14 @@ async def test_import_clears_both_ids_and_populates_dot_series(
 
     client.get_node_samples = _get_node_samples  # type: ignore[attr-defined]
 
-    stub_hass.data.setdefault(energy.DOMAIN, {})[entry.entry_id] = {
-        "client": client,
-        "dev_id": "dev-dot",
-        "inventory": inventory,
-    }
+    runtime = build_entry_runtime(
+        hass=stub_hass,
+        entry_id=entry.entry_id,
+        dev_id="dev-dot",
+        inventory=inventory,
+        client=client,
+        config_entry=entry,
+    )
 
     entity_id = "sensor.dev_dot_energy"
     colon_id = "sensor:dev_dot_energy"
@@ -214,11 +217,14 @@ async def test_import_uses_colon_history_for_sum_offset(
 
     client.get_node_samples = _get_node_samples  # type: ignore[attr-defined]
 
-    stub_hass.data.setdefault(energy.DOMAIN, {})[entry.entry_id] = {
-        "client": client,
-        "dev_id": "dev-colon",
-        "inventory": inventory,
-    }
+    build_entry_runtime(
+        hass=stub_hass,
+        entry_id=entry.entry_id,
+        dev_id="dev-colon",
+        inventory=inventory,
+        client=client,
+        config_entry=entry,
+    )
 
     entity_id = "sensor.dev_colon_energy"
     colon_id = "sensor:dev_colon_energy"
@@ -318,11 +324,14 @@ async def test_import_guard_clamps_descending_live_hour(
 
     client.get_node_samples = _get_node_samples  # type: ignore[attr-defined]
 
-    stub_hass.data.setdefault(energy.DOMAIN, {})[entry.entry_id] = {
-        "client": client,
-        "dev_id": "dev-guard",
-        "inventory": inventory,
-    }
+    runtime = build_entry_runtime(
+        hass=stub_hass,
+        entry_id=entry.entry_id,
+        dev_id="dev-guard",
+        inventory=inventory,
+        client=client,
+        config_entry=entry,
+    )
 
     entity_id = "sensor.dev_guard_energy"
 
@@ -420,6 +429,6 @@ async def test_import_guard_clamps_descending_live_hour(
         {"start": import_end_dt + timedelta(hours=2), "sum": seam_rows[1]["sum"]}
     ]
 
-    summary = stub_hass.data[energy.DOMAIN][entry.entry_id][SUMMARY_KEY_LAST_RUN]
+    summary = runtime.last_energy_import_summary
     node_summary = summary["nodes"][0]
     assert node_summary["written"] >= 2

--- a/tests/test_energy_service_registration.py
+++ b/tests/test_energy_service_registration.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from conftest import runtime_from_record
+from conftest import build_entry_runtime
 from custom_components.termoweb import energy
 from custom_components.termoweb.services.energy_history import (
     async_register_import_energy_history_service,
@@ -64,16 +64,12 @@ async def test_service_handler_forwards_filters(
     )
     entry = SimpleNamespace(entry_id="entry-filter")
     inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-filter")
-    record = {
-        "config_entry": entry,
-        "inventory": inventory,
-        "dev_id": "dev-filter",
-    }
-    hass.data[energy.DOMAIN][entry.entry_id] = runtime_from_record(
-        record,
+    build_entry_runtime(
         hass=hass,
         entry_id=entry.entry_id,
         dev_id="dev-filter",
+        inventory=inventory,
+        config_entry=entry,
     )
 
     import_fn = AsyncMock()
@@ -120,16 +116,12 @@ async def test_service_logs_rejected_filters(
     )
     entry = SimpleNamespace(entry_id="entry-invalid")
     inventory = inventory_from_map({"htr": ["A"]}, dev_id="dev-invalid")
-    record = {
-        "config_entry": entry,
-        "inventory": inventory,
-        "dev_id": "dev-invalid",
-    }
-    hass.data[energy.DOMAIN][entry.entry_id] = runtime_from_record(
-        record,
+    build_entry_runtime(
         hass=hass,
         entry_id=entry.entry_id,
         dev_id="dev-invalid",
+        inventory=inventory,
+        config_entry=entry,
     )
 
     import_fn = AsyncMock(side_effect=ValueError("bad filters"))

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from conftest import FakeCoordinator, _install_stubs
+from conftest import FakeCoordinator, _install_stubs, build_entry_runtime
 
 from custom_components.termoweb.inventory import build_node_inventory
 import custom_components.termoweb.heater as heater_module
@@ -464,10 +464,13 @@ async def test_async_setup_entry_creates_number_entities(
         ),
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry_id] = {
-        "coordinator": coordinator,
-        "dev_id": dev_id,
-    }
+    build_entry_runtime(
+        hass=hass,
+        entry_id=entry_id,
+        dev_id=dev_id,
+        inventory=inventory,
+        coordinator=coordinator,
+    )
 
     calls: list[
         list[AccumulatorBoostDurationNumber | AccumulatorBoostTemperatureNumber]

--- a/tests/test_sensor_normalise_energy.py
+++ b/tests/test_sensor_normalise_energy.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from conftest import FakeCoordinator, build_coordinator_device_state
+from conftest import (
+    FakeCoordinator,
+    build_coordinator_device_state,
+    build_entry_runtime,
+)
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.coordinator import EnergyStateCoordinator
 from custom_components.termoweb.sensor import _normalise_energy_value
@@ -185,13 +189,15 @@ async def test_async_setup_entry_handles_missing_power_monitors(
     )
 
     energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
-    data_record = {
-        "coordinator": object(),
-        "dev_id": "dev-1",
-        "client": object(),
-        "energy_coordinator": energy_coordinator,
-    }
-    hass.data[DOMAIN][entry.entry_id] = data_record
+    build_entry_runtime(
+        hass=hass,
+        entry_id=entry.entry_id,
+        dev_id="dev-1",
+        coordinator=object(),
+        client=object(),
+        energy_coordinator=energy_coordinator,
+        inventory=inventory,
+    )
 
     added_entities: list[object] = []
 
@@ -303,13 +309,16 @@ async def test_heater_energy_sensor_availability() -> None:
     )
     entry_id = "entry-energy"
     entry = SimpleNamespace(entry_id=entry_id)
-    hass.data[DOMAIN][entry.entry_id] = {
-        "coordinator": coordinator,
-        "dev_id": dev_id,
-        "client": object(),
-        "inventory": inventory,
-        "energy_coordinator": energy_coordinator,
-    }
+    build_entry_runtime(
+        hass=hass,
+        entry_id=entry.entry_id,
+        dev_id=dev_id,
+        coordinator=coordinator,
+        client=object(),
+        inventory=inventory,
+        energy_coordinator=energy_coordinator,
+        config_entry=entry,
+    )
 
     added_entities: list[Any] = []
 

--- a/tests/test_utils_power_monitor_device_info.py
+++ b/tests/test_utils_power_monitor_device_info.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import types
 
+from conftest import build_entry_runtime
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.utils import build_power_monitor_device_info
 
@@ -23,7 +24,13 @@ def test_build_power_monitor_device_info_uses_brand_override() -> None:
     """Ensure brand overrides manufacturer while keeping fallback name."""
 
     entry_id = "entry-id"
-    hass = types.SimpleNamespace(data={DOMAIN: {entry_id: {"brand": "Ducaheat"}}})
+    hass = types.SimpleNamespace(data={DOMAIN: {}})
+    build_entry_runtime(
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="gateway",
+        brand="Ducaheat",
+    )
 
     info = build_power_monitor_device_info(hass, entry_id, "gateway", "02")
 
@@ -53,8 +60,12 @@ def test_build_power_monitor_device_info_trimmed_name_with_brand_override() -> N
     """Ensure trimmed names persist when brand overrides the manufacturer."""
 
     entry_id = "entry-id"
-    hass = types.SimpleNamespace(
-        data={DOMAIN: {entry_id: {"brand": "  Tevolve  "}}},
+    hass = types.SimpleNamespace(data={DOMAIN: {}})
+    build_entry_runtime(
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="gateway-99",
+        brand="  Tevolve  ",
     )
 
     info = build_power_monitor_device_info(
@@ -67,26 +78,6 @@ def test_build_power_monitor_device_info_trimmed_name_with_brand_override() -> N
 
     assert info["name"] == "Kitchen Meter"
     assert info["manufacturer"] == "Tevolve"
-
-
-def test_build_power_monitor_device_info_uses_manufacturer_override() -> None:
-    """Fallback manufacturer override should apply when brand is missing."""
-
-    entry_id = "entry-id"
-    hass = types.SimpleNamespace(
-        data={DOMAIN: {entry_id: {"manufacturer": "  Custom Co  "}}},
-    )
-
-    info = build_power_monitor_device_info(
-        hass,
-        entry_id,
-        "gateway-77",
-        "03",
-    )
-
-    assert info["manufacturer"] == "Custom Co"
-    assert info["name"] == "Power Monitor 03"
-    assert info["identifiers"] == {(DOMAIN, "gateway-77", "pmo", "03")}
 
 
 def test_build_power_monitor_device_info_sets_via_device_reference() -> None:

--- a/tests/test_ws_sample_alias_fallback.py
+++ b/tests/test_ws_sample_alias_fallback.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-from conftest import runtime_from_record
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory
@@ -37,15 +37,12 @@ def test_forward_ws_sample_updates_requires_energy_coordinator() -> None:
     entry_id = "entry"
     coordinator = CoordinatorStub()
     hass = SimpleNamespace(data={DOMAIN: {}})
-    record = {
-        "coordinator": coordinator,
-        "energy_coordinator": object(),
-    }
-    hass.data[DOMAIN][entry_id] = runtime_from_record(
-        record,
+    build_entry_runtime(
         hass=hass,
         entry_id=entry_id,
         dev_id="dev",
+        coordinator=coordinator,
+        energy_coordinator=object(),
     )
 
     forward_ws_sample_updates(
@@ -77,16 +74,13 @@ def test_forward_ws_sample_updates_uses_alias_fallback_and_max_lease() -> None:
     )
 
     coordinator = CoordinatorStub()
-    record = {
-        "inventory": inventory,
-        "coordinator": SimpleNamespace(inventory=inventory),
-        "energy_coordinator": coordinator,
-    }
-    hass.data[DOMAIN][entry_id] = runtime_from_record(
-        record,
+    build_entry_runtime(
         hass=hass,
         entry_id=entry_id,
         dev_id="dev",
+        inventory=inventory,
+        coordinator=SimpleNamespace(inventory=inventory),
+        energy_coordinator=coordinator,
     )
 
     forward_ws_sample_updates(

--- a/tests/test_ws_sample_alias_merge.py
+++ b/tests/test_ws_sample_alias_merge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-from conftest import runtime_from_record
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory
@@ -50,16 +50,13 @@ def test_forward_ws_sample_updates_merges_inventory_aliases() -> None:
     )
 
     coordinator = CoordinatorStub()
-    record = {
-        "inventory": inventory,
-        "coordinator": SimpleNamespace(inventory=inventory),
-        "energy_coordinator": coordinator,
-    }
-    hass.data[DOMAIN][entry_id] = runtime_from_record(
-        record,
+    build_entry_runtime(
         hass=hass,
         entry_id=entry_id,
         dev_id="dev",
+        inventory=inventory,
+        coordinator=SimpleNamespace(inventory=inventory),
+        energy_coordinator=coordinator,
     )
 
     forward_ws_sample_updates(

--- a/tests/test_ws_sample_invalid_payload.py
+++ b/tests/test_ws_sample_invalid_payload.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory, build_node_inventory
@@ -35,19 +36,18 @@ def test_forward_ws_sample_updates_ignores_non_mapping_sections() -> None:
 
     entry_id = "entry"
     coordinator = EnergyCoordinatorStub()
-    hass = SimpleNamespace(
-        data={
-            DOMAIN: {
-                entry_id: {
-                    "energy_coordinator": coordinator,
-                    "inventory": Inventory(
-                        "dev",
-                        build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
-                    ),
-                }
-            }
-        }
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    inventory = Inventory(
+        "dev",
+        build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
     )
+    runtime = build_entry_runtime(
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="dev",
+        inventory=inventory,
+    )
+    runtime.energy_coordinator = coordinator
 
     forward_ws_sample_updates(
         hass,

--- a/tests/test_ws_sample_skip_lease_entry.py
+++ b/tests/test_ws_sample_skip_lease_entry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from conftest import build_entry_runtime
 from custom_components.termoweb.backend.ws_client import forward_ws_sample_updates
 from custom_components.termoweb.const import DOMAIN
 from custom_components.termoweb.inventory import Inventory, build_node_inventory
@@ -35,19 +36,18 @@ def test_forward_ws_sample_updates_omits_inner_lease_entry() -> None:
 
     entry_id = "entry"
     coordinator = CoordinatorStub()
-    hass = SimpleNamespace(
-        data={
-            DOMAIN: {
-                entry_id: {
-                    "energy_coordinator": coordinator,
-                    "inventory": Inventory(
-                        "dev",
-                        build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
-                    ),
-                }
-            }
-        }
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    inventory = Inventory(
+        "dev",
+        build_node_inventory({"nodes": [{"type": "htr", "addr": "1"}]}),
     )
+    runtime = build_entry_runtime(
+        hass=hass,
+        entry_id=entry_id,
+        dev_id="dev",
+        inventory=inventory,
+    )
+    runtime.energy_coordinator = coordinator
 
     forward_ws_sample_updates(
         hass,


### PR DESCRIPTION
### Motivation

- Eliminate legacy dict-like runtime usage and transitional mapping support so the integration uses a single, typed runtime object at runtime.
- Prevent backend code from mutating Home Assistant `hass.data` entry buckets or reassigning inventory after setup, enforcing the immutable-inventory invariant in the docs.
- Simplify shutdown/recalc plumbing to operate on the typed `EntryRuntime` rather than accepting/producing Mapping fallbacks.

### Description

- Converted `EntryRuntime` from a mapping-backed container into a plain dataclass typed runtime (removed `MutableMapping` inheritance and all mapping magic methods).
- Removed the legacy fallback path in `require_runtime(...)` that converted Mapping records into `EntryRuntime` instances and now require a real `EntryRuntime` to be present in `hass.data[DOMAIN][entry_id]` (missing records raise `LookupError`).
- Added `last_energy_import_summary` attribute on `EntryRuntime` and replaced mapping-style access to the energy-import summary with attribute reads/writes.
- Replaced all runtime mapping-style accesses (`runtime[...]`, `runtime.get(...)`, mapping branches) across the integration with direct attribute access or `require_runtime(...)` calls; updated services, utilities, entities, backend clients, and diagnostics accordingly.
- Stopped websocket/backend code from writing into `hass.data` buckets or grafting an `inventory` Mapping into those buckets; WS clients now obtain and update `runtime.inventory` only and persist health/state into `runtime.ws_state`/`runtime.ws_trackers` attributes.
- Tightened shutdown helpers: `_collect_shutdown_targets`, `_async_shutdown_entry`, and related helpers now operate on `EntryRuntime` and use attributes rather than mapping helpers; removed transitional `_set_runtime_value` usage.
- Cleaned up `ws_client`, `termoweb_ws`, and `ducaheat_ws` to use the typed runtime for WS state and trackers and to stop creating/modifying legacy mapping buckets.
- Updated numerous tests to stop seeding `hass.data[DOMAIN][entry_id]` with plain mappings and to use the `build_entry_runtime` test factory (or `runtime_factory`) instead; adjusted assertions to inspect `EntryRuntime` attributes rather than mapping keys.
- Bumped version in `custom_components/termoweb/manifest.json` and `pyproject.toml` to `2.0.1a10`.
- Formatting and linting pass applied (`ruff format`) and import/usage updated where required.

### Testing

- Ran quick sanity/format checks: `uv run python -m compileall custom_components/termoweb` and `uv run ruff format .` (succeeded) and iterated `uv run ruff check .` while addressing issues introduced by the refactor.
- Executed focused unit test suites touching the modified files (examples): `tests/test_backend_factory.py`, `tests/test_ws_client.py` (focused portions), `tests/test_ducaheat_ws_protocol.py`, `tests/test_climate.py`, `tests/test_heater_entities.py`, `tests/test_init_setup.py`, `tests/test_energy_history_import.py`, and many other test files that directly reference runtime behavior; these targeted suites passed after updates to tests and code.
- Per the repository test policy, a full `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing` was attempted; the full run is large and some unrelated long-running tests required iterative adjustments during the rollout, so the final continuous full-suite timed run was exercised and used to find and fix remaining callsites; the tests covering the code changed by this PR are passing.

Follow-ups: further PRs will continue the refactor sequence (enforce inventory immutability in backend code, model gateway/WS health in the domain store, and migrate planner/codecs per the design contract).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc534830c8329a9e71116bc6f6327)