### PR TITLE
Create planner/ package and move Ducaheat planner out of codecs

### DIFF
--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -28,7 +28,7 @@ from custom_components.termoweb.boost import (
     validate_boost_minutes,
 )
 from custom_components.termoweb.codecs.ducaheat_codec import decode_settings
-from custom_components.termoweb.codecs.ducaheat_planner import plan_command
+from custom_components.termoweb.planner.ducaheat_planner import plan_command
 from custom_components.termoweb.const import (
     BRAND_DUCAHEAT,
     NODE_SAMPLES_PATH_FMT,

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a11"
+    "version": "2.0.1a12"
 }

--- a/custom_components/termoweb/planner/__init__.py
+++ b/custom_components/termoweb/planner/__init__.py
@@ -1,0 +1,1 @@
+"""Planner package for vendor-specific sequencing."""

--- a/custom_components/termoweb/planner/ducaheat_planner.py
+++ b/custom_components/termoweb/planner/ducaheat_planner.py
@@ -19,7 +19,7 @@ from custom_components.termoweb.domain.commands import (
 )
 from custom_components.termoweb.domain.ids import NodeId, NodeType
 
-from .ducaheat_codec import (
+from custom_components.termoweb.codecs.ducaheat_codec import (
     encode_boost_command,
     encode_extra_options_command,
     encode_mode_command,
@@ -29,7 +29,7 @@ from .ducaheat_codec import (
     encode_setpoint_command,
     encode_units_command,
 )
-from .ducaheat_models import StatusWritePayload
+from custom_components.termoweb.codecs.ducaheat_models import StatusWritePayload
 
 
 @dataclass(slots=True)

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -836,11 +836,11 @@ custom_components/termoweb/codecs/ducaheat_models.py :: BoostPayload._format_boo
     Format boost temperature values.
 custom_components/termoweb/codecs/ducaheat_models.py :: BoostPayload._validate_units
     Ensure units are uppercase when provided.
-custom_components/termoweb/codecs/ducaheat_planner.py :: plan_command
+custom_components/termoweb/planner/ducaheat_planner.py :: plan_command
     Return a select→write→release plan for a single command.
-custom_components/termoweb/codecs/ducaheat_planner.py :: _build_write_call
+custom_components/termoweb/planner/ducaheat_planner.py :: _build_write_call
     Build the primary write call for the supplied command.
-custom_components/termoweb/codecs/ducaheat_planner.py :: _ensure_accumulator
+custom_components/termoweb/planner/ducaheat_planner.py :: _ensure_accumulator
     Validate that accumulator-only commands target an accumulator.
 custom_components/termoweb/codecs/ducaheat_read_models.py :: _coerce_bool
     Coerce common truthy and falsy values to ``bool``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a11"
+version = "2.0.1a12"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_ducaheat_planner.py
+++ b/tests/test_ducaheat_planner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from custom_components.termoweb.codecs.ducaheat_planner import plan_command
+from custom_components.termoweb.planner.ducaheat_planner import plan_command
 from custom_components.termoweb.domain.commands import SetMode, StopBoost
 from custom_components.termoweb.domain.ids import NodeId, NodeType
 


### PR DESCRIPTION
### Motivation
- Introduce a dedicated `planner/` package to host vendor-specific command sequencing and keep planner logic outside of the `codecs/` wire boundary. 
- This change aligns code layout with the design contract that vendor differences live under `backend/`, `codecs/`, and `planner/` only. 
- Keep the change minimal and mechanical: move the existing Ducaheat planner module without altering planner logic.

### Description
- Create `custom_components/termoweb/planner/__init__.py` and move `ducaheat_planner.py` from `codecs/` into the new `planner/` package. 
- Update imports to reference `custom_components.termoweb.planner.ducaheat_planner` from `backend/ducaheat.py` and tests. 
- Adjust internal imports inside the moved module to import codec models from `custom_components.termoweb.codecs` with fully-qualified paths. 
- Update `docs/function_map.txt` to point at the new planner path and bump the integration version to `2.0.1a12` in both `custom_components/termoweb/manifest.json` and `pyproject.toml`.

### Testing
- Ran `uv run python -m compileall custom_components/termoweb` which completed successfully. 
- Ran `timeout 30s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing` which collected and executed tests but the run exceeded the timeout and was aborted (partial test execution completed before the timeout). 
- Attempts to run `uv run python -m ruff check .` and `uv run python -m ruff format .` failed because `ruff` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e52c76c2483299f68e9b1993e5525)