### PR TITLE
Increase pytest timeout to 60s

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
-          uv run pytest --cov=custom_components.termoweb --cov-report=term-missing | tee coverage-report.txt
+          timeout 60s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing | tee coverage-report.txt
 
       - name: Enforce coverage threshold
         run: uv run coverage report --fail-under=90

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,10 @@ End users are non-technical Home Assistant operators. Documentation must be task
 * Format and lint all changes with `ruff` before committing.
 
 ## Testing Requirements
-* Execute `timeout 30s pytest --cov=custom_components.termoweb --cov-report=term-missing`.
+* Execute `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`.
 * Capture partial logs whenever the timed run aborts; treat timeouts as failures requiring investigation. 
 * During debugging, run targeted, no-coverage subsets.
-* If tests approach the 30-second limit, suspect an asynchronous wait issue and stop the run rather than letting it hang.
+* If tests approach the 60-second limit, suspect an asynchronous wait issue and stop the run rather than letting it hang.
 * Test only the code files you have changed. Do not try to fix failing tests unrelated to your changes.
 * If you remove duplicate or redundant code, remove the corresponding tests. Do not leave code or tests behind for backwards compatibility. 
 * Get 100% coverage on the code you are chaging.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ uv pip install --all-extras -r pyproject.toml -p 3.13
 Run tests with coverage:
 
 ```bash
-uv run pytest --cov=custom_components/termoweb --cov-report=term-missing
+timeout 60s uv run pytest --cov=custom_components/termoweb --cov-report=term-missing
 ```
 
 See [`docs/developer-notes.md`](docs/developer-notes.md) for backend write semantics and other


### PR DESCRIPTION
### Motivation
- Tests occasionally hit the existing 30s CI timeout even when they succeed, causing misleading failures. 
- The developer docs, guidance, and CI workflow need to be consistent and allow a safe margin for the full test suite.

### Description
- Update `AGENTS.md` to require `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` and change the guidance text from 30s to 60s. 
- Update `README.md` to show running tests with `timeout 60s uv run pytest --cov=custom_components/termoweb --cov-report=term-missing`. 
- Update `.github/workflows/tests.yml` to run the CI pytest step as `timeout 60s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing`.

### Testing
- Ran `uv run ruff format .` which completed successfully. 
- Ran `uv run ruff check .` which reported pre-existing lint issues unrelated to these documentation/CI changes and therefore failed. 
- Ran `timeout 60s uv run pytest --cov=custom_components.termoweb --cov-report=term-missing` which completed successfully (`972 passed in 25.46s`) and produced the coverage report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5d0b98a883299deb281cb8b5a423)