### PR TITLE
Backend: move REST client into backend/ + remove vendor-specific client branching from __init__

### DIFF
--- a/custom_components/termoweb/assets/INSTALL.md
+++ b/custom_components/termoweb/assets/INSTALL.md
@@ -127,7 +127,7 @@ Then, add the Lovelace resource in the UI (see step A‑3).
   The card calls `termoweb.set_schedule` (entity service). Confirm it appears in **Developer Tools → Actions**. If missing, restart Home Assistant.
 
 - **Save succeeds but nothing updates**  
-  Make sure your `prog` has exactly 168 integers in `{0,1,2}`. Check the log for `custom_components.termoweb.climate` and `custom_components.termoweb.api` lines.
+  Make sure your `prog` has exactly 168 integers in `{0,1,2}`. Check the log for `custom_components.termoweb.climate` and `custom_components.termoweb.backend.rest_client` lines.
 
 - **File paths**  
   The public resource path is `/config/www/termoweb/termoweb_schedule_card.js`. In the browser this is `/local/termoweb/termoweb_schedule_card.js`.

--- a/custom_components/termoweb/backend/__init__.py
+++ b/custom_components/termoweb/backend/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .base import Backend, HttpClientProto, WsClientProto
-from .factory import create_backend
+from .factory import create_backend, create_rest_client
 
 __all__ = [
     "Backend",
@@ -15,6 +15,7 @@ __all__ = [
     "TermoWebBackend",
     "WsClientProto",
     "create_backend",
+    "create_rest_client",
 ]
 
 
@@ -22,7 +23,7 @@ def __getattr__(name: str) -> Any:
     """Lazily import backend implementations to avoid circular imports."""
 
     if name in {"DucaheatBackend", "DucaheatRESTClient"}:
-        from .ducaheat import DucaheatBackend, DucaheatRESTClient
+        from .ducaheat import DucaheatBackend, DucaheatRESTClient  # noqa: PLC0415
 
         mapping = {
             "DucaheatBackend": DucaheatBackend,
@@ -32,7 +33,7 @@ def __getattr__(name: str) -> Any:
         globals()[name] = value
         return value
     if name == "TermoWebBackend":
-        from .termoweb import TermoWebBackend
+        from .termoweb import TermoWebBackend  # noqa: PLC0415
 
         globals()[name] = TermoWebBackend
         return TermoWebBackend

--- a/custom_components/termoweb/backend/debug.py
+++ b/custom_components/termoweb/backend/debug.py
@@ -1,0 +1,53 @@
+"""Backend debug helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from custom_components.termoweb.const import uses_ducaheat_backend
+from custom_components.termoweb.inventory import (
+    normalize_node_addr,
+    normalize_node_type,
+)
+
+
+def build_unknown_node_probe_requests(
+    brand: str,
+    dev_id: str,
+    node_type: str,
+    addr: str,
+) -> tuple[tuple[str, Mapping[str, str] | None], ...]:
+    """Return common REST endpoints to query for an unknown node type."""
+
+    dev_id_str = str(dev_id).strip()
+    normalized_type = normalize_node_type(
+        node_type,
+        use_default_when_falsey=True,
+    )
+    normalized_addr = normalize_node_addr(
+        addr,
+        use_default_when_falsey=True,
+    )
+    if not dev_id_str or not normalized_type:
+        return ()
+
+    base_path = f"/api/v2/devs/{dev_id_str}/{normalized_type}"
+    node_path = base_path if not normalized_addr else f"{base_path}/{normalized_addr}"
+
+    requests: list[tuple[str, Mapping[str, str] | None]] = []
+    seen_paths: set[str] = set()
+
+    def _append(path: str, params: Mapping[str, str] | None = None) -> None:
+        if path in seen_paths:
+            return
+        seen_paths.add(path)
+        requests.append((path, params))
+
+    if uses_ducaheat_backend(brand) and normalized_addr:
+        _append(base_path)
+
+    _append(node_path)
+    _append(f"{node_path}/settings")
+    if normalized_addr:
+        _append(f"{node_path}/samples", {"start": "0", "end": "0"})
+    return tuple(requests)

--- a/custom_components/termoweb/backend/ducaheat.py
+++ b/custom_components/termoweb/backend/ducaheat.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from aiohttp import ClientResponseError
 
-from custom_components.termoweb.api import RESTClient
 from custom_components.termoweb.backend.base import (
     Backend,
     BoostContext,
@@ -18,6 +17,7 @@ from custom_components.termoweb.backend.base import (
     fetch_normalised_hourly_samples,
 )
 from custom_components.termoweb.backend.ducaheat_ws import DucaheatWSClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 from custom_components.termoweb.backend.sanitize import (
     build_acm_boost_payload,
     mask_identifier,

--- a/custom_components/termoweb/backend/ducaheat_ws.py
+++ b/custom_components/termoweb/backend/ducaheat_ws.py
@@ -21,7 +21,7 @@ import aiohttp
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 from custom_components.termoweb.backend.ws_client import (
     DUCAHEAT_NAMESPACE,
     HandshakeError,

--- a/custom_components/termoweb/backend/factory.py
+++ b/custom_components/termoweb/backend/factory.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from custom_components.termoweb.const import uses_ducaheat_backend
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from custom_components.termoweb.const import (
+    get_brand_api_base,
+    get_brand_basic_auth,
+    uses_ducaheat_backend,
+)
 
 from .base import Backend, HttpClientProto
+from .rest_client import RESTClient
 
 
 def create_backend(*, brand: str, client: HttpClientProto) -> Backend:
@@ -18,3 +26,26 @@ def create_backend(*, brand: str, client: HttpClientProto) -> Backend:
     from . import TermoWebBackend  # noqa: PLC0415
 
     return TermoWebBackend(brand=brand, client=client)
+
+
+def create_rest_client(
+    hass: HomeAssistant, username: str, password: str, brand: str
+) -> RESTClient:
+    """Return a REST client configured for the selected brand."""
+
+    session = aiohttp_client.async_get_clientsession(hass)
+    api_base = get_brand_api_base(brand)
+    basic_auth = get_brand_basic_auth(brand)
+    if uses_ducaheat_backend(brand):
+        from .ducaheat import DucaheatRESTClient  # noqa: PLC0415
+
+        client_cls = DucaheatRESTClient
+    else:
+        client_cls = RESTClient
+    return client_cls(
+        session,
+        username,
+        password,
+        api_base=api_base,
+        basic_auth_b64=basic_auth,
+    )

--- a/custom_components/termoweb/backend/rest_client.py
+++ b/custom_components/termoweb/backend/rest_client.py
@@ -1,3 +1,5 @@
+"""REST client for the TermoWeb backend."""
+
 from __future__ import annotations
 
 import asyncio
@@ -10,8 +12,8 @@ from typing import Any
 
 import aiohttp
 
-from .backend.sanitize import mask_identifier, redact_text
-from .codecs.termoweb_codec import (
+from custom_components.termoweb.backend.sanitize import mask_identifier, redact_text
+from custom_components.termoweb.codecs.termoweb_codec import (
     build_boost_payload,
     build_extra_options_payload,
     build_settings_payload,
@@ -20,7 +22,7 @@ from .codecs.termoweb_codec import (
     decode_nodes_payload,
     decode_samples,
 )
-from .const import (
+from custom_components.termoweb.const import (
     ACCEPT_LANGUAGE,
     API_BASE,
     BASIC_AUTH_B64,
@@ -34,7 +36,7 @@ from .const import (
     get_brand_requested_with,
     get_brand_user_agent,
 )
-from .domain.commands import (
+from custom_components.termoweb.domain.commands import (
     SetExtraOptions,
     SetMode,
     SetPresetTemps,
@@ -44,7 +46,12 @@ from .domain.commands import (
     StartBoost,
     StopBoost,
 )
-from .inventory import Node, NodeDescriptor, normalize_node_addr, normalize_node_type
+from custom_components.termoweb.inventory import (
+    Node,
+    NodeDescriptor,
+    normalize_node_addr,
+    normalize_node_type,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/termoweb/backend/termoweb_ws.py
+++ b/custom_components/termoweb/backend/termoweb_ws.py
@@ -29,7 +29,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 import socketio
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 from custom_components.termoweb.backend.sanitize import (
     mask_identifier,
     redact_token_fragment,

--- a/custom_components/termoweb/backend/ws_client.py
+++ b/custom_components/termoweb/backend/ws_client.py
@@ -15,7 +15,7 @@ import aiohttp
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 from custom_components.termoweb.const import (
     BRAND_DUCAHEAT,
     BRAND_TERMOWEB,

--- a/custom_components/termoweb/config_flow.py
+++ b/custom_components/termoweb/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.data_entry_flow import FlowResult
 import voluptuous as vol
 
 from . import async_list_devices, create_rest_client
-from .api import BackendAuthError, BackendRateLimitError
+from .backend.rest_client import BackendAuthError, BackendRateLimitError
 from .const import (
     BRAND_DUCAHEAT,
     BRAND_LABELS,

--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .api import BackendAuthError, BackendRateLimitError, RESTClient
+from .backend.rest_client import BackendAuthError, BackendRateLimitError, RESTClient
 from .backend.sanitize import mask_identifier
 from .boost import coerce_int, resolve_boost_end_from_fields
 from .const import BRAND_TERMOWEB, HTR_ENERGY_UPDATE_INTERVAL, MIN_POLL_INTERVAL

--- a/custom_components/termoweb/energy.py
+++ b/custom_components/termoweb/energy.py
@@ -22,7 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .api import RESTClient
+from .backend.rest_client import RESTClient
 from .const import DOMAIN
 from .identifiers import build_heater_energy_unique_id
 from .inventory import Inventory, normalize_node_addr, normalize_node_type

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a17"
+    "version": "2.0.1a18"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -2,8 +2,6 @@
 
 custom_components/termoweb/__init__.py :: _async_import_energy_history
     Delegate to the energy helper with shared rate limiting and filters.
-custom_components/termoweb/__init__.py :: _build_unknown_node_probe_requests
-    Return common REST endpoints to query for an unknown node type.
 custom_components/termoweb/__init__.py :: _async_probe_unknown_node_types
     Log discovery probes for node types not yet supported.
 custom_components/termoweb/__init__.py :: _register_diagnostics_platform
@@ -14,8 +12,6 @@ custom_components/termoweb/__init__.py :: _async_register_diagnostics_when_ready
     Wait for diagnostics setup and register TermoWeb helpers.
 custom_components/termoweb/__init__.py :: _async_register_diagnostics_when_ready._async_import_diagnostics_module
     Import the diagnostics module without blocking the event loop.
-custom_components/termoweb/__init__.py :: create_rest_client
-    Return a REST client configured for the selected brand.
 custom_components/termoweb/__init__.py :: async_list_devices
     Call ``list_devices`` logging auth/connection issues consistently.
 custom_components/termoweb/__init__.py :: async_setup_entry
@@ -48,56 +44,6 @@ custom_components/termoweb/__init__.py :: async_migrate_entry
     Migrate a config entry; no migrations are needed yet.
 custom_components/termoweb/__init__.py :: async_update_entry_options
     Handle options updates; recompute interval if needed.
-custom_components/termoweb/api.py :: RESTClient.__init__
-    Initialise the REST client with authentication context.
-custom_components/termoweb/api.py :: RESTClient.api_base
-    Expose API base for auxiliary clients (e.g. WS).
-custom_components/termoweb/api.py :: RESTClient._request
-    Perform an HTTP request.
-custom_components/termoweb/api.py :: RESTClient._ensure_token
-    Ensure a bearer token is present; fetch if missing.
-custom_components/termoweb/api.py :: RESTClient.user_agent
-    Return the configured User-Agent string.
-custom_components/termoweb/api.py :: RESTClient.requested_with
-    Return the configured X-Requested-With header.
-custom_components/termoweb/api.py :: RESTClient.authed_headers
-    Return HTTP headers including a valid bearer token.
-custom_components/termoweb/api.py :: RESTClient.refresh_token
-    Refresh the cached bearer token immediately.
-custom_components/termoweb/api.py :: RESTClient.list_devices
-    Return normalized device list: [{'dev_id', ...}, ...].
-custom_components/termoweb/api.py :: RESTClient.get_nodes
-    Return raw nodes payload for a device (shape varies by firmware).
-custom_components/termoweb/api.py :: RESTClient.get_node_settings
-    Return settings/state for a node.
-custom_components/termoweb/api.py :: RESTClient.get_rtc_time
-    Return RTC metadata for a device's manager endpoint.
-custom_components/termoweb/api.py :: RESTClient._ensure_temperature
-    Normalise a numeric temperature to a string with one decimal.
-custom_components/termoweb/api.py :: RESTClient._ensure_prog
-    Validate and normalise a weekly program list.
-custom_components/termoweb/api.py :: RESTClient._ensure_ptemp
-    Validate preset temperatures and return formatted strings.
-custom_components/termoweb/api.py :: RESTClient._extract_samples
-    Normalise heater samples payloads into {"t", "counter"} lists.
-custom_components/termoweb/api.py :: RESTClient.set_node_settings
-    Update heater settings.
-custom_components/termoweb/api.py :: RESTClient._build_acm_extra_options_payload
-    Return a validated payload for accumulator extra options.
-custom_components/termoweb/api.py :: RESTClient.set_acm_extra_options
-    Write default boost settings for an accumulator.
-custom_components/termoweb/api.py :: RESTClient.set_acm_boost_state
-    Start or stop an accumulator boost session.
-custom_components/termoweb/api.py :: RESTClient.debug_probe_get
-    Issue a GET request with verbose logging for discovery probes.
-custom_components/termoweb/api.py :: RESTClient.get_node_samples
-    Return heater samples as list of {"t", "counter"} dicts.
-custom_components/termoweb/api.py :: RESTClient._resolve_node_descriptor
-    Return ``(node_type, addr)`` for the provided descriptor.
-custom_components/termoweb/api.py :: RESTClient._log_non_htr_payload
-    Log payloads for unsupported node types at DEBUG level.
-custom_components/termoweb/api.py :: RESTClient.normalise_ws_nodes
-    Return websocket node payloads unchanged by default.
 custom_components/termoweb/backend/__init__.py :: __getattr__
     Lazily import backend implementations to avoid circular imports.
 custom_components/termoweb/backend/base.py :: HttpClientProto.list_devices
@@ -132,6 +78,8 @@ custom_components/termoweb/backend/base.py :: normalise_sample_records
     Return sorted sample dictionaries containing ``ts`` and ``energy_wh``.
 custom_components/termoweb/backend/base.py :: fetch_normalised_hourly_samples
     Return per-node normalised samples for ``nodes`` between ``start`` and ``end``.
+custom_components/termoweb/backend/debug.py :: build_unknown_node_probe_requests
+    Return common REST endpoints to query for an unknown node type.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRequestError.__init__
     Initialise error metadata for logging and diagnostics.
 custom_components/termoweb/backend/ducaheat.py :: DucaheatRESTClient._post_segmented
@@ -306,6 +254,58 @@ custom_components/termoweb/backend/ducaheat_ws.py :: DucaheatWSClient._replay_su
     Replay cached subscription paths after a reconnect.
 custom_components/termoweb/backend/factory.py :: create_backend
     Create a backend for the given brand.
+custom_components/termoweb/backend/factory.py :: create_rest_client
+    Return a REST client configured for the selected brand.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.__init__
+    Initialise the REST client with authentication context.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.api_base
+    Expose API base for auxiliary clients (e.g. WS).
+custom_components/termoweb/backend/rest_client.py :: RESTClient._request
+    Perform an HTTP request.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._ensure_token
+    Ensure a bearer token is present; fetch if missing.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.user_agent
+    Return the configured User-Agent string.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.requested_with
+    Return the configured X-Requested-With header.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.authed_headers
+    Return HTTP headers including a valid bearer token.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.refresh_token
+    Refresh the cached bearer token immediately.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.list_devices
+    Return normalized device list: [{'dev_id', ...}, ...].
+custom_components/termoweb/backend/rest_client.py :: RESTClient.get_nodes
+    Return raw nodes payload for a device (shape varies by firmware).
+custom_components/termoweb/backend/rest_client.py :: RESTClient.get_node_settings
+    Return settings/state for a node.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.get_rtc_time
+    Return RTC metadata for a device's manager endpoint.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._ensure_temperature
+    Normalise a numeric temperature to a string with one decimal.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._ensure_prog
+    Validate and normalise a weekly program list.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._ensure_ptemp
+    Validate preset temperatures and return formatted strings.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._extract_samples
+    Normalise heater samples payloads into {"t", "counter"} lists.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.set_node_settings
+    Update heater settings.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._build_acm_extra_options_payload
+    Return a validated payload for accumulator extra options.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.set_acm_extra_options
+    Write default boost settings for an accumulator.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.set_acm_boost_state
+    Start or stop an accumulator boost session.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.debug_probe_get
+    Issue a GET request with verbose logging for discovery probes.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.get_node_samples
+    Return heater samples as list of {"t", "counter"} dicts.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._resolve_node_descriptor
+    Return ``(node_type, addr)`` for the provided descriptor.
+custom_components/termoweb/backend/rest_client.py :: RESTClient._log_non_htr_payload
+    Log payloads for unsupported node types at DEBUG level.
+custom_components/termoweb/backend/rest_client.py :: RESTClient.normalise_ws_nodes
+    Return websocket node payloads unchanged by default.
 custom_components/termoweb/backend/sanitize.py :: redact_text
     Return ``value`` with bearer tokens, emails and query tokens removed.
 custom_components/termoweb/backend/sanitize.py :: redact_token_fragment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a17"
+version = "2.0.1a18"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock
 import aiohttp
 import pytest
 
-import custom_components.termoweb.api as api
+import custom_components.termoweb.backend.rest_client as api
 from custom_components.termoweb.backend.ducaheat import (
     DucaheatRESTClient,
     DucaheatRequestError,

--- a/tests/test_api_ensure_prog.py
+++ b/tests/test_api_ensure_prog.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import aiohttp
 import pytest
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 
 
 @pytest.fixture

--- a/tests/test_api_ensure_ptemp.py
+++ b/tests/test_api_ensure_ptemp.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import aiohttp
 import pytest
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 
 
 @pytest.fixture()

--- a/tests/test_api_ensure_temperature.py
+++ b/tests/test_api_ensure_temperature.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 from tests.test_api import FakeSession
 
 

--- a/tests/test_api_request_text_failure.py
+++ b/tests/test_api_request_text_failure.py
@@ -8,7 +8,7 @@ import logging
 import aiohttp
 import pytest
 
-import custom_components.termoweb.api as api
+import custom_components.termoweb.backend.rest_client as api
 from tests.test_api import FakeSession, MockResponse
 
 

--- a/tests/test_backend_ducaheat.py
+++ b/tests/test_backend_ducaheat.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from aiohttp import ClientResponseError
 
-from custom_components.termoweb.api import RESTClient
+from custom_components.termoweb.backend.rest_client import RESTClient
 from custom_components.termoweb.backend.base import BoostContext
 from custom_components.termoweb.backend.ducaheat import (
     DucaheatBackend,

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -15,7 +15,10 @@ _install_stubs()
 
 from aiohttp import ClientError
 from custom_components.termoweb import coordinator as coord_module
-from custom_components.termoweb.api import BackendAuthError, BackendRateLimitError
+from custom_components.termoweb.backend.rest_client import (
+    BackendAuthError,
+    BackendRateLimitError,
+)
 from custom_components.termoweb.const import (
     HTR_ENERGY_UPDATE_INTERVAL,
     signal_ws_data,


### PR DESCRIPTION
### Motivation

- Isolate vendor/protocol logic under the `backend/` package so the top-level integration remains vendor-agnostic and follows the v2 architecture contract. 
- Move REST client implementation and vendor probe logic into backend-owned modules and centralise REST client construction to eliminate vendor imports/branching from `__init__.py`.
- Keep the existing public wire models and behaviours unchanged while reorganising module placement and entrypoints.

### Description

- Moved `custom_components/termoweb/api.py` into `custom_components/termoweb/backend/rest_client.py` and updated internal imports to the new module path. 
- Added `custom_components/termoweb/backend/debug.py` containing `build_unknown_node_probe_requests` and replaced the previous top-level probe helper with this backend-owned helper; `__init__.py` now calls the backend helper. 
- Moved REST client construction into the backend factory by adding `create_rest_client` to `custom_components/termoweb/backend/factory.py` and exported it from `backend.__init__`, and removed the vendor-specific client class imports/branching from `custom_components/termoweb/__init__.py`. 
- Updated imports/tests to reference `backend.rest_client`, changed tests to monkeypatch the backend factory where appropriate, regenerated the function map, and bumped version to `2.0.1a18` in `manifest.json` and `pyproject.toml`.

### Testing

- Ran `uv run python -m compileall custom_components/termoweb`, which succeeded. 
- Ran `uv run ruff format .` to apply formatting, which succeeded; `uv run ruff check .` was executed but reported lint issues/warnings (existing broad `BLE001`/style items surfaced during the transition). 
- Ran `uv run timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`, which completed successfully with the test suite passing (`954 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7d8b6854832982c086f2fb64e0cb)