### PR TITLE
Runtime: enforce EntryRuntime invariant

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a18"
+    "version": "2.0.1a19"
 }

--- a/custom_components/termoweb/runtime.py
+++ b/custom_components/termoweb/runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -67,27 +67,6 @@ def require_runtime(hass: HomeAssistant, entry_id: str) -> EntryRuntime:
     runtime = domain_data.get(entry_id)
     if isinstance(runtime, EntryRuntime):
         return runtime
-    if runtime is not None and all(
-        hasattr(runtime, key)
-        for key in (
-            "backend",
-            "client",
-            "coordinator",
-            "energy_coordinator",
-            "dev_id",
-            "inventory",
-            "hourly_poller",
-            "config_entry",
-            "base_poll_interval",
-            "version",
-            "brand",
-            "ws_tasks",
-            "ws_clients",
-            "ws_state",
-            "ws_trackers",
-        )
-    ):
-        return cast(EntryRuntime, runtime)
     raise LookupError("TermoWeb runtime data is unavailable")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a18"
+version = "2.0.1a19"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]


### PR DESCRIPTION
### Motivation
- Enforce the runtime invariant so `hass.data[DOMAIN][entry_id]` must be an `EntryRuntime` instance and remove the transitional "attribute-probing" fallback that treated other objects as runtime proxies.

### Description
- Remove the attribute-probing fallback and `cast` return in `require_runtime(...)` so the function returns only when `isinstance(runtime, EntryRuntime)` is true, otherwise it raises `LookupError`.
- Bump integration version to `2.0.1a19` in `custom_components/termoweb/manifest.json` and `pyproject.toml` to reflect the change.

### Testing
- Ran `uv run python -m compileall custom_components/termoweb`, which succeeded.
- Ran `uv run ruff check .`, which reported existing lint issues in the repository (these are unrelated to the minimal change and pre-existing); `uv run ruff format .` was executed to ensure formatting.
- Ran `uv run timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`, which passed (`954 passed`, full coverage on modified package).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e82d43b288329be3662b18475dc85)