### PR TITLE
Integrate energy snapshots into DomainStateStore/DomainStateView (v2.0.1a20)

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -422,7 +422,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         brand=brand,
     )
 
-    energy_coordinator = EnergyStateCoordinator(hass, client, dev_id, inventory)
+    energy_coordinator = EnergyStateCoordinator(
+        hass,
+        client,
+        dev_id,
+        inventory,
+        state_coordinator=coordinator,
+    )
     await energy_coordinator.async_config_entry_first_refresh()
 
     poller = HourlySamplesPoller(hass, energy_coordinator, backend, inventory)

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a19"
+    "version": "2.0.1a20"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,8 +56,8 @@ This map defines responsibilities for each module family in the final design.
 - `runtime.py` — `EntryRuntime` definition, `require_runtime(...)` accessor, and
   runtime invariants (single instance per entry).
 - `inventory.py` — immutable inventory models and lookup helpers.
-- `domain/` — domain dataclasses, deltas, `DomainStateStore`, and
-  `DomainStateView`.
+- `domain/` — domain dataclasses, deltas, `DomainStateStore` (including energy
+  snapshots), and `DomainStateView`.
 - `backend/` — vendor-specific REST/WS clients (including the REST client
   implementation), protocol details, and brand selection.
 - `codecs/` — Pydantic payload models and conversion to/from domain types.

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -834,6 +834,8 @@ custom_components/termoweb/coordinator.py :: StateCoordinator.gateway_connected
     Return True when the coordinator reports the gateway online.
 custom_components/termoweb/coordinator.py :: StateCoordinator.update_gateway_connection
     Update the gateway connection state in the domain store.
+custom_components/termoweb/coordinator.py :: StateCoordinator.apply_energy_snapshot
+    Store an energy snapshot in the domain state store.
 custom_components/termoweb/coordinator.py :: StateCoordinator._device_record
     Return a minimal coordinator payload for this device.
 custom_components/termoweb/coordinator.py :: StateCoordinator._publish_device_record
@@ -900,6 +902,10 @@ custom_components/termoweb/coordinator.py :: StateCoordinator._async_update_data
     Fetch the latest settings for every known node on each poll.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.__init__
     Initialize the heater energy coordinator.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._publish_to_state_store
+    Update the canonical state store with ``snapshot``.
+custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.async_set_updated_data
+    Store ``data`` in the domain state before notifying listeners.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._resolve_inventory
     Return the active inventory, preferring ``candidate`` when provided.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._node_id_for
@@ -990,6 +996,8 @@ custom_components/termoweb/domain/state.py :: DomainStateStore.__init__
     Initialise the store for a set of allowable nodes.
 custom_components/termoweb/domain/state.py :: DomainStateStore.reset_nodes
     Reset the allowed node list and prune any stale state.
+custom_components/termoweb/domain/state.py :: DomainStateStore._prune_energy_snapshot
+    Return ``snapshot`` with metrics restricted to allowed nodes.
 custom_components/termoweb/domain/state.py :: DomainStateStore._resolve_node_id
     Return a canonical NodeId when permitted by the inventory.
 custom_components/termoweb/domain/state.py :: DomainStateStore.resolve_node_id
@@ -1004,6 +1012,10 @@ custom_components/termoweb/domain/state.py :: DomainStateStore.apply_delta
     Apply a typed domain delta to the store.
 custom_components/termoweb/domain/state.py :: DomainStateStore.get_state
     Return the stored state for ``(node_type, addr)`` when known.
+custom_components/termoweb/domain/state.py :: DomainStateStore.get_energy_snapshot
+    Return the stored energy snapshot when available.
+custom_components/termoweb/domain/state.py :: DomainStateStore.set_energy_snapshot
+    Store an energy snapshot and return ``True`` when it changed.
 custom_components/termoweb/domain/state.py :: DomainStateStore.addresses_by_type
     Return known addresses grouped by node type.
 custom_components/termoweb/domain/state.py :: DomainStateStore.known_types
@@ -1040,6 +1052,12 @@ custom_components/termoweb/domain/view.py :: DomainStateView.get_power_monitor_s
     Return the power monitor state for ``addr`` when present.
 custom_components/termoweb/domain/view.py :: DomainStateView.get_gateway_connection_state
     Return the gateway connection state when available.
+custom_components/termoweb/domain/view.py :: DomainStateView.get_energy_snapshot
+    Return the latest energy snapshot for this gateway.
+custom_components/termoweb/domain/view.py :: DomainStateView.get_energy_metric
+    Return metrics for ``(node_type, addr)`` when available.
+custom_components/termoweb/domain/view.py :: DomainStateView.get_energy_metrics_for_type
+    Return metrics keyed by address for ``node_type``.
 custom_components/termoweb/energy.py :: RecorderImports.__init__
     Initialize the recorder import references.
 custom_components/termoweb/energy.py :: _iso_date


### PR DESCRIPTION
### Motivation

- Make energy data part of the canonical domain state so entities and services can read energy metrics via the `DomainStateView` rather than ad-hoc coordinator caches.
- Ensure energy snapshots produced by the `EnergyStateCoordinator` are stored in the domain store before listeners are notified so view reads observe the latest snapshot.

### Description

- Add an `_energy_snapshot` slot to `DomainStateStore` with `get_energy_snapshot()` and `set_energy_snapshot()` and automatic pruning of metrics to the store’s allowed inventory via `_prune_energy_snapshot()`.
- Extend `DomainStateView` with `get_energy_snapshot()`, `get_energy_metric(node_type, addr)`, and `get_energy_metrics_for_type(node_type)` helpers that validate dev_id and inventory boundaries.
- Add `StateCoordinator.apply_energy_snapshot(snapshot)` to accept snapshots into the canonical store and publish the device record to listeners when the snapshot changes.
- Update `EnergyStateCoordinator` to accept an optional `state_coordinator` dependency, publish snapshots into the store before notifying listeners (override `async_set_updated_data` and publish on poll/skip paths), and wire the coordinator in setup (`__init__.py`).
- Bump integration version to `2.0.1a20`, add focused unit tests for store/view integration, and update docs/function map to reflect energy snapshots in the domain store.

### Testing

- Ran unit tests with `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` and observed all tests passing (956 passed) with coverage reported by the test run.
- Ran `uv run ruff format` (succeeded) before committing and inspected `uv run ruff check`; `ruff check` reports pre-existing lint issues elsewhere in the repo that were not introduced by this change.
- Added targeted tests: `test_domain_view_energy_metrics_prune` and `test_energy_coordinator_writes_snapshot_to_state_view`, which verify pruning to inventory and that snapshots produced by the energy coordinator are visible through `StateCoordinator.domain_view`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f1d7680408329bb3d63e4585a1d7d)