### PR TITLE
Route energy sensors to read from DomainStateView

### DIFF
--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a20"
+    "version": "2.0.1a21"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1499,7 +1499,7 @@ custom_components/termoweb/entities/sensor.py :: HeaterEnergyBase.__init__
 custom_components/termoweb/entities/sensor.py :: HeaterEnergyBase._device_available
     Return True when inventory and coordinator expose this heater node.
 custom_components/termoweb/entities/sensor.py :: HeaterEnergyBase._metric_entry
-    Return the cached metric entry for this heater.
+    Return the energy metrics for this heater from the domain view.
 custom_components/termoweb/entities/sensor.py :: HeaterEnergyBase._raw_native_value
     Return the raw metric value for this heater address.
 custom_components/termoweb/entities/sensor.py :: HeaterEnergyBase._coerce_native_value
@@ -1533,7 +1533,7 @@ custom_components/termoweb/entities/sensor.py :: PowerMonitorSensorBase.__init__
 custom_components/termoweb/entities/sensor.py :: PowerMonitorSensorBase._resolve_inventory
     Return the immutable inventory backing this sensor.
 custom_components/termoweb/entities/sensor.py :: PowerMonitorSensorBase._metric_entry
-    Return the cached metric entry for this power monitor.
+    Return the energy metrics for this power monitor from the domain view.
 custom_components/termoweb/entities/sensor.py :: PowerMonitorSensorBase._coerce_native_value
     Convert a metric payload value to ``float`` if possible.
 custom_components/termoweb/entities/sensor.py :: PowerMonitorSensorBase.should_poll
@@ -1557,7 +1557,7 @@ custom_components/termoweb/entities/sensor.py :: InstallationTotalEnergySensor.d
 custom_components/termoweb/entities/sensor.py :: InstallationTotalEnergySensor._handle_gateway_dispatcher
     Handle websocket payloads that may update the totals.
 custom_components/termoweb/entities/sensor.py :: InstallationTotalEnergySensor.available
-    Return True if the latest coordinator data contains totals.
+    Return True if the domain view contains energy totals.
 custom_components/termoweb/entities/sensor.py :: InstallationTotalEnergySensor.native_value
     Return the summed energy usage across all heaters.
 custom_components/termoweb/entities/sensor.py :: InstallationTotalEnergySensor.extra_state_attributes


### PR DESCRIPTION
### Motivation

- Make energy snapshot the canonical read source for entities so sensor platforms no longer read `coordinator.data` or call coordinator `metric_for` directly.
- Prepare the codebase for the DomainStateStore/DomainStateView energy integration contract by routing entity reads through the view instead of coordinator internals.

### Description

- Updated sensor entities to accept and use a `DomainStateView` and to read energy metrics via `DomainStateView.get_energy_metric()` and `get_energy_metrics_for_type()` instead of accessing `EnergyStateCoordinator.data` or `metric_for` (changes in `custom_components/termoweb/entities/sensor.py`).
- Wired the coordinator's `domain_view` into `async_setup_entry` and passed the view into energy/power sensor constructors and into the installation-total sensor.
- Added focused unit tests that assert heater and power-monitor energy sensors read metrics from the `DomainStateView` and raise if they attempt to access `coordinator.data` (tests added/updated in `tests/test_sensor_normalise_energy.py`).
- Bumped integration version to `2.0.1a21` and updated the `docs/function_map.txt` to reflect the new behavior.

### Testing

- Ran formatting and lint checks: `uv run ruff check custom_components/termoweb/entities/sensor.py tests/test_sensor_normalise_energy.py` (passed).
- Ran the full test suite with coverage: `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`, which completed successfully with all tests passing (958 passed).
- New tests specifically verifying domain-view reads for heater and power-monitor sensors succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f21fbf8208329b67bf11da5533bba)