### PR TITLE
Remove gateway metadata reads from coordinator.data

### DIFF
--- a/custom_components/termoweb/entities/binary_sensor.py
+++ b/custom_components/termoweb/entities/binary_sensor.py
@@ -152,15 +152,6 @@ class GatewayOnlineBinarySensor(
         coordinator = self.coordinator
         name = getattr(coordinator, "gateway_name", None)
         model = getattr(coordinator, "gateway_model", None)
-        if name is None or model is None:
-            data = getattr(coordinator, "data", None)
-            if isinstance(data, Mapping):
-                record = data.get(self._dev_id)
-                if isinstance(record, Mapping):
-                    if name is None:
-                        name = record.get("name")
-                    if model is None:
-                        model = record.get("model")
         connection_state = self._gateway_connection_state()
         return {
             "dev_id": self._dev_id,

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a21"
+    "version": "2.0.1a22"
 }

--- a/custom_components/termoweb/utils.py
+++ b/custom_components/termoweb/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import math
-import typing
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -108,17 +107,12 @@ def build_gateway_device_info(
         return info
 
     coordinator = entry_data.coordinator
-    data: Mapping[str, typing.Any] | None = None
     if coordinator is not None:
-        data = getattr(coordinator, "data", None)
-        if not isinstance(data, Mapping):
-            data = None
-    if data:
-        gateway_data = data.get(str(dev_id))
-        if isinstance(gateway_data, Mapping):
-            model = gateway_data.get("model")
-            if model not in (None, ""):
-                info["model"] = str(model)
+        model = getattr(coordinator, "gateway_model", None)
+        if callable(model):
+            model = model()
+        if model not in (None, ""):
+            info["model"] = str(model)
 
     return info
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2057,6 +2057,8 @@ class FakeCoordinator:
             metadata = build_device_metadata(dev_id, normalised_dev)
 
         self.dev_metadata = metadata
+        self.gateway_name = self.dev_metadata.name
+        self.gateway_model = self.dev_metadata.model
         self.dev = self._normalise_device_record(normalised_dev)
         self.nodes = nodes or {}
         inventory_obj, nodes_list = _coerce_inventory(inventory)

--- a/tests/test_binary_sensor_button.py
+++ b/tests/test_binary_sensor_button.py
@@ -52,12 +52,9 @@ def test_binary_sensor_setup_and_dispatch(
             hass,
             dev_id=dev_id,
             inventory=inventory,
-            data={
-                dev_id: {
-                    "name": "Living Room",  # attributes
-                    "connected": True,
-                    "model": "TW-GW",
-                }
+            dev={
+                "name": "Living Room",
+                "model": "TW-GW",
             },
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,7 +167,7 @@ def test_build_gateway_device_info_respects_include_version_flag() -> None:
         dev_id="dev",
         brand="Ducaheat",
         version="9.1",
-        coordinator=types.SimpleNamespace(data={"dev": {"model": "Controller"}}),
+        coordinator=types.SimpleNamespace(gateway_model="Controller"),
     )
 
     info = build_gateway_device_info(hass, "entry", "dev", include_version=False)
@@ -183,7 +183,7 @@ def test_build_gateway_device_info_uses_gateway_model_from_coordinator() -> None
         hass=hass,
         entry_id="entry",
         dev_id="dev",
-        coordinator=types.SimpleNamespace(data={"dev": {"model": "Controller"}}),
+        coordinator=types.SimpleNamespace(gateway_model="Controller"),
     )
 
     info = build_gateway_device_info(hass, "entry", "dev")
@@ -191,13 +191,13 @@ def test_build_gateway_device_info_uses_gateway_model_from_coordinator() -> None
     assert info["model"] == "Controller"
 
 
-def test_build_gateway_device_info_ignores_non_mapping_coordinator_data() -> None:
+def test_build_gateway_device_info_ignores_empty_gateway_model() -> None:
     hass = types.SimpleNamespace(data={DOMAIN: {}})
     build_entry_runtime(
         hass=hass,
         entry_id="entry",
         dev_id="dev",
-        coordinator=types.SimpleNamespace(data=[1, 2, 3]),
+        coordinator=types.SimpleNamespace(gateway_model=""),
     )
 
     info = build_gateway_device_info(hass, "entry", "dev")
@@ -222,26 +222,6 @@ def test_build_power_monitor_device_info_uses_fallback_translation() -> None:
 
     assert info["name"] == "Meter 01"
     assert info["identifiers"] == {(DOMAIN, "dev", "pmo", "01")}
-
-
-def test_build_gateway_device_info_discards_truthy_non_mapping_data() -> None:
-    class TruthyNonMapping:
-        def __bool__(self) -> bool:
-            return True
-
-    hass = types.SimpleNamespace(
-        data={
-            DOMAIN: {
-                "entry": {
-                    "coordinator": types.SimpleNamespace(data=TruthyNonMapping()),
-                }
-            }
-        }
-    )
-
-    info = build_gateway_device_info(hass, "entry", "dev")
-
-    assert info["model"] == "Gateway/Controller"
 
 
 def test_normalize_heater_addresses_with_none() -> None:


### PR DESCRIPTION
### Motivation
- Eliminate entity reads from `StateCoordinator.data` and read gateway metadata via coordinator accessor properties to enforce the DomainState/View boundary and satisfy the v2.0.1a22 goal.

### Description
- Stop looking up gateway `name`/`model` in `coordinator.data` in `GatewayOnlineBinarySensor.extra_state_attributes` and instead use `coordinator.gateway_name` / `coordinator.gateway_model` accessors.
- Update `build_gateway_device_info` to obtain the gateway model from `coordinator.gateway_model` (calling it if callable) instead of inspecting `coordinator.data` mappings.
- Adjust test scaffolding in `tests/conftest.py` to expose `gateway_name`/`gateway_model` on `FakeCoordinator` and update tests (`tests/test_binary_sensor_button.py`, `tests/test_utils.py`) to provide/expect metadata via the coordinator metadata fields.
- Bump integration version to `2.0.1a22` in `custom_components/termoweb/manifest.json`.

### Testing
- Ran formatter: `uv run ruff format` which completed successfully.
- Ran linter: `uv run ruff check` which failed due to pre-existing repository lint issues unrelated to this change (reported but not modified here).
- Ran unit tests and coverage: `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`, which completed with all tests passing (957 passed) and full coverage for the codebase and modified paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f257180f48329b98df7a1c1e2ba8a)