### PR TITLE
Remove energy coordinator repair path

### DIFF
--- a/custom_components/termoweb/__init__.py
+++ b/custom_components/termoweb/__init__.py
@@ -429,6 +429,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         inventory,
         state_coordinator=coordinator,
     )
+    energy_coordinator.update_addresses(inventory)
     await energy_coordinator.async_config_entry_first_refresh()
 
     poller = HourlySamplesPoller(hass, energy_coordinator, backend, inventory)

--- a/custom_components/termoweb/entities/sensor.py
+++ b/custom_components/termoweb/entities/sensor.py
@@ -174,14 +174,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     energy_coordinator = runtime.energy_coordinator
     if not isinstance(energy_coordinator, EnergyStateCoordinator):
-        if not hasattr(energy_coordinator, "update_addresses"):
-            energy_coordinator = EnergyStateCoordinator(
-                hass, runtime.client, dev_id, inventory
-            )
-            runtime.energy_coordinator = energy_coordinator
-            await energy_coordinator.async_config_entry_first_refresh()
-
-    energy_coordinator.update_addresses(inventory)
+        listener = getattr(energy_coordinator, "async_add_listener", None)
+        if not callable(listener):
+            _LOGGER.error("Energy coordinator unavailable for %s", dev_id)
+            return
     attach_fallbacks(energy_coordinator, fallbacks)
 
     power_monitor_entities: list[SensorEntity] = []

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a23"
+    "version": "2.0.1a24"
 }

--- a/tests/test_sensor_normalise_energy.py
+++ b/tests/test_sensor_normalise_energy.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib
 from types import SimpleNamespace
 from typing import Any, Callable
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -188,7 +187,12 @@ async def test_async_setup_entry_handles_missing_power_monitors(
         entities_sensor_module, "InstallationTotalEnergySensor", _DummyTotalEnergy
     )
 
-    energy_coordinator = SimpleNamespace(update_addresses=MagicMock())
+    energy_coordinator = EnergyStateCoordinator(
+        hass,
+        SimpleNamespace(),
+        "dev-1",
+        inventory,
+    )
     build_entry_runtime(
         hass=hass,
         entry_id=entry.entry_id,
@@ -206,7 +210,6 @@ async def test_async_setup_entry_handles_missing_power_monitors(
 
     await module.async_setup_entry(hass, entry, _async_add_entities)
 
-    energy_coordinator.update_addresses.assert_called_once_with(inventory)
     assert iter_calls == [(("pmo",), None)]
     assert added_entities[:3] == [
         "temp-sensor",


### PR DESCRIPTION
### Motivation
- Enforce setup-owned lifecycle for the `EnergyStateCoordinator` so runtime code does not attempt to patch or recreate the coordinator during platform setup, matching the v2 hardening goal to remove repair paths.
- Ensure the coordinator has its inventory bound once during config-entry setup so entities can rely on a stable energy coordinator.
- Bump integration version to reflect the v2.0.1a24 change set.

### Description
- Move `energy_coordinator.update_addresses(inventory)` into config-entry setup so the coordinator is populated during `async_setup_entry` (`custom_components/termoweb/__init__.py`).
- Remove the runtime “repair” path in sensor platform setup that attempted to construct/assign a new `EnergyStateCoordinator` from `entities/sensor.py`, and instead guard setup when a usable coordinator/listener is not present (log and return).
- Update a sensor test to use a real `EnergyStateCoordinator` instance instead of a MagicMock to reflect the new lifecycle expectations (`tests/test_sensor_normalise_energy.py`).
- Bump `custom_components/termoweb/manifest.json` `version` to "2.0.1a24".

### Testing
- Ran code formatting with `uv run ruff format` prior to committing; formatting was applied.
- Executed the full test suite with `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`, which completed successfully with all tests passing (`948 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f62f296648329a56bd919c69b45df)