### PR TITLE
Route entity writes through backend APIs

### DIFF
--- a/custom_components/termoweb/backend/base.py
+++ b/custom_components/termoweb/backend/base.py
@@ -58,6 +58,18 @@ class HttpClientProto(Protocol):
     ) -> Any:
         """Update node settings for the specified node."""
 
+    async def set_acm_boost_state(
+        self,
+        dev_id: str,
+        addr: str | int,
+        *,
+        boost: bool,
+        boost_time: int | None = None,
+        stemp: float | None = None,
+        units: str | None = None,
+    ) -> Any:
+        """Toggle accumulator boost state for the specified node."""
+
     async def get_node_samples(
         self,
         dev_id: str,
@@ -128,6 +140,27 @@ class Backend(ABC):
             stemp=stemp,
             prog=prog,
             ptemp=ptemp,
+            units=units,
+        )
+
+    async def set_acm_boost_state(
+        self,
+        dev_id: str,
+        addr: str | int,
+        *,
+        boost: bool,
+        boost_time: int | None = None,
+        stemp: float | None = None,
+        units: str | None = None,
+    ) -> Any:
+        """Toggle accumulator boost state using the backend client."""
+
+        await self.client.set_acm_boost_state(
+            dev_id,
+            addr,
+            boost=boost,
+            boost_time=boost_time,
+            stemp=stemp,
             units=units,
         )
 

--- a/custom_components/termoweb/entities/heater.py
+++ b/custom_components/termoweb/entities/heater.py
@@ -952,7 +952,7 @@ class HeaterNodeBase(CoordinatorEntity):
         return derive_boost_state_from_domain(self.heater_state(), self.coordinator)
 
     def _client(self) -> Any:
-        """Return the REST client used for write operations."""
+        """Return the backend used for write operations."""
         hass = self._hass_for_runtime()
         if hass is None:
             return None
@@ -962,7 +962,7 @@ class HeaterNodeBase(CoordinatorEntity):
             runtime = require_runtime(hass, self._entry_id)
         except LookupError:
             return None
-        return runtime.client
+        return runtime.backend
 
     def _units(self) -> str:
         """Return the configured temperature units for this heater."""

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a24"
+    "version": "2.0.1a25"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -54,6 +54,8 @@ custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_settings
     Return settings for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.set_node_settings
     Update node settings for the specified node.
+custom_components/termoweb/backend/base.py :: HttpClientProto.set_acm_boost_state
+    Toggle accumulator boost state for the specified node.
 custom_components/termoweb/backend/base.py :: HttpClientProto.get_node_samples
     Return historical samples for the specified node.
 custom_components/termoweb/backend/base.py :: WsClientProto.start
@@ -68,6 +70,8 @@ custom_components/termoweb/backend/base.py :: Backend.client
     Return the HTTP client associated with this backend.
 custom_components/termoweb/backend/base.py :: Backend.set_node_settings
     Update node settings using the backend client.
+custom_components/termoweb/backend/base.py :: Backend.set_acm_boost_state
+    Toggle accumulator boost state using the backend client.
 custom_components/termoweb/backend/base.py :: Backend.create_ws_client
     Create a websocket client for the given device.
 custom_components/termoweb/backend/base.py :: Backend.fetch_hourly_samples
@@ -1367,7 +1371,7 @@ custom_components/termoweb/entities/heater.py :: HeaterNodeBase.hass
 custom_components/termoweb/entities/heater.py :: HeaterNodeBase.boost_state
     Return derived boost metadata for this heater.
 custom_components/termoweb/entities/heater.py :: HeaterNodeBase._client
-    Return the REST client used for write operations.
+    Return the backend used for write operations.
 custom_components/termoweb/entities/heater.py :: HeaterNodeBase._units
     Return the configured temperature units for this heater.
 custom_components/termoweb/entities/heater.py :: HeaterNodeBase.device_info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def build_entry_runtime(
             brand=brand,
             create_ws_client=MagicMock(),
             set_node_settings=AsyncMock(),
+            set_acm_boost_state=AsyncMock(),
         )
 
     if hourly_poller is None:


### PR DESCRIPTION
### Motivation

- Prevent entities from calling the low-level REST client directly and enforce the backend/planner boundary for all node write operations.
- Ensure accumulator boost semantics are expressed via the backend layer so brand-specific heuristics are centralized.

### Description

- Add `Backend.set_acm_boost_state` to the backend abstraction and a default implementation that forwards to the HTTP client (`HttpClientProto.set_acm_boost_state`).
- Route climate entity write calls through the backend by changing `_async_submit_settings` to accept a `backend` and call `backend.set_node_settings(...)`, and include `boost_context` for accumulator writes.
- Make heater entities obtain the `runtime.backend` (instead of `runtime.client`) for write operations (`HeaterNodeBase._client` now returns the backend).
- Update test harness and unit tests to use `runtime.backend` mocks (`tests/conftest.py`, `tests/test_climate.py`) and adjust assertions to expect `backend.set_node_settings` calls; regenerate `docs/function_map.txt` entries for the new backend method.
- Bump integration version to `2.0.1a25` in `custom_components/termoweb/manifest.json`.

### Testing

- Ran code formatting with `uv run ruff format .` which completed successfully.
- Ran targeted lint checks with `uv run ruff check custom_components/termoweb/backend/base.py custom_components/termoweb/entities/climate.py custom_components/termoweb/entities/heater.py tests/test_climate.py tests/conftest.py` which passed.
- Executed the project test suite with `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` and observed all tests passing: `948 passed` with 100% coverage on the package and overall test run completion in ~33.6s.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6694714883298c9b8f4ee362ae3f)