### PR TITLE
Enforce immutable inventory rebinding guard

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -775,7 +775,13 @@ class StateCoordinator(
         *,
         inventory: Inventory | None = None,
     ) -> None:
-        """Update cached inventory metadata."""
+        """Update cached inventory metadata when first configured."""
+
+        if self._inventory is not None:
+            if inventory is None or inventory is self._inventory:
+                return
+            msg = "Inventory rebinding is not allowed after setup"
+            raise ValueError(msg)
 
         if isinstance(inventory, Inventory):
             self._inventory = inventory

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a25"
+    "version": "2.0.1a26"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -889,7 +889,7 @@ custom_components/termoweb/coordinator.py :: StateCoordinator._apply_boost_metad
 custom_components/termoweb/coordinator.py :: StateCoordinator._should_defer_pending_setting
     Return True when a pending write should defer payload merging.
 custom_components/termoweb/coordinator.py :: StateCoordinator.update_nodes
-    Update cached inventory metadata.
+    Update cached inventory metadata when first configured.
 custom_components/termoweb/coordinator.py :: StateCoordinator._ensure_inventory
     Ensure cached inventory metadata is available.
 custom_components/termoweb/coordinator.py :: StateCoordinator._node_ids_from_inventory

--- a/tests/test_energy_coordinator.py
+++ b/tests/test_energy_coordinator.py
@@ -1512,6 +1512,8 @@ def test_state_coordinator_update_nodes_uses_provided_inventory(
         [str, Mapping[str, Any] | None, Iterable[Any] | None], coord_module.Inventory
     ],
 ) -> None:
+    """Inventory rebinding after setup should be rejected."""
+
     hass = HomeAssistant()
     client = types.SimpleNamespace()
     nodes = {"nodes": [{"addr": "A", "type": "htr"}]}
@@ -1529,11 +1531,11 @@ def test_state_coordinator_update_nodes_uses_provided_inventory(
         inventory=inventory,
     )
 
-    coord.update_nodes(nodes, inventory=provided_inventory)
+    with pytest.raises(ValueError, match="Inventory rebinding"):
+        coord.update_nodes(nodes, inventory=provided_inventory)
 
     inventory = coord._inventory
-    assert inventory is provided_inventory
-    assert inventory.nodes[0] is provided_nodes[0]
+    assert inventory is not provided_inventory
 
 
 def test_energy_state_coordinator_requires_inventory(


### PR DESCRIPTION
### Motivation

- Align runtime invariants with the architecture contract by preventing inventory rebinding after initial setup so the inventory remains immutable for the entry lifetime.

### Description

- Prevent `StateCoordinator.update_nodes(...)` from accepting a different `Inventory` after the coordinator has been configured by raising `ValueError` when rebinding is attempted.
- Update `tests/test_energy_coordinator.py` to assert that rebinding raises `ValueError` and to reflect the new behavior.
- Bump integration version to `2.0.1a26` in `manifest.json` and update the `docs/function_map.txt` entry for `StateCoordinator.update_nodes` to reflect the tightened contract.

### Testing

- Ran formatter: `uv run ruff format` which completed successfully.
- Ran lint checks targeted at the changed files: `uv run ruff check custom_components/termoweb/coordinator.py tests/test_energy_coordinator.py` which passed.
- Executed the full test suite with coverage: `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` and all tests passed (`948 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6a74b31c8329b5bf857f38dde0d7)