### PR TITLE
Remove unused EnergyStateCoordinator.metric_for and bump version to 2.0.1a27

### DIFF
--- a/custom_components/termoweb/coordinator.py
+++ b/custom_components/termoweb/coordinator.py
@@ -1334,17 +1334,6 @@ class EnergyStateCoordinator(
             ws_deadline=ws_deadline,
         )
 
-    def metric_for(self, node_type: str, addr: str) -> EnergyNodeMetrics | None:
-        """Return metrics for ``node_type``/``addr`` when cached."""
-
-        snapshot = coerce_snapshot(self.data)
-        if snapshot is None or snapshot.dev_id != self._dev_id:
-            return None
-        node_id = self._node_id_for(node_type, addr)
-        if node_id is None:
-            return None
-        return snapshot.metrics.get(node_id)
-
     def metrics_by_type(self, node_type: str) -> dict[str, EnergyNodeMetrics]:
         """Return metrics mapping keyed by address for ``node_type``."""
 

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a26"
+    "version": "2.0.1a27"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -922,7 +922,6 @@ custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._prefill_ene
     Seed energy and power buckets from cached coordinator state.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator._build_snapshot
     Return an :class:`EnergySnapshot` built from metric buckets.
-custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.metric_for
     Return metrics for ``node_type``/``addr`` when cached.
 custom_components/termoweb/coordinator.py :: EnergyStateCoordinator.metrics_by_type
     Return metrics mapping keyed by address for ``node_type``.


### PR DESCRIPTION
### Motivation
- Remove a dead/unused helper on the energy coordinator as part of clean-up for the v2 hardening plan and advance the package to the next patch version.

### Description
- Deleted `EnergyStateCoordinator.metric_for` from `custom_components/termoweb/coordinator.py` and updated `docs/function_map.txt` to reflect the removal.
- Bumped integration version in `custom_components/termoweb/manifest.json` to `2.0.1a27`.

### Testing
- Ran `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` and all tests passed (948 passed, coverage 100%).
- Ran `uv run ruff format .` which completed successfully, and `uv run ruff check .` which reported pre-existing lint issues in the repository not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6c8eaf388329a47efb32f0b52a70)