### PR TITLE
Remove heater platform compatibility shims and bump to 2.0.1a30

### DIFF
--- a/custom_components/termoweb/entities/heater.py
+++ b/custom_components/termoweb/entities/heater.py
@@ -30,7 +30,6 @@ from custom_components.termoweb.domain.state import (
 )
 from custom_components.termoweb.i18n import COORDINATOR_FALLBACK_ATTR, format_fallback
 from custom_components.termoweb.inventory import (
-    HEATER_NODE_TYPES,
     Inventory,
     Node,
     normalize_node_addr,
@@ -90,13 +89,6 @@ class HeaterPlatformDetails:
 
     inventory: Inventory
     default_name_simple: Callable[[str], str]
-
-    def __iter__(self) -> Iterator[Any]:
-        """Provide tuple-style iteration compatibility."""
-
-        yield self.nodes_by_type
-        yield self.addrs_by_type
-        yield self.resolve_name
 
     @property
     def nodes_by_type(self) -> dict[str, list[Node]]:
@@ -464,18 +456,7 @@ def iter_boostable_heater_nodes(
 ) -> Iterator[tuple[str, Node, str, str]]:
     """Yield heater nodes that expose boost functionality."""
 
-    if isinstance(details, HeaterPlatformDetails):
-        metadata_iter = details.iter_metadata()
-    elif isinstance(details, Inventory):  # pragma: no cover - compatibility shim
-        metadata_iter = (
-            (meta.node_type, meta.node, meta.addr, meta.name)
-            for meta in details.iter_nodes_metadata(
-                node_types=HEATER_NODE_TYPES,
-                default_name_simple=lambda addr: f"Heater {addr}",
-            )
-        )
-    else:
-        return
+    metadata_iter = details.iter_metadata()
 
     if node_types is None:
         filter_types: set[str] | None = None

--- a/custom_components/termoweb/manifest.json
+++ b/custom_components/termoweb/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/ha-termoweb/ha-termoweb/issues",
     "loggers": ["custom_components.termoweb"],
     "requirements": ["python-socketio==5.16.0"],
-    "version": "2.0.1a28"
+    "version": "2.0.1a30"
 }

--- a/docs/function_map.txt
+++ b/docs/function_map.txt
@@ -1271,8 +1271,6 @@ custom_components/termoweb/entities/climate.py :: AccumulatorClimateEntity.async
     Cancel the active accumulator boost session.
 custom_components/termoweb/entities/heater.py :: _build_boost_button_metadata
     Return the configured metadata describing boost helper buttons.
-custom_components/termoweb/entities/heater.py :: HeaterPlatformDetails.__iter__
-    Provide tuple-style iteration compatibility.
 custom_components/termoweb/entities/heater.py :: HeaterPlatformDetails.nodes_by_type
     Return nodes grouped by type from the immutable inventory.
 custom_components/termoweb/entities/heater.py :: HeaterPlatformDetails.addrs_by_type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-termoweb"
-version = "2.0.1a19"
+version = "2.0.1a30"
 description = "TermoWeb heaters integration for Home Assistant"
 readme = "README.md"
 authors = [{ name = "ha-termoweb" }]


### PR DESCRIPTION
### Motivation
- Remove legacy compatibility paths in the heater entity helpers so platform metadata is consumed via the canonical `HeaterPlatformDetails` API only.
- Tighten the v2 invariants around inventory immutability and entity-layer contracts by eliminating tuple-style iteration and inventory fallbacks.

### Description
- Deleted `HeaterPlatformDetails.__iter__` and removed tuple-compat iteration usage so callers use `HeaterPlatformDetails.iter_metadata()` directly.
- Removed the `Inventory`-fallback branch inside `iter_boostable_heater_nodes`, and simplified the function to call `details.iter_metadata()` exclusively.
- Removed an unused `HEATER_NODE_TYPES` import reference and updated the `docs/function_map.txt` to reflect the API cleanup.
- Bumped the integration version to `2.0.1a30` in `custom_components/termoweb/manifest.json` and `pyproject.toml`.

### Testing
- Ran `uv run ruff format custom_components/termoweb/entities/heater.py` and `uv run ruff check custom_components/termoweb/entities/heater.py`, both passed.
- Ran `pytest -q` which completed successfully (tests passed; run output: 936 passed, 2 skipped in ~16s).
- Ran `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` and the coverage run passed with full coverage reported for the modified modules (overall suite passed, 100% coverage on repository files in the report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f86bb7cc8832982c73adce34cfb5b)