### PR TITLE
Docs: Align energy history import rate limit to 1 QPS

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ flowchart LR
 
 - REST requests must be rate-limited and treated as a fallback when WebSocket
   updates are unavailable.
-- The `import_energy_history` service must throttle to **2 queries per second**.
+- The `import_energy_history` service must throttle to **1 query per second**.
 - Inventory-driven assumptions (node list, addresses, and types) are immutable
   for the life of the entry; if hardware changes, the user must reload the
   integration.


### PR DESCRIPTION
### Motivation
- Align the architecture documentation with the intended operational constraint that the `import_energy_history` service is limited to 1 query per second.

### Description
- Update `docs/architecture.md` to change the `import_energy_history` throttle note from **2 queries per second** to **1 query per second**.

### Testing
- Ran `uv run ruff format` which completed successfully; `uv run ruff check` reported existing lint issues in the repository; `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing` completed successfully (all tests passed), and `pytest -q` also completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fa51977a48329842631bd279b780b)