### PR TITLE
Remove duplicate throttle module docstring

### DIFF
--- a/custom_components/termoweb/throttle.py
+++ b/custom_components/termoweb/throttle.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-"""Shared throttling helpers for the TermoWeb integration."""
-
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -79,7 +77,7 @@ def default_samples_rate_limit_state(
 ) -> MonotonicRateLimiter:
     """Return the shared rate limiter for heater samples requests."""
 
-    global _SAMPLES_RATE_LIMITER
+    global _SAMPLES_RATE_LIMITER  # noqa: PLW0603
     if _SAMPLES_RATE_LIMITER is None:
         _SAMPLES_RATE_LIMITER = _new_samples_rate_limiter(
             time_module=time_module,
@@ -98,6 +96,5 @@ def reset_samples_rate_limit_state(
 ) -> None:
     """Reset the shared samples rate limiter to its initial state."""
 
-    global _SAMPLES_RATE_LIMITER
     limiter = default_samples_rate_limit_state(time_module=time_module, sleep=sleep)
     limiter.reset()


### PR DESCRIPTION
### Motivation
- Remove a duplicated module docstring in the throttle helper and silence a local linter warning to keep the module clean and ruff-compliant.

### Description
- Delete the stray duplicate docstring in `custom_components/termoweb/throttle.py` and add a localized `# noqa: PLW0603` comment for the `global _SAMPLES_RATE_LIMITER` usage.

### Testing
- Ran `ruff format custom_components/termoweb/throttle.py` and `ruff check custom_components/termoweb/throttle.py`, both succeeded.
- Ran `timeout 60s pytest --cov=custom_components.termoweb --cov-report=term-missing`, which completed successfully (test run with coverage passed).
- Ran `pytest -q`, which completed successfully with `926 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fad94eff88329aa54881305183004)